### PR TITLE
[Five 165] Mostrar confirmacion antes de borrar un artefacto

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/package-lock.json
+++ b/FiveRockingFingers/FRF.Web/ClientApp/package-lock.json
@@ -12927,6 +12927,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "sweetalert2": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.9.0.tgz",
+      "integrity": "sha512-ijIYsQ4ybOVt49GbZd5FfLoA5A3CCtHK2iSJqnIbCGT/p9d0SwhjtHNO10w/VU8chzM+5hJQ2J6Z6eAEUYtXtw=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/FiveRockingFingers/FRF.Web/ClientApp/package-lock.json
+++ b/FiveRockingFingers/FRF.Web/ClientApp/package-lock.json
@@ -12927,11 +12927,6 @@
         "util.promisify": "~1.0.0"
       }
     },
-    "sweetalert2": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.9.0.tgz",
-      "integrity": "sha512-ijIYsQ4ybOVt49GbZd5FfLoA5A3CCtHK2iSJqnIbCGT/p9d0SwhjtHNO10w/VU8chzM+5hJQ2J6Z6eAEUYtXtw=="
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/FiveRockingFingers/FRF.Web/ClientApp/package.json
+++ b/FiveRockingFingers/FRF.Web/ClientApp/package.json
@@ -6,12 +6,12 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@material-ui/icons": "^4.9.1",
-    "@types/es6-promise": "^3.3.0",
     "@hookform/resolvers": "^1.0.0",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/system": "^4.9.14",
+    "@types/es6-promise": "^3.3.0",
     "@types/react-router-bootstrap": "^0.24.5",
     "axios": "^0.20.0",
     "bootstrap": "^4.3.1",
@@ -31,6 +31,7 @@
     "react-scripts": "^3.4.4",
     "reactstrap": "8.1.1",
     "svgo": "1.3.0",
+    "sweetalert2": "^10.9.0",
     "yup": "^0.29.3"
   },
   "devDependencies": {

--- a/FiveRockingFingers/FRF.Web/ClientApp/package.json
+++ b/FiveRockingFingers/FRF.Web/ClientApp/package.json
@@ -31,7 +31,6 @@
     "react-scripts": "^3.4.4",
     "reactstrap": "8.1.1",
     "svgo": "1.3.0",
-    "sweetalert2": "^10.9.0",
     "yup": "^0.29.3"
   },
   "devDependencies": {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/SnackbarMessage.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/SnackbarMessage.tsx
@@ -1,0 +1,27 @@
+﻿import * as React from 'react';
+import { Snackbar } from '@material-ui/core';
+import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
+
+function Alert(props: AlertProps) {
+    return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
+
+const SnackbarMessage = (props: { message: string, severity: "success" | "info" | "warning" | "error" | undefined, open: boolean, setOpen: Function }) => {
+
+    const handleCloseSnackbar = (event?: React.SyntheticEvent, reason?: string) => {
+        if (reason === 'clickaway') {
+            return;
+        }
+        props.setOpen(false);
+    };
+
+    return (
+        <Snackbar open={props.open} autoHideDuration={4000} onClose={handleCloseSnackbar}>
+            <Alert onClose={handleCloseSnackbar} severity={props.severity}>
+                {props.message}
+            </Alert>
+        </Snackbar>
+    );
+};
+
+export default SnackbarMessage;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -3,10 +3,14 @@ import { Table } from 'reactstrap';
 import Artifact from '../../interfaces/Artifact'
 import ArtifactsTableRow from './ArtifactsTableRow';
 import axios from 'axios';
+import SnackbarMessage from '../../commons/SnackbarMessage';
+import SnackbarSettings from '../../interfaces/SnackbarSettings'
 
 const ArtifactsTable = (props: { projectId: number }) => {
 
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
+    const [openSnackbar, setOpenSnackbar] = React.useState(false);
+    const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
 
     const getArtifacts = async () => {
         const response = await axios.get("https://localhost:44346/api/Artifacts/GetAllByProjectId/" + props.projectId);
@@ -24,23 +28,36 @@ const ArtifactsTable = (props: { projectId: number }) => {
     }, [props.projectId]);
 
     return (
-        <Table striped bordered hover>
-            <thead>
-                <tr>
-                    <th>Nombre</th>
-                    <th>Provedor</th>
-                    <th>Tipo</th>
-                </tr>
-            </thead>
-            <tbody>
-                {Array.isArray(artifacts)
-                    ? artifacts.map((artifact) => <ArtifactsTableRow
-                                                        key={artifact.id}
-                                                        artifact={artifact}
-                                                        deleteArtifact={deleteArtifact} />)
-                    : null}
-            </tbody>
-        </Table>
+        <React.Fragment>
+            <Table striped bordered hover>
+                <thead>
+                    <tr>
+                        <th>Nombre</th>
+                        <th>Provedor</th>
+                        <th>Tipo</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.isArray(artifacts)
+                        ? artifacts.map((artifact) => <ArtifactsTableRow
+                            key={artifact.id}
+                            artifact={artifact}
+                            deleteArtifact={deleteArtifact}
+                            setOpenSnackbar = {setOpenSnackbar }
+                            setSnackbarSettings={setSnackbarSettings}
+                            />
+                            )
+                        : null}
+                </tbody>
+            </Table>
+            <SnackbarMessage
+                message={snackbarSettings.message}
+                severity={snackbarSettings.severity}
+                open={openSnackbar}
+                setOpen={setOpenSnackbar}
+            />
+
+        </React.Fragment>
     );
 };
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
@@ -1,22 +1,31 @@
 ﻿import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
 import { Button } from 'reactstrap';
+import ConfirmationDialog from './ConfirmationDialog';
 
 const ArtifactsTableRow = (props: { artifact: Artifact, deleteArtifact: Function }) => {
 
+    const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
+
+    
+
     const deleteButtonClick = () => {
-        props.deleteArtifact(props.artifact.id)
+        setOpenConfirmDialog(true);
     }
 
     return (
-        <tr>
-            <td>{props.artifact.name}</td>
-            <td>{props.artifact.provider}</td>
-            <td>{props.artifact.artifactType.name}</td>
-            <td>
-                <Button color="danger" onClick={deleteButtonClick}>Borrar</Button>
-            </td>
-        </tr>
+        <React.Fragment>
+            <tr>
+                <td>{props.artifact.name}</td>
+                <td>{props.artifact.provider}</td>
+                <td>{props.artifact.artifactType.name}</td>
+                <td>
+                    <Button color="danger" onClick={deleteButtonClick}>Borrar</Button>
+                </td>
+            </tr>
+            <ConfirmationDialog open={openConfirmDialog} setOpen={setOpenConfirmDialog} artifactToDelete={props.artifact} deleteArtifact={props.deleteArtifact} />
+
+         </React.Fragment>
     );
 };
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
@@ -3,11 +3,9 @@ import Artifact from '../../interfaces/Artifact';
 import { Button } from 'reactstrap';
 import ConfirmationDialog from './ConfirmationDialog';
 
-const ArtifactsTableRow = (props: { artifact: Artifact, deleteArtifact: Function }) => {
+const ArtifactsTableRow = (props: { artifact: Artifact, deleteArtifact: Function, setOpenSnackbar: Function, setSnackbarSettings: Function }) => {
 
     const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
-
-    
 
     const deleteButtonClick = () => {
         setOpenConfirmDialog(true);
@@ -23,8 +21,14 @@ const ArtifactsTableRow = (props: { artifact: Artifact, deleteArtifact: Function
                     <Button color="danger" onClick={deleteButtonClick}>Borrar</Button>
                 </td>
             </tr>
-            <ConfirmationDialog open={openConfirmDialog} setOpen={setOpenConfirmDialog} artifactToDelete={props.artifact} deleteArtifact={props.deleteArtifact} />
-
+            <ConfirmationDialog
+                open={openConfirmDialog}
+                setOpen={setOpenConfirmDialog}
+                artifactToDelete={props.artifact}
+                deleteArtifact={props.deleteArtifact}
+                setOpenSnackbar={props.setOpenSnackbar}
+                setSnackbarSettings={props.setSnackbarSettings}
+            />
          </React.Fragment>
     );
 };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -1,14 +1,8 @@
 ﻿import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Snackbar } from '@material-ui/core';
-import { Alert } from 'reactstrap';
-import axios from 'axios';
 import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
-import Swal from 'sweetalert2'
 
-
-const ConfirmationDialog = (props: { open: boolean, setOpen: Function, deleteArtifact: Function, artifactToDelete: Artifact }) => {
-
-
+const ConfirmationDialog = (props: { open: boolean, setOpen: Function, deleteArtifact: Function, artifactToDelete: Artifact, setOpenSnackbar: Function, setSnackbarSettings: Function }) => {
 
     const handleClose = () => {
         props.setOpen(false);
@@ -17,10 +11,12 @@ const ConfirmationDialog = (props: { open: boolean, setOpen: Function, deleteArt
     const handleConfirm = () => {
         try {
             props.deleteArtifact(props.artifactToDelete.id);
-            Swal.fire("El artefacto ha sido borrado con éxito", "", "success");
+            props.setSnackbarSettings({ message: "El artefacto ha sido borrado con éxito", severity: "success" });
+            props.setOpenSnackbar(true);
         }
         catch {
-            Swal.fire("Hubo un error al borrar el artefacto", "", "error");
+            props.setSnackbarSettings({ message: "Hubo un error al borrar el artefacto", severity: "error" });
+            props.setOpenSnackbar(true);
         }
         handleClose();
     };
@@ -47,7 +43,7 @@ const ConfirmationDialog = (props: { open: boolean, setOpen: Function, deleteArt
                     <Button onClick={handleConfirm} color="primary">
                         Confirmar
                     </Button>
-                    <Button onClick={handleCancel} color="primary" autoFocus>
+                    <Button onClick={handleCancel} color="secondary">
                         Cancelar
                     </Button>
                 </DialogActions>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -1,0 +1,59 @@
+﻿import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Snackbar } from '@material-ui/core';
+import { Alert } from 'reactstrap';
+import axios from 'axios';
+import * as React from 'react';
+import Artifact from '../../interfaces/Artifact';
+import Swal from 'sweetalert2'
+
+
+const ConfirmationDialog = (props: { open: boolean, setOpen: Function, deleteArtifact: Function, artifactToDelete: Artifact }) => {
+
+
+
+    const handleClose = () => {
+        props.setOpen(false);
+    };
+
+    const handleConfirm = () => {
+        try {
+            props.deleteArtifact(props.artifactToDelete.id);
+            Swal.fire("El artefacto ha sido borrado con éxito", "", "success");
+        }
+        catch {
+            Swal.fire("Hubo un error al borrar el artefacto", "", "error");
+        }
+        handleClose();
+    };
+
+    const handleCancel = () => {
+        handleClose();
+    };
+
+    return (
+        <div>
+            <Dialog
+                open={props.open}
+                onClose={handleClose}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">{"¿Está seguro que desea eliminar el artefacto?"}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                        El proyecto <i>"{props.artifactToDelete.name}</i>" será eliminado
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleConfirm} color="primary">
+                        Confirmar
+                    </Button>
+                    <Button onClick={handleCancel} color="primary" autoFocus>
+                        Cancelar
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    );
+}
+
+export default ConfirmationDialog;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/SnackbarSettings.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/SnackbarSettings.ts
@@ -1,0 +1,4 @@
+﻿export default interface SnackbarSettings {
+    message: string,
+    severity: "success" | "info" | "warning" | "error" | undefined,
+}


### PR DESCRIPTION
Descripción
Se debe mostrar un cartel de confirmación antes de borrar un artefacto de un proyecto

Cambios realizados:

- Se añadió un componente para mostrar el cartel de confirmación antes de borrar un artefacto de un proyecto.

- Se instaló el paquete sweetalert2 para mostrar un cartel de exito o error al momento de borrar un artefacto