### PR TITLE
[FIVE-162 Improvement] Corregir uso excesivo de la API en el ABM de proyectos

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import * as React from 'react';
 import Project from '../../interfaces/Project';
 
-export default function ConfirmationDialog(props: { keepMounted: boolean, open: boolean, project: Project | null, onClose: Function, resetView: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, updateProjects: Function }) {
+export default function ConfirmationDialog(props: { keepMounted: boolean, open: boolean, project: Project | null, onClose: Function, resetView: Function, openSnackbar: Function, updateProjects: Function }) {
     const { onClose, project, open, updateProjects } = props;
 
     const handleCancel = () => {
@@ -16,17 +16,14 @@ export default function ConfirmationDialog(props: { keepMounted: boolean, open: 
             try {
                 const response = await axios.delete("https://localhost:44346/api/Projects/Delete/" + project.id.toString());
                 if (response.status === 204) {
-                    props.setSnackbarSettings({ message: "Se eliminó el proyecto con éxito", severity: "success" });
-                    props.setOpenSnackbar(true);
+                    props.openSnackbar({ message: "Se eliminó el proyecto con éxito", severity: "success" });
                     updateProjects();
                 } else {
-                    props.setSnackbarSettings({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
-                    props.setOpenSnackbar(true);
+                    props.openSnackbar({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
                 }
             }
             catch {
-                props.setSnackbarSettings({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
             }
         }
         onClose();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
     }
 });
 
-const EditProject = (props: { project: Project, cancelEdit: any, categories: Category[], setOpenSnackbar: Function, setSnackbarSettings: Function, updateProjects: Function }) => {
+const EditProject = (props: { project: Project, cancelEdit: any, categories: Category[], openSnackbar: Function, updateProjects: Function }) => {
     const classes = useStyles();
 
     const { register, handleSubmit, errors } = useForm();
@@ -65,18 +65,15 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
         try {
             const response = await axios.put("https://localhost:44346/api/Projects/Update", project);
             if (response.status === 200) {
-                props.setSnackbarSettings({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
                 props.updateProjects();
             } else {
-                props.setSnackbarSettings({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
             }
             props.cancelEdit();
         }
         catch {
-            props.setSnackbarSettings({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
-            props.setOpenSnackbar(true);
+            props.openSnackbar({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
         }
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     }
 });
 
-const NewProjectDialog = (props: { create: boolean, categories: Category[], finishCreation: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, updateProjects: Function }) => {
+const NewProjectDialog = (props: { create: boolean, categories: Category[], finishCreation: Function, openSnackbar: Function, updateProjects: Function }) => {
 
     const classes = useStyles();
 
@@ -73,18 +73,15 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
         try {
             const response = await axios.post("https://localhost:44346/api/Projects/Save", project);
             if (response.status === 200) {
-                props.setSnackbarSettings({ message: "El proyecto ha sido creado con éxito", severity: "success" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "El proyecto ha sido creado con éxito", severity: "success" });
                 props.updateProjects();
             } else {
-                props.setSnackbarSettings({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
             }
             props.finishCreation();
         }
         catch {
-            props.setSnackbarSettings({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
-            props.setOpenSnackbar(true);
+            props.openSnackbar({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
         }
         clearState();
         props.finishCreation();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -103,6 +103,11 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
         setCreate(false);
     }
 
+    const manageOpenSnackbar = (settings: SnackbarSettings) => {
+        setSnackbarSettings(settings);
+        setOpenSnackbar(true);
+    }
+
     return (
         <div className={classes.root}>
             <CssBaseline />
@@ -112,13 +117,13 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     <Button size="large" variant="contained" className={classes.button} fullWidth={true} endIcon={<AddIcon />} onClick={createProject}>
                         Nuevo Proyecto
                     </Button>
-                    <NewProjectDialog create={create} finishCreation={finishCreation} categories={props.categories} setOpenSnackbar={setOpenSnackbar} setSnackbarSettings={setSnackbarSettings} updateProjects={props.updateProjects} />
+                    <NewProjectDialog create={create} finishCreation={finishCreation} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />
                     <Divider />
                     <List>
                         {props.projects.map((project: Project) =>
                             <ListElement selected={selectedIndex === project.id} key={project.id} id={project.id} selectProject={selectProject} deleteProject={deleteProject} name={project.name} />
                         )}
-                        <ConfirmationDialog keepMounted open={openDelete} onClose={handleClose} project={projectToDelete} resetView={resetView} setOpenSnackbar={setOpenSnackbar} setSnackbarSettings={setSnackbarSettings} updateProjects={props.updateProjects} />
+                        <ConfirmationDialog keepMounted open={openDelete} onClose={handleClose} project={projectToDelete} resetView={resetView} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />
                     </List>
                 </div>
             </Drawer>
@@ -127,7 +132,7 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     selectedIndex === -1 ?
                         (<h1>Seleccione un proyecto para ver sus detalles</h1>)
                         : (edit ?
-                            (<EditProject project={props.projects.filter(p => p.id === selectedIndex)[0]} cancelEdit={cancelEdit} categories={props.categories} setOpenSnackbar={setOpenSnackbar} setSnackbarSettings={setSnackbarSettings} updateProjects={props.updateProjects} />)
+                            (<EditProject project={props.projects.filter(p => p.id === selectedIndex)[0]} cancelEdit={cancelEdit} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />)
                             : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
                 }
                 <SnackbarMessage


### PR DESCRIPTION
- Creado método único para establecer opciones y mostrar snackbar en ProjectsList.
- Los componentes hijos ahora usan ese método solo, en lugar de uno para establecer las opciones, y otro para mostrarlo.