### PR TITLE
[FIVE-187] Corregir llamada a la api en el detalle de Artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
 import NewArtifactDialog from '../NewArtifactDialog';
+import ArtifactService from '../../services/ArtifactService';
 
 const ArtifactsTable = (props: { projectId: number }) => {
 
@@ -16,19 +17,17 @@ const ArtifactsTable = (props: { projectId: number }) => {
 
     const getArtifacts = async () => {
         try {
-            const response = await axios.get("https://localhost:44346/api/Artifacts/GetAllByProjectId/" + props.projectId);
+            const response = await ArtifactService.getAllByProjectId(props.projectId);
 
             if (response.status == 200) {
                 setArtifacts(response.data);
             }
             else {
-                setSnackbarSettings({ message: "Hubo un error al cargar los artifacts", severity: "error" });
-                setOpenSnackbar(true);
+                manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
             }
         }
         catch {
-            setSnackbarSettings({ message: "Hubo un error al cargar los artifacts", severity: "error" });
-            setOpenSnackbar(true);
+            manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
         }    
     }
 
@@ -42,7 +41,12 @@ const ArtifactsTable = (props: { projectId: number }) => {
 
     React.useEffect(() => {
         getArtifacts();
-    }, [props.projectId, artifacts]);
+    }, [props.projectId]);
+
+    const manageOpenSnackbar = (settings: SnackbarSettings) => {
+        setSnackbarSettings(settings);
+        setOpenSnackbar(true);
+    }
 
     return (
         <React.Fragment>
@@ -62,8 +66,8 @@ const ArtifactsTable = (props: { projectId: number }) => {
                         ? artifacts.map((artifact) => <ArtifactsTableRow
                             key={artifact.id}
                             artifact={artifact}
-                            setOpenSnackbar = {setOpenSnackbar }
-                            setSnackbarSettings={setSnackbarSettings}
+                            openSnackbar={manageOpenSnackbar}
+                            updateList={getArtifacts}
                             />
                             )
                         : null}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -2,7 +2,6 @@
 import { Table, Button } from 'reactstrap';
 import Artifact from '../../interfaces/Artifact'
 import ArtifactsTableRow from './ArtifactsTableRow';
-import axios from 'axios';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
 import NewArtifactDialog from '../NewArtifactDialog';

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
@@ -3,7 +3,7 @@ import Artifact from '../../interfaces/Artifact';
 import { Button } from 'reactstrap';
 import ConfirmationDialog from './ConfirmationDialog';
 
-const ArtifactsTableRow = (props: { artifact: Artifact, setOpenSnackbar: Function, setSnackbarSettings: Function }) => {
+const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, updateList: Function }) => {
 
     const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
 
@@ -25,8 +25,8 @@ const ArtifactsTableRow = (props: { artifact: Artifact, setOpenSnackbar: Functio
                 open={openConfirmDialog}
                 setOpen={setOpenConfirmDialog}
                 artifactToDelete={props.artifact}
-                setOpenSnackbar={props.setOpenSnackbar}
-                setSnackbarSettings={props.setSnackbarSettings}
+                openSnackbar={props.openSnackbar}
+                updateList={props.updateList}
             />
          </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -1,7 +1,6 @@
 ﻿import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Snackbar } from '@material-ui/core';
 import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
-import axios from 'axios';
 import ArtifactService from '../../services/ArtifactService';
 
 const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactToDelete: Artifact, openSnackbar: Function, updateList: Function }) => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -2,8 +2,9 @@
 import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
 import axios from 'axios';
+import ArtifactService from '../../services/ArtifactService';
 
-const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactToDelete: Artifact, setOpenSnackbar: Function, setSnackbarSettings: Function }) => {
+const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactToDelete: Artifact, openSnackbar: Function, updateList: Function }) => {
 
     const handleClose = () => {
         props.setOpen(false);
@@ -11,21 +12,18 @@ const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactT
 
     const handleConfirm = async () => {
         try {
-            var route = "https://localhost:44346/api/Artifacts/Delete/" + props.artifactToDelete.id.toString();
-            const response = await axios.delete(route);
+            const response = await ArtifactService.delete(props.artifactToDelete.id)
 
             if (response.status == 204) {
-                props.setSnackbarSettings({ message: "El artefacto ha sido borrado con éxito", severity: "success" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "El artefacto ha sido borrado con éxito", severity: "success" });
+                props.updateList();
             }
             else {
-                props.setSnackbarSettings({ message: "Hubo un error al borrar el artefacto", severity: "error" });
-                props.setOpenSnackbar(true);
+                props.openSnackbar({ message: "Hubo un error al borrar el artefacto", severity: "error" });
             }
         }
         catch {
-            props.setSnackbarSettings({ message: "Hubo un error al borrar el artefacto", severity: "error" });
-            props.setOpenSnackbar(true);
+            props.openSnackbar({ message: "Hubo un error al borrar el artefacto", severity: "error" });
         }
         handleClose();
     };


### PR DESCRIPTION
Descripción:
Se debe realizar las siguientes modificaciones en el detalle de artifacts por proyecto:

- Se debe corregir la llamada a la Api para asegurarse que se realice una sola vez al momento de cargar los artefactos y al momento de borrar uno

- Se debe mover las consultas a la Api para que se realicen en los servicios

- Se debe agrupar código repetido dentro de funciones en una única función

Cambios realizados

- Se modificó los componentes relacionados con el detalle de artefactos (ArtifactsTable, ArtifactsTableRow, ConfirmationDialog) para que usen el servicio de Artefactos al realizar una llamada a api

- Se corrigió el bug de llamadas múltiples a la api en el componente ArtifactsTable

- Se agrupó código repetido en muchas funciones (relacionadas con mostrar el Snackbar al momento de borrar un artefacto) dentro de una única función