### PR TITLE
[FIVE-201] Arreglar el UnitTest del controlador de categorias

### DIFF
--- a/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
@@ -26,7 +26,7 @@ namespace FRF.Web.Tests.Controllers
         }
 
         [Fact]
-        public async Task Get_ReturnsOk()
+        public async Task GetAsync_ReturnsOk()
         {
             // Arrange
             var categoryId = 900;
@@ -66,7 +66,7 @@ namespace FRF.Web.Tests.Controllers
         }
 
         [Fact]
-        public async Task Get_ReturnsNotFound()
+        public async Task GetAsync_ReturnsNotFound()
         {
             // Arrange
             var categoryId = 900;

--- a/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
@@ -51,7 +51,7 @@ namespace FRF.Web.Tests.Controllers
                 });
 
             // Act
-            var result = await _classUnderTest.Get(categoryId);
+            var result = await _classUnderTest.GetAsync(categoryId);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
@@ -72,7 +72,7 @@ namespace FRF.Web.Tests.Controllers
             var categoryId = 900;
 
             // Act
-            var result = await _classUnderTest.Get(categoryId);
+            var result = await _classUnderTest.GetAsync(categoryId);
 
             // Assert
             var notFoundResult = Assert.IsType<NotFoundResult>(result);


### PR DESCRIPTION
Descripción

- Se debe modificar el nombre de los métodos que se usan del controlador de categorías para incorporar el sufijo Async

Cambios realizados:

- Se modificó el nombre de los métodos Get por GetAsync del atributo _classUnderTest