### PR TITLE
[NoTicket] Simplify mapper for tests

### DIFF
--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -8,7 +8,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Xunit;
@@ -17,16 +16,15 @@ namespace FRF.Web.Tests.Controllers
 {
     public class ArtifactsControllerTests
     {
-        private readonly Mock<IMapper> _mapper;
+        private readonly IMapper _mapper = MapperBuilder.Build();
         private readonly Mock<IArtifactsService> _artifactsService;
 
         private readonly ArtifactsController _classUnderTest;
 
         public ArtifactsControllerTests()
         {
-            _mapper = new Mock<IMapper>();
             _artifactsService = new Mock<IArtifactsService>();
-            _classUnderTest = new ArtifactsController(_artifactsService.Object, _mapper.Object);
+            _classUnderTest = new ArtifactsController(_artifactsService.Object, _mapper);
         }
 
         [Fact]
@@ -53,13 +51,6 @@ namespace FRF.Web.Tests.Controllers
                 Description = "Description of Artifact Type 1"
             };
 
-            var artifactTypeDTO = new ArtifactTypeDTO
-            {
-                Id = artifactType.Id,
-                Name = artifactType.Name,
-                Description = artifactType.Description
-            };
-
             var artifactId = 1;
             var artifact = new Artifact
             {
@@ -79,33 +70,14 @@ namespace FRF.Web.Tests.Controllers
                 ArtifactType = artifactType
             };
 
-            var artifactDTO = new ArtifactDTO
-            {
-                Id = artifact.Id,
-                Name = artifact.Name,
-                Provider = artifact.Provider,
-                Settings = artifact.Settings,
-                ProjectId = projectId,
-                ArtifactType = artifactTypeDTO
-            };
-
             List<Artifact> artifacts = new List<Artifact>
             {
                 artifact
             };
 
-            List<ArtifactDTO> artifactsDTO = new List<ArtifactDTO>
-            {
-                artifactDTO
-            };
-
             _artifactsService
                 .Setup(mock => mock.GetAll())
                 .ReturnsAsync(artifacts);
-
-            _mapper
-                .Setup(mock => mock.Map<IEnumerable<ArtifactDTO>>(It.IsAny<List<Artifact>>()))
-                .Returns(artifactsDTO);
 
             //Act
             var result = await _classUnderTest.GetAllAsync();
@@ -116,9 +88,8 @@ namespace FRF.Web.Tests.Controllers
             var returnValueList = returnValue.ToList();
 
             AssertCompareList(artifacts, returnValueList);
-            
+
             _artifactsService.Verify(mock => mock.GetAll(), Times.Once);
-            _mapper.Verify(mock => mock.Map<IEnumerable<ArtifactDTO>>(It.Is<List<Artifact>>(a => a.Contains(artifact))), Times.Once);
         }
 
         [Fact]
@@ -144,13 +115,6 @@ namespace FRF.Web.Tests.Controllers
                 Description = "Description of Artifact Type 1"
             };
 
-            var artifactTypeDTO = new ArtifactTypeDTO
-            {
-                Id = artifactType.Id,
-                Name = artifactType.Name,
-                Description = artifactType.Description
-            };
-
             var artifactId = 1;
             var artifact = new Artifact
             {
@@ -170,33 +134,14 @@ namespace FRF.Web.Tests.Controllers
                 ArtifactType = artifactType
             };
 
-            var artifactDTO = new ArtifactDTO
-            {
-                Id = artifact.Id,
-                Name = artifact.Name,
-                Provider = artifact.Provider,
-                Settings = artifact.Settings,
-                ProjectId = projectId,
-                ArtifactType = artifactTypeDTO
-            };
-
             List<Artifact> artifacts = new List<Artifact>
             {
                 artifact
             };
 
-            List<ArtifactDTO> artifactsDTO = new List<ArtifactDTO>
-            {
-                artifactDTO
-            };
-
             _artifactsService
                 .Setup(mock => mock.GetAllByProjectId(It.IsAny<int>()))
                 .ReturnsAsync(artifacts);
-
-            _mapper
-                .Setup(mock => mock.Map<IEnumerable<ArtifactDTO>>(It.IsAny<List<Artifact>>()))
-                .Returns(artifactsDTO);
 
             //Act
             var result = await _classUnderTest.GetAllByProjectIdAsync(projectId);
@@ -209,7 +154,6 @@ namespace FRF.Web.Tests.Controllers
             AssertCompareList(artifacts, returnValueList);
 
             _artifactsService.Verify(mock => mock.GetAllByProjectId(projectId), Times.Once);
-            _mapper.Verify(mock => mock.Map<IEnumerable<ArtifactDTO>>(It.Is<List<Artifact>>(a => a.Contains(artifact))), Times.Once);
         }
 
         [Fact]
@@ -261,27 +205,9 @@ namespace FRF.Web.Tests.Controllers
                 Description = "Description of Artifact Type 1"
             };
 
-            var artifactDTO = new ArtifactDTO
-            {
-                Id = 1,
-                Name = "Artifact 1",
-                Provider = "AWS",
-                Settings = new XElement("Root",
-                                new XElement("Child1", 1),
-                                new XElement("Child2", 2),
-                                new XElement("Child3", 3)
-                            ),
-                ProjectId = projectId,
-                ArtifactType = artifactTypeDTO
-            };
-
             _artifactsService
                 .Setup(mock => mock.Get(It.IsAny<int>()))
                 .ReturnsAsync(artifact);
-
-            _mapper
-                .Setup(mock => mock.Map<ArtifactDTO>(It.IsAny<Artifact>()))
-                .Returns(artifactDTO);
 
             //Act
             var result = await _classUnderTest.GetAsync(artifactId);
@@ -293,7 +219,6 @@ namespace FRF.Web.Tests.Controllers
             AssertCompareArtifactArtifactDTO(artifact, returnValue);
 
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
-            _mapper.Verify(mock => mock.Map<ArtifactDTO>(It.Is<Artifact>(a => a.Equals(artifact))), Times.Once);
         }
 
         [Fact]
@@ -308,7 +233,6 @@ namespace FRF.Web.Tests.Controllers
             // Assert
             Assert.IsType<NotFoundResult>(result);
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
-            _mapper.Verify(mock => mock.Map<ArtifactDTO>(It.IsAny<Artifact>()), Times.Never);
         }
 
         [Fact]
@@ -353,27 +277,6 @@ namespace FRF.Web.Tests.Controllers
                 ArtifactTypeId = artifactTypeId,
                 ArtifactType = artifactType
             };
-        
-            var artifactTypeDTO = new ArtifactTypeDTO
-            {
-                Id = artifactTypeId,
-                Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
-            };
-
-            var artifactDTO = new ArtifactDTO
-            {
-                Id = 1,
-                Name = "Artifact 1",
-                Provider = "AWS",
-                Settings = new XElement("Root",
-                                new XElement("Child1", 1),
-                                new XElement("Child2", 2),
-                                new XElement("Child3", 3)
-                            ),
-                ProjectId = projectId,
-                ArtifactType = artifactTypeDTO
-            };
 
             var artifactUpsertDTO = new ArtifactUpsertDTO
             {
@@ -392,14 +295,6 @@ namespace FRF.Web.Tests.Controllers
                 .Setup(mock => mock.Save(It.IsAny<Artifact>()))
                 .ReturnsAsync(artifact);
 
-            _mapper
-                .Setup(mock => mock.Map<Artifact>(It.IsAny<ArtifactUpsertDTO>()))
-                .Returns(artifact);
-
-            _mapper
-                .Setup(mock => mock.Map<ArtifactDTO>(It.IsAny<Artifact>()))
-                .Returns(artifactDTO);
-
             //Act
             var result = await _classUnderTest.SaveAsync(artifactUpsertDTO);
 
@@ -407,10 +302,12 @@ namespace FRF.Web.Tests.Controllers
             var okResult = Assert.IsType<OkObjectResult>(result);
             var returnValue = Assert.IsAssignableFrom<ArtifactDTO>(okResult.Value);
 
-            AssertCompareArtifactArtifactDTO(artifact, artifactDTO);
-            _artifactsService.Verify(mock => mock.Save(artifact), Times.Once);
-            _mapper.Verify(mock => mock.Map<ArtifactDTO>(It.Is<Artifact>(a => a.Equals(artifact))), Times.Once);
-            _mapper.Verify(mock => mock.Map<Artifact>(It.Is<ArtifactUpsertDTO>(a => a.Equals(artifactUpsertDTO))), Times.Once);
+            AssertCompareArtifactArtifactDTO(artifact, returnValue);
+            _artifactsService.Verify(mock => mock.Save(It.Is<Artifact>(a => 
+                a.Name == artifactUpsertDTO.Name
+                && a.Provider == artifactUpsertDTO.Provider
+                && a.ProjectId == artifactUpsertDTO.ProjectId
+                && a.ArtifactTypeId == artifactUpsertDTO.ArtifactTypeId)), Times.Once);
         }
 
         [Fact]
@@ -456,27 +353,6 @@ namespace FRF.Web.Tests.Controllers
                 ArtifactType = artifactType
             };
 
-            var artifactTypeDTO = new ArtifactTypeDTO
-            {
-                Id = artifactTypeId,
-                Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
-            };
-
-            var artifactDTO = new ArtifactDTO
-            {
-                Id = 1,
-                Name = "Artifact 1",
-                Provider = "AWS",
-                Settings = new XElement("Root",
-                                new XElement("Child1", 1),
-                                new XElement("Child2", 2),
-                                new XElement("Child3", 3)
-                            ),
-                ProjectId = projectId,
-                ArtifactType = artifactTypeDTO
-            };
-
             var artifactUpsertDTO = new ArtifactUpsertDTO
             {
                 Name = "Artifact 1",
@@ -498,14 +374,6 @@ namespace FRF.Web.Tests.Controllers
                 .Setup(mock => mock.Update(It.IsAny<Artifact>()))
                 .ReturnsAsync(artifact);
 
-            _mapper
-                .Setup(mock => mock.Map<ArtifactDTO>(It.IsAny<Artifact>()))
-                .Returns(artifactDTO);
-
-            _mapper
-                .Setup(mock => mock.Map(It.IsAny<ArtifactUpsertDTO>(), It.IsAny<Artifact>()))
-                .Returns(artifact);
-
             //Act
             var result = await _classUnderTest.UpdateAsync(artifactId, artifactUpsertDTO);
 
@@ -517,8 +385,6 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
             _artifactsService.Verify(mock => mock.Update(artifact), Times.Once);
-            _mapper.Verify(mock => mock.Map(It.Is<ArtifactUpsertDTO>(a => a.Equals(artifactUpsertDTO)), It.Is<Artifact>(a => a.Equals(artifact))), Times.Once);
-            _mapper.Verify(mock => mock.Map<ArtifactDTO>(It.Is<Artifact>(a => a.Equals(artifact))), Times.Once);
         }
 
         [Fact]
@@ -533,8 +399,6 @@ namespace FRF.Web.Tests.Controllers
             // Assert
             Assert.IsType<NotFoundResult>(result);
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
-            _mapper.Verify(mock => mock.Map(It.IsAny<ArtifactUpsertDTO>(), It.IsAny<Artifact>()), Times.Never);
-            _mapper.Verify(mock => mock.Map<ArtifactDTO>(It.IsAny<Artifact>()), Times.Never);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
@@ -12,17 +12,16 @@ namespace FRF.Web.Tests.Controllers
 {
     public class CategoriesControllerTests
     {
-        private readonly Mock<IMapper> _mapper;
+        private readonly IMapper _mapper = MapperBuilder.Build();
         private readonly Mock<ICategoriesService> _categoriesService;
 
         private readonly CategoriesController _classUnderTest;
 
         public CategoriesControllerTests()
         {
-            _mapper = new Mock<IMapper>();
             _categoriesService = new Mock<ICategoriesService>();
 
-            _classUnderTest = new CategoriesController(_categoriesService.Object, _mapper.Object);
+            _classUnderTest = new CategoriesController(_categoriesService.Object, _mapper);
         }
 
         [Fact]
@@ -41,15 +40,6 @@ namespace FRF.Web.Tests.Controllers
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
                 .ReturnsAsync(category);
 
-            _mapper
-                .Setup(mock => mock.Map<CategoryDTO>(It.IsAny<Category>()))
-                .Returns(new CategoryDTO
-                {
-                    Id = category.Id,
-                    Name = category.Name,
-                    Description = category.Description
-                });
-
             // Act
             var result = await _classUnderTest.GetAsync(categoryId);
 
@@ -62,7 +52,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(category.Description, returnValue.Description);
 
             _categoriesService.Verify(mock => mock.GetAsync(categoryId), Times.Once);
-            _mapper.Verify(mock => mock.Map<CategoryDTO>(It.Is<Category>(c => c.Name == category.Name)), Times.Once);
         }
 
         [Fact]
@@ -77,7 +66,6 @@ namespace FRF.Web.Tests.Controllers
             // Assert
             var notFoundResult = Assert.IsType<NotFoundResult>(result);
             _categoriesService.Verify(mock => mock.GetAsync(categoryId), Times.Once);
-            _mapper.Verify(mock => mock.Map<CategoryDTO>(It.IsAny<Category>()), Times.Never);
         }
     }
 }

--- a/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Configuration;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -19,18 +18,19 @@ namespace FRF.Web.Tests.Controllers
     {
         private readonly ProjectsController _classUnderTest;
         private readonly Mock<IConfiguration> _configuration;
-        private readonly Mock<IMapper> _mapper;
         private readonly Mock<IProjectsService> _projectsService;
         private readonly Mock<IUserService> _userService;
+        private readonly IMapper _mapper = MapperBuilder.Build();
 
         public ProjectsControllerTests()
         {
-            _mapper = new Mock<IMapper>();
             _projectsService = new Mock<IProjectsService>();
             _userService = new Mock<IUserService>();
             _configuration = new Mock<IConfiguration>();
 
-            _classUnderTest = new ProjectsController(_projectsService.Object, _mapper.Object, _userService.Object,
+            _classUnderTest = new ProjectsController(_projectsService.Object,
+                _mapper,
+                _userService.Object,
                 _configuration.Object);
         }
 
@@ -65,30 +65,6 @@ namespace FRF.Web.Tests.Controllers
             return project;
         }
 
-        private ProjectDTO CreateProjectDto(Project project)
-        {
-            var projectCategories = new Mock<ProjectCategoryDTO>();
-            var userByProject = new Mock<UsersByProjectDTO>();
-            var projectDto = new ProjectDTO
-            {
-                Id = project.Id,
-                Budget = project.Budget,
-                Client = project.Client,
-                Name = project.Name,
-                Owner = project.Owner,
-                CreatedDate = project.CreatedDate,
-                ProjectCategories = new List<ProjectCategoryDTO>
-                {
-                    projectCategories.Object
-                },
-                UsersByProject = new List<UsersByProjectDTO>
-                {
-                    userByProject.Object
-                }
-            };
-            return projectDto;
-        }
-
         private ProjectUpsertDTO CreateProjectUpsertDto(Project project)
         {
             var projectCategories = new Mock<ProjectCategoryDTO>();
@@ -121,9 +97,6 @@ namespace FRF.Web.Tests.Controllers
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
                 .ReturnsAsync(project);
-            _mapper
-                .Setup(mock => mock.Map<ProjectDTO>(It.IsAny<Project>()))
-                .Returns(CreateProjectDto(project));
 
             // Act
             var result = await _classUnderTest.GetAsync(projectId);
@@ -137,7 +110,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(project.Budget, returnValue.Budget);
 
             _projectsService.Verify(mock => mock.GetAsync(projectId), Times.Once);
-            _mapper.Verify(mock => mock.Map<ProjectDTO>(It.Is<Project>(c => c.Name == project.Name)), Times.Once);
         }
 
         [Fact]
@@ -146,7 +118,6 @@ namespace FRF.Web.Tests.Controllers
             // Arrange
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
-            var project = CreateProject(projectId);
 
             // Act
             var result = await _classUnderTest.GetAsync(projectId);
@@ -155,7 +126,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.IsType<NotFoundResult>(result);
 
             _projectsService.Verify(mock => mock.GetAsync(projectId), Times.Once);
-            _mapper.Verify(mock => mock.Map<ProjectDTO>(It.Is<Project>(c => c.Name == project.Name)), Times.Never);
         }
 
         [Fact]
@@ -173,12 +143,6 @@ namespace FRF.Web.Tests.Controllers
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(listOfMockProject);
 
-            var listOfMockProjectDto = listOfMockProject.Select(CreateProjectDto)
-                .ToList();
-
-            _mapper
-                .Setup(mock => mock.Map<IEnumerable<ProjectDTO>>(It.IsAny<List<Project>>()))
-                .Returns(listOfMockProjectDto);
             // Act
             var result = await _classUnderTest.GetAllAsync();
 
@@ -189,9 +153,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(sizeOfList, returnValue.Count);
             //_userService.Verify(mock => mock.GetCurrentUserId(), Times.Once);
             _projectsService.Verify(mock => mock.GetAllAsync(It.IsAny<Guid>()), Times.Once);
-            _mapper.Verify(
-                mock => mock.Map<IEnumerable<ProjectDTO>>(It.Is<List<Project>>(p =>
-                    p.Count == listOfMockProjectDto.Count)), Times.Once);
         }
 
         [Fact]
@@ -199,15 +160,11 @@ namespace FRF.Web.Tests.Controllers
         {
             // Arrange
             var listOfMockProjectEmpty = new List<Project>();
-            var listOfMockProjectDtoEmpty = listOfMockProjectEmpty.Select(CreateProjectDto)
-                .ToList();
 
             _projectsService
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(listOfMockProjectEmpty);
-            _mapper
-                .Setup(mock => mock.Map<IEnumerable<ProjectDTO>>(It.IsAny<List<Project>>()))
-                .Returns(listOfMockProjectDtoEmpty);
+
             // Act
             var result = await _classUnderTest.GetAllAsync();
 
@@ -218,9 +175,6 @@ namespace FRF.Web.Tests.Controllers
             //_userService.Verify(mock => mock.GetCurrentUserId(), Times.Once);
             Assert.Empty(returnValue);
             _projectsService.Verify(mock => mock.GetAllAsync(It.IsAny<Guid>()), Times.Once);
-            _mapper.Verify(
-                mock => mock.Map<IEnumerable<ProjectDTO>>(It.Is<List<Project>>(p =>
-                    p.Count == 0)), Times.Once);
         }
 
         [Fact]
@@ -230,17 +184,12 @@ namespace FRF.Web.Tests.Controllers
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
             var project = CreateProject(projectId);
-            var projectDTO = CreateProjectDto(project);
             var projectUpsertDTO = CreateProjectUpsertDto(project);
 
-            _mapper
-                .Setup(mock => mock.Map<Project>(It.IsAny<ProjectUpsertDTO>()))
-                .Returns(project);
             _projectsService
                 .Setup(mock => mock.SaveAsync(It.IsAny<Project>()))
                 .ReturnsAsync(project);
-            _mapper
-                .Setup(mock => mock.Map<ProjectDTO>(It.IsAny<Project>())).Returns(projectDTO);
+
             // Act
             var result = await _classUnderTest.SaveAsync(projectUpsertDTO);
 
@@ -251,11 +200,9 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(project.Name, returnValue.Name);
             Assert.Equal(project.Budget, returnValue.Budget);
 
-            _projectsService.Verify(mock => mock.SaveAsync(project), Times.Once);
-            _mapper.Verify(mock => mock.Map<Project>(It.Is<ProjectUpsertDTO>(p => p.Owner == project.Owner)),
-                Times.Once);
-            _mapper.Verify(mock => mock.Map<ProjectDTO>(It.Is<Project>(p => p.Owner == project.Owner)),
-                Times.Once);
+            _projectsService.Verify(mock => mock.SaveAsync(It.Is<Project>(p =>
+                p.Name == returnValue.Name
+                && p.Budget == returnValue.Budget)), Times.Once);
         }
 
         [Fact]
@@ -274,7 +221,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.IsType<BadRequestResult>(result);
 
             _projectsService.Verify(mock => mock.SaveAsync(project), Times.Never);
-            _mapper.Verify(mock => mock.Map<ProjectDTO>(It.IsAny<Project>()), Times.Never);
         }
 
         [Fact]
@@ -285,7 +231,6 @@ namespace FRF.Web.Tests.Controllers
             var projectId = rnd.Next(1, 99999);
             var project = CreateProject(projectId);
             var projectUpsertDTO = CreateProjectUpsertDto(project);
-
 
             // Act
             var result = await _classUnderTest.UpdateAsync(9, projectUpsertDTO);
@@ -305,19 +250,15 @@ namespace FRF.Web.Tests.Controllers
             var projectId = rnd.Next(1, 99999);
             var project = CreateProject(projectId);
             var projectUpsertDTO = CreateProjectUpsertDto(project);
-            _mapper
-                .Setup(mock => mock.Map<Project>(It.IsAny<ProjectDTO>()))
-                .Returns(project);
+
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
                 .ReturnsAsync(project);
-            _mapper
-                .Setup(mock => mock.Map(projectUpsertDTO, project));
+
             _projectsService
                 .Setup(mock => mock.UpdateAsync(It.IsAny<Project>()))
                 .ReturnsAsync(project);
-            _mapper
-                .Setup(mock => mock.Map<ProjectDTO>(It.IsAny<Project>())).Returns(CreateProjectDto(project));
+
             // Act
             var result = await _classUnderTest.UpdateAsync(projectId, projectUpsertDTO);
 
@@ -329,26 +270,28 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(project.Budget, returnValue.Budget);
 
             _projectsService.Verify(mock => mock.UpdateAsync(project), Times.Once);
-            _mapper.Verify(mock => mock.Map<ProjectDTO>(It.Is<Project>(p => p.Owner == project.Owner)),
-                Times.Once);
         }
 
         [Fact]
         public async Task Delete_WhenProjectIsDeleted_NoContent()
         {
-            //Arrange
+            // Arrange
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
             var project = CreateProject(projectId);
+
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
                 .ReturnsAsync(project);
+
             _projectsService
                 .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
                 .ReturnsAsync(true);
-            //Act
+
+            // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
-            //Assert
+
+            // Assert
             Assert.IsType<NoContentResult>(result);
 
             _projectsService.Verify(mock => mock.GetAsync(It.Is<int>(p => p.Equals(projectId))), Times.Once);
@@ -358,11 +301,11 @@ namespace FRF.Web.Tests.Controllers
         [Fact]
         public async Task Delete_WhenProjectDoesntExist_NotFound()
         {
-            //Arrange
+            // Arrange
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
 
-            //Act
+            // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
 
             // Assert
@@ -382,10 +325,12 @@ namespace FRF.Web.Tests.Controllers
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
                 .ReturnsAsync(project);
+
             _projectsService
                 .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
                 .ReturnsAsync(false);
-            //Act
+
+            // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
 
             // Assert

--- a/test/FRF.Web.Tests/MapperBuilder.cs
+++ b/test/FRF.Web.Tests/MapperBuilder.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+
+namespace FRF.Web.Tests
+{
+    public static class MapperBuilder
+    {
+        public static IMapper Build()
+        {
+            var mapperConfiguration = new MapperConfiguration(mc =>
+            {
+                mc.AddProfile<Core.AutoMapperProfile>();
+                mc.AddProfile<Dtos.AutoMapperProfile>();
+            });
+
+            var mapper = new Mapper(mapperConfiguration);
+            return mapper;
+        }
+    }
+}


### PR DESCRIPTION
## Background

I made a promise to make a quality of life improvement on tests for all the automapper related _inconveniences_. You are currently setting up again and again the mappings (like doing twice the work) so instead with the following changes you will rely on the profiles you already built.

I believe there might be more improvements but this so far will become very handy for you guys. Let's see how it evolves.

## Changes

- Added like a builder. I'm not very fan of static classes but this is one of the scenarios where it's quite useful and risk-free. I will create a mapper for you so have it in mind if you later on add more profiles.
- Updated all test classes so now uses the real deal instead of a mocked instance.
- Updated all tests, removing all the mocked stuff about automapper.