### PR TITLE
[FIVE-193] Quitar hardcoding de claves

### DIFF
--- a/FiveRockingFingers/FRF.Web/FRF.Web.csproj
+++ b/FiveRockingFingers/FRF.Web/FRF.Web.csproj
@@ -6,7 +6,8 @@
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>  
+    <UserSecretsId>5c16a8aa-20f7-4767-af6c-0383666f04f4</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FiveRockingFingers/FRF.Web/appsettings.Development.json
+++ b/FiveRockingFingers/FRF.Web/appsettings.Development.json
@@ -6,10 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "ConnectionStrings": {
-    "FiveRockingFingers": "Password=frfAdmin;Persist Security Info=True;User ID=frfAdmin;Initial Catalog=FiveRockingFingers;Data Source=DESKTOP-28EG8E0;MultipleActiveResultSets=True",
-    "OnConfiguring": "server=DESKTOP-28EG8E0;database=FiveRockingFingers;trusted_connection=true;"
-  },
   "Regex": {
     "EmailPattern": "^((([!#$%&'*+\\-/=?^_`{|}~\\w])|([!#$%&'*+\\-/=?^_`{|}~\\w][!#$%&'*+\\-/=?^_`{|}~\\.\\w]{0,}[!#$%&'*+\\-/=?^_`{|}~\\w]))[@]\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*)$",
     "PasswordPattern": "^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # five-rocking-fingers
 Project estimation system 
+
+## Table of Contents
+
+- [Description](#description)
+- [Structure](#structure)
+- [Project Documentation](#project-documentation)
+- [Tools](#tools)
+- [Team](#team)
+- [Workflow](#workflow)
+
+## Description
+
+Five Rocking Fingers is a software development cost estimation system.
+It was originally conceived as an academic proyect, but it is strongly oriented to a common business need.
+
+It consists on a [ASP.NET Web Development solution](https://visualstudio.microsoft.com/es/downloads/) with a [React](https://reactjs.org/) frontend and a [SQL Server](https://www.microsoft.com/es-es/sql-server/sql-server-downloads) database.
+
+## Structure
+
+* **FiveRockingFingers:** Solution directory.
+    * **FiveRockingFingers:** Project directory.
+        * **ClientApp:**
+        * **Controllers:**
+        * **Entities:**
+        * **Pages:**
+        * **Properties:**
+        * **Services:**
+
+## Project Documentation
+
+* Ramp Up document: https://docs.google.com/document/d/13Mov9mwQ1GcpQDYjRgYnb1HYqXSzPQBi/edit
+* Shared drive: https://drive.google.com/drive/u/1/folders/0AAQT4NPWq-uQUk9PVA
+
+## Tools
+* [Visual Studio](https://visualstudio.microsoft.com/es/downloads/)
+* [SQL Server](https://www.microsoft.com/es-es/sql-server/sql-server-downloads)
+* [Nodejs](https://nodejs.org/en/)
+* [React](https://reactjs.org/)
+
+## Team
+
+* Project Leader: [Erwin Martin Gutbrod](https://github.com/egutbrod)
+
+Developers:
+* [Gonzalo Perelstein](https://github.com/gperelstein)
+* [Martin Mena](https://github.com/martinmena)
+* [Gonzalo Romero](https://github.com/gonzalorom)
+
+## Workflow
+
+Five Rocking Fingers follows [Scrum](https://www.scrum.org/) methodology, organized on 2 weeks [sprints](https://drive.google.com/drive/u/1/folders/1_6KpLydBq47Twx6AwBgNiROTDHJbZCmk).
+
+Planned stories are managed on [Jira](https://makingsense.atlassian.net/secure/RapidBoard.jspa?rapidView=73&projectKey=FIVE&view=planning.nodetail&selectedIssue=FIVE-153&issueLimit=100), where developers can task and estimate the stories.
+
+Then, they can start working on [GitHub repository](https://github.com/MakingSense/five-rocking-fingers) following [Git-Flow](https://datasift.github.io/gitflow/IntroducingGitFlow.html).
+
+## Secret keys
+
+The scret keys are store in:
+
+* For Windows: %APPDATA%\Microsoft\UserSecrets\5c16a8aa-20f7-4767-af6c-0383666f04f4\secrets.json
+* For Linux/MacOS: ~/.microsoft/usersecrets/5c16a8aa-20f7-4767-af6c-0383666f04f4/secrets.json

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, they can start working on [GitHub repository](https://github.com/MakingSen
 
 ## Secret keys
 
-The scret keys are store in:
+The scret keys are stored in:
 
-* For Windows: %APPDATA%\Microsoft\UserSecrets\5c16a8aa-20f7-4767-af6c-0383666f04f4\secrets.json
+* For Windows: %APPDATA%\Roaming\Microsoft\UserSecrets\5c16a8aa-20f7-4767-af6c-0383666f04f4\secrets.json
 * For Linux/MacOS: ~/.microsoft/usersecrets/5c16a8aa-20f7-4767-af6c-0383666f04f4/secrets.json


### PR DESCRIPTION
Descripción:

Se debe eliminar la información sensible de los archivos que van a GitHub.

Cambios realizados:

-Se eliminó el conection string a la base de datos del appsettings.Development
-Se agregó la referencia al secrets.json en FRF.Web.csproj
-Se agregó la indicación de la ruta donde se guarda el secrets.json en el README.md