### PR TITLE
[FIVE-263](DAL) Crear metodo de relaciones de artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -169,13 +169,9 @@ namespace FRF.Core.Services
             {
                 var innerException = except.InnerException as SqlException;
                 if (innerException != null && (innerException.Number == 2627 || innerException.Number == 2601))
-                {
                     return null;
-                }
-                else
-                {
-                    throw;
-                }
+
+                else throw;
             }
             
             return resultArtifactRelations;

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -143,10 +143,10 @@ namespace FRF.Core.Services
             return;
         }
 
-        public async Task<IList<ArtifactsRelation>> SetRelation(IList<ArtifactsRelation> artifactRelations)
+        public async Task<IList<ArtifactsRelation>> SetRelationAsync(IList<ArtifactsRelation> artifactRelations)
         {
             var resultArtifactRelations = new List<ArtifactsRelation>();
-            var dbArtifactsId = _dataContext.Artifacts.Select(a => a.Id).ToList();
+            var dbArtifactsId = await _dataContext.Artifacts.Select(a => a.Id).ToListAsync();
             var artifactsRelationIds = artifactRelations
                 .Select(ar => ar.Artifact1Id)
                 .Concat(artifactRelations.Select(ar=>ar.Artifact2Id));

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -3,7 +3,6 @@ using FRF.Core.Models;
 using FRF.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,13 +13,11 @@ namespace FRF.Core.Services
 {
     public class ArtifactsService : IArtifactsService
     {
-        private readonly IConfiguration _configuration;
         private readonly DataAccessContext _dataContext;
         private readonly IMapper _mapper;
 
-        public ArtifactsService(IConfiguration configuration, DataAccessContext dataContext, IMapper mapper)
+        public ArtifactsService(DataAccessContext dataContext, IMapper mapper)
         {
-            _configuration = configuration;
             _dataContext = dataContext;
             _mapper = mapper;
         }
@@ -173,6 +170,7 @@ namespace FRF.Core.Services
                 resultArtifactRelations.Add(artifactRelation);
             }
 
+            await _dataContext.SaveChangesAsync();
             return resultArtifactRelations;
         }
     }

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
@@ -12,5 +12,6 @@ namespace FRF.Core.Services
         Task<Artifact> Update(Artifact artifact);
         Task Delete(int id);
         Task<Artifact> Save(Artifact artifact);
+        Task<IList<ArtifactsRelation>> SetRelation(IList<ArtifactsRelation> artifactRelations);
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
@@ -12,6 +12,6 @@ namespace FRF.Core.Services
         Task<Artifact> Update(Artifact artifact);
         Task Delete(int id);
         Task<Artifact> Save(Artifact artifact);
-        Task<IList<ArtifactsRelation>> SetRelation(IList<ArtifactsRelation> artifactRelations);
+        Task<IList<ArtifactsRelation>> SetRelationAsync(IList<ArtifactsRelation> artifactRelations);
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -1,12 +1,10 @@
 ﻿using AutoMapper;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using FRF.Core.Models;
 using FRF.Core.Services;
-using Microsoft.AspNetCore.Mvc;
 using FRF.Web.Dtos.Artifacts;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace FRF.Web.Controllers
 {
@@ -98,18 +96,6 @@ namespace FRF.Web.Controllers
             await _artifactsService.Delete(id);
 
             return NoContent();
-        }
-
-        [HttpPost]
-        public async Task<IActionResult> SetRelation(IList<ArtifactsRelationDTO> artifactRelationList)
-        {
-            var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
-            var result = await _artifactsService.SetRelation(artifactsRelations);
-            var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result);
-            
-            if (artifactsResult == null) return BadRequest();
-
-            return Ok(artifactsResult);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -99,5 +99,17 @@ namespace FRF.Web.Controllers
 
             return NoContent();
         }
+
+        [HttpPost]
+        public async Task<IActionResult> SetRelation(IList<ArtifactsRelationDTO> artifactRelationList)
+        {
+            var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
+            var result = await _artifactsService.SetRelation(artifactsRelations);
+            var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result);
+            
+            if (artifactsResult == null) return BadRequest();
+
+            return Ok(artifactsResult);
+        }
     }
 }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 using System.Threading.Tasks;
 using FRF.DataAccess.EntityModels;
 using Microsoft.Extensions.Configuration;
+using ArtifactsRelation = FRF.Core.Models.ArtifactsRelation;
 
 namespace FRF.Core.Tests.Services
 {
@@ -31,7 +32,7 @@ namespace FRF.Core.Tests.Services
             _dataAccess.Database.EnsureDeleted();
             _dataAccess.Database.EnsureCreated();
 
-            _classUnderTest = new ArtifactsService(_configuration.Object, _dataAccess, _mapper);
+            _classUnderTest = new ArtifactsService(_dataAccess, _mapper);
         }
 
         private ArtifactType CreateArtifactType()
@@ -73,6 +74,22 @@ namespace FRF.Core.Tests.Services
             _dataAccess.SaveChanges();
 
             return artifact;
+        }
+
+        private Models.ArtifactsRelation CreateArtifactsRelationModel(int artifact1Id,int artifact2Id)
+        {
+            var random = new Random();
+            var propertyId = random.Next(1000);
+            var artifactRelation = new Models.ArtifactsRelation()
+            {
+                Artifact1Id = artifact1Id,
+                Artifact2Id = artifact2Id,
+                Artifact1Property = "Mock 1 Property "+propertyId,
+                Artifact2Property = "Mock 2 Property "+propertyId,
+                RelationTypeId = 1
+            };
+
+            return artifactRelation;
         }
 
         [Fact]
@@ -434,5 +451,107 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.Null(await _dataAccess.Artifacts.FirstOrDefaultAsync(a => a.Id == artifact.Id));
         }
+        
+        [Fact]
+        public async Task SetRelationAsync_ReturnsListOfRelations()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationInDb = new List<DataAccess.EntityModels.ArtifactsRelation>();
+            var i = 0;
+            while (i < 3)
+            {
+                var artifactType = CreateArtifactType();
+                var project = CreateProject();
+                var artifact = CreateArtifact(project, artifactType);
+                var artifact1Id = artifact.Id;
+                var artifact2Id = artifact1Id++;
+
+                var artifactRelation = CreateArtifactsRelationModel(artifact1Id, artifact2Id);
+                artifactsRelationToSave.Add(artifactRelation);
+
+                var artifactRelationDb =
+                    _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(
+                        CreateArtifactsRelationModel(artifact1Id, artifact2Id));
+                await _dataAccess.ArtifactsRelation.AddAsync(artifactRelationDb);
+                artifactsRelationInDb.Add(artifactRelationDb);
+                var art = CreateArtifact(project, artifactType);
+                i++;
+            }
+
+            await _dataAccess.SaveChangesAsync();
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(artifactsRelationToSave);
+
+            // Assert
+            var result = Assert.IsAssignableFrom<IList<ArtifactsRelation>>(response);
+            for (var j = 0; j < result.Count; j++)
+            {
+                Assert.Equal(artifactsRelationToSave[j].Artifact1Id, result[j].Artifact1Id);
+                Assert.Equal(artifactsRelationToSave[j].Artifact2Id, result[j].Artifact2Id);
+                Assert.Equal(artifactsRelationToSave[j].Artifact1Property, result[j].Artifact1Property);
+                Assert.Equal(artifactsRelationToSave[j].Artifact2Property, result[j].Artifact2Property);
+            }
+        }
+
+        [Fact]
+        public async Task SetRelationAsync_ReturnsNull_WhenIsAnyArtifactExcept()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var i = 0;
+            while (i < 3)
+            {
+                var artifactRelation = CreateArtifactsRelationModel(i, ++i);
+                artifactsRelationToSave.Add(artifactRelation);
+            }
+
+            await _dataAccess.SaveChangesAsync();
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(artifactsRelationToSave);
+
+            // Assert
+            Assert.Null(response);
+        }
+
+        [Fact]
+        public async Task SetRelationAsync_ReturnsNull_WhenIsAnyArtifactRepeated()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationInDb = new List<DataAccess.EntityModels.ArtifactsRelation>();
+            var i = 0;
+            while (i < 3)
+            {
+                var artifactType = CreateArtifactType();
+                var project = CreateProject();
+                var artifact = CreateArtifact(project, artifactType);
+                var artifact1Id = artifact.Id;
+                var artifact2Id = artifact1Id++;
+
+                var artifactRelation = CreateArtifactsRelationModel(artifact1Id, artifact2Id);
+                artifactsRelationToSave.Add(artifactRelation);
+
+                var artifactRelationDb = _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation);
+                await _dataAccess.ArtifactsRelation.AddAsync(artifactRelationDb);
+                artifactsRelationInDb.Add(artifactRelationDb);
+                i++;
+            }
+
+            await _dataAccess.SaveChangesAsync();
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(artifactsRelationToSave);
+
+            // Assert
+            Assert.Null(response);
+            Assert.Equal(artifactsRelationInDb[0].Artifact1Property, artifactsRelationToSave[0].Artifact1Property);
+            Assert.Equal(artifactsRelationInDb[0].Artifact2Property, artifactsRelationToSave[0].Artifact2Property);
+            Assert.Equal(artifactsRelationInDb[0].Artifact2Id, artifactsRelationToSave[0].Artifact2Id);
+            Assert.Equal(artifactsRelationInDb[0].Artifact1Id, artifactsRelationToSave[0].Artifact1Id);
+        }
+
     }
 }


### PR DESCRIPTION
### Tareas realizadas:
- Se creó método `SetRelation` en `ArtifactsService`, validará que existan los ids de los artefactos a relacionar y que la relación no exista actualmente.
- Se agregan Unit Tests en `ArtifactsServiceTests` para metodo `SetRelationAsync`.