### PR TITLE
[FIVE-125] Asignar categorías a proyectos

### DIFF
--- a/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
@@ -20,6 +20,8 @@ namespace FRF.Web.Dtos
                 .ReverseMap();
             CreateMap<Category, Projects.CategoryDTO>()
                 .ReverseMap();
+            CreateMap<Project, Categories.ProjectDTO>()
+                .ReverseMap();
             CreateMap<ProjectCategory, Categories.ProjectCategoryDTO>()
                 .ReverseMap();
             CreateMap<Category, Categories.CategoryDTO>()

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
@@ -4,27 +4,8 @@ import Project from '../interfaces/Project';
 import { useUserContext } from './auth/contextLib';
 import Navbar from './ManageProjectsComponents/Navbar';
 import ProjectService from '../services/ProjectService';
+import CategoryService from '../services/CategoryService';
 import ProjectsList from './ManageProjectsComponents/ProjectsList';
-
-// Categorias de prueba, una vez que este listo el servicio y su API
-// deberian reemplazarlas
-const mockCategories = [
-    {
-        id: 1,
-        name: "CatNom1",
-        description: "CatDesc1"
-    },
-    {
-        id: 2,
-        name: "CatNom2",
-        description: "CatDesc2"
-    },
-    {
-        id: 3,
-        name: "CatNom3",
-        description: "CatDesc3"
-    }
-];
 
 export default function ManageProjects() {
 
@@ -36,8 +17,9 @@ export default function ManageProjects() {
         setProjects(response.data);
     }
 
-    const getCategoryList = () => {
-        setCategories(mockCategories);
+    const getCategoryList = async () => {
+        const response = await CategoryService.getAll();
+        setCategories(response.data);
     }
 
     React.useEffect(() => {
@@ -48,7 +30,7 @@ export default function ManageProjects() {
     return (
         <div className="App">
             <Navbar />
-            <ProjectsList projects={projects} categories={categories} updateProjects={getProjectList} />
+            <ProjectsList projects={projects} categories={categories} updateProjects={getProjectList} updateCategories={getCategoryList}/>
         </div>
     )
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -9,9 +9,7 @@ import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import Category from '../../interfaces/Category';
 import Project from '../../interfaces/Project';
-import ProjectCategory from '../../interfaces/ProjectCategory';
 import UserProfile from '../../interfaces/UserProfile';
-import CategoryService from '../../services/CategoryService';
 import ProjectService from '../../services/ProjectService';
 import { HelperAddUser } from './HelperAddUser';
 import { ValidateEmail } from "./ValidateEmail";
@@ -41,7 +39,7 @@ const useStyles = makeStyles({
 
 const filter = createFilterOptions<Category>();
 
-const EditProject = (props: { project: Project, cancelEdit: any, categories: Category[], openSnackbar: Function, updateProjects: Function, updateCategories: Function }) => {
+const EditProject = (props: { project: Project, cancelEdit: any, categories: Category[], openSnackbar: Function, updateProjects: Function, updateCategories: Function, fillProjectCategories: Function }) => {
     const classes = useStyles();
     const email = React.useRef<TextFieldProps>(null);
     const [fieldEmail, setFieldEmail] = React.useState<string | null>("")
@@ -122,26 +120,8 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
         setState({ ...state, selectedCategories: value });
     }
 
-    const fillProjectCategories = async () => {
-        let aux = [] as ProjectCategory[];
-        for (const category of state.selectedCategories) {
-            let categoryToAdd = props.categories.find(c => c.name === category.name);
-            if (categoryToAdd === undefined) {
-                const response = await CategoryService.save(category);
-                if (response.status === 200) {
-                    let aux2: ProjectCategory = { category: response.data };
-                    aux.push(aux2);
-                }
-            } else {
-                let aux2: ProjectCategory = { category: categoryToAdd };
-                aux.push(aux2);
-            }
-        };
-        return aux;
-    }
-
     const handleConfirm = async () => {
-        var projectCategories = await fillProjectCategories();
+        var projectCategories = await props.fillProjectCategories(state.selectedCategories);
         const { name, client, owner, budget, id, createdDate, users } = state;
         const project = { name, client, owner, budget, id, createdDate, projectCategories, users }
         const response = await ProjectService.update(id, project as Project);

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -220,13 +220,14 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
                             id="tags-standard"
                             options={tempCategories}
                             fullWidth
+                            autoHighlight
                             onChange={handleChangeCategories}
                             defaultValue={state.projectCategories.map(pc => pc.category)}
                             filterOptions={(options, params) => {
                                 var filtered = filter(options, params);
 
-                                if (params.inputValue !== '' && tempCategories.find(c => c.name === params.inputValue) === undefined) { // and not in tempcategories
-                                    filtered.push({
+                                if (params.inputValue !== '' && tempCategories.find(c => c.name === params.inputValue) === undefined) {
+                                    filtered.unshift({
                                         id: -1,
                                         name: params.inputValue,
                                         description: ""

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ManageCategories.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ManageCategories.tsx
@@ -1,0 +1,66 @@
+﻿import { TextField } from '@material-ui/core';
+import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
+import * as React from 'react';
+import Category from '../../interfaces/Category';
+
+const filter = createFilterOptions<Category>();
+
+const ManageCategories = (props: { categories: Category[], selectedCategories: Category[], setSelectedCategories: Function }) => {
+    const [tempCategories, setTempCategories] = React.useState([...props.categories]);
+
+    React.useEffect(() => {
+        setTempCategories([...props.categories]);
+    }, [props.categories.length]);
+
+    const handleChangeCategories = (event: React.ChangeEvent<{}>, value: Category[]) => {
+        if (value.length === 0) {
+            props.setSelectedCategories([]);
+            return
+        }
+        if (tempCategories.filter(c => c.name === value[value.length - 1].name).length === 0) {
+            let aux = [...tempCategories];
+            aux.push(value[value.length - 1]);
+            setTempCategories(aux);
+        }
+        props.setSelectedCategories(value);
+    }
+
+    return (
+        <>
+            <Autocomplete
+                multiple
+                id="tags-standard"
+                options={tempCategories}
+                fullWidth
+                onChange={handleChangeCategories}
+                autoHighlight
+                filterOptions={(options, params) => {
+                    var filtered = filter(options, params);
+
+                    if (params.inputValue !== '' && tempCategories.find(c => c.name === params.inputValue) === undefined) {
+                        filtered.unshift({
+                            id: -1,
+                            name: params.inputValue,
+                            description: ""
+                        });
+                    }
+                    return filtered;
+                }}
+                getOptionLabel={(option) => {
+                    return option.name
+                }}
+                getOptionSelected={(option, value) => option.name === value.name}
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        variant="outlined"
+                        label="Categorías"
+                        placeholder="Escriba el nombre de la categoría"
+                    />
+                )}
+            />
+        </>
+        )
+}
+
+export default ManageCategories;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ManageCategories.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ManageCategories.tsx
@@ -18,9 +18,9 @@ const ManageCategories = (props: { categories: Category[], selectedCategories: C
             return
         }
         if (tempCategories.filter(c => c.name === value[value.length - 1].name).length === 0) {
-            let aux = [...tempCategories];
-            aux.push(value[value.length - 1]);
-            setTempCategories(aux);
+            let categories = [...tempCategories];
+            categories.push(value[value.length - 1]);
+            setTempCategories(categories);
         }
         props.setSelectedCategories(value);
     }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -226,11 +226,12 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
                         options={tempCategories}
                         fullWidth
                         onChange={handleChangeCategories}
+                        autoHighlight
                         filterOptions={(options, params) => {
                             var filtered = filter(options, params);
 
-                            if (params.inputValue !== '' && tempCategories.find(c => c.name === params.inputValue) === undefined) { // and not in tempcategories
-                                filtered.push({
+                            if (params.inputValue !== '' && tempCategories.find(c => c.name === params.inputValue) === undefined) {
+                                filtered.unshift({
                                     id: -1,
                                     name: params.inputValue,
                                     description: ""

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -88,21 +88,21 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
     }
 
     const fillProjectCategories = async (selectedCategories: Category[]) => {
-        let aux = [] as ProjectCategory[];
+        let projectCategories = [] as ProjectCategory[];
         for (const category of selectedCategories) {
             let categoryToAdd = props.categories.find(c => c.name === category.name);
             if (categoryToAdd === undefined) {
                 const response = await CategoryService.save(category);
                 if (response.status === 200) {
-                    let aux2: ProjectCategory = { category: response.data };
-                    aux.push(aux2);
+                    let projectCategory: ProjectCategory = { category: response.data };
+                    projectCategories.push(projectCategory);
                 }
             } else {
-                let aux2: ProjectCategory = { category: categoryToAdd };
-                aux.push(aux2);
+                let projectCategory: ProjectCategory = { category: categoryToAdd };
+                projectCategories.push(projectCategory);
             }
         };
-        return aux;
+        return projectCategories;
     }
 
     // Turn edit on/off

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -5,7 +5,9 @@ import * as React from 'react';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import Category from '../../interfaces/Category';
 import Project from '../../interfaces/Project';
+import ProjectCategory from '../../interfaces/ProjectCategory';
 import SnackbarSettings from '../../interfaces/SnackbarSettings';
+import CategoryService from '../../services/CategoryService';
 import ConfirmationDialog from './ConfirmationDialog';
 import EditProject from './EditProject';
 import ListElement from './ListElement';
@@ -85,6 +87,24 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
         }
     }
 
+    const fillProjectCategories = async (selectedCategories: Category[]) => {
+        let aux = [] as ProjectCategory[];
+        for (const category of selectedCategories) {
+            let categoryToAdd = props.categories.find(c => c.name === category.name);
+            if (categoryToAdd === undefined) {
+                const response = await CategoryService.save(category);
+                if (response.status === 200) {
+                    let aux2: ProjectCategory = { category: response.data };
+                    aux.push(aux2);
+                }
+            } else {
+                let aux2: ProjectCategory = { category: categoryToAdd };
+                aux.push(aux2);
+            }
+        };
+        return aux;
+    }
+
     // Turn edit on/off
     const changeEdit = () => {
         setEdit(true);
@@ -117,7 +137,14 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     <Button size="large" variant="contained" className={classes.button} fullWidth={true} endIcon={<AddIcon />} onClick={createProject}>
                         Nuevo Proyecto
                     </Button>
-                    <NewProjectDialog create={create} finishCreation={finishCreation} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} updateCategories={props.updateCategories} />
+                    <NewProjectDialog
+                        create={create}
+                        finishCreation={finishCreation}
+                        categories={props.categories}
+                        openSnackbar={manageOpenSnackbar}
+                        updateProjects={props.updateProjects}
+                        updateCategories={props.updateCategories}
+                        fillProjectCategories={fillProjectCategories} />
                     <Divider />
                     <List>
                         {props.projects.map((project: Project) =>
@@ -132,7 +159,14 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     selectedIndex === -1 ?
                         (<h1>Seleccione un proyecto para ver sus detalles</h1>)
                         : (edit ?
-                            (<EditProject project={props.projects.filter(p => p.id === selectedIndex)[0]} cancelEdit={cancelEdit} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} updateCategories={props.updateCategories} />)
+                            (<EditProject
+                                project={props.projects.filter(p => p.id === selectedIndex)[0]}
+                                cancelEdit={cancelEdit}
+                                categories={props.categories}
+                                openSnackbar={manageOpenSnackbar}
+                                updateProjects={props.updateProjects}
+                                updateCategories={props.updateCategories}
+                                fillProjectCategories={fillProjectCategories} />)
                             : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
                 }
                 <SnackbarMessage

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-const ProjectsList = (props: { projects: Project[], categories: Category[], updateProjects: Function }) => {
+const ProjectsList = (props: { projects: Project[], categories: Category[], updateProjects: Function, updateCategories: Function }) => {
 
     const classes = useStyles();
 
@@ -117,7 +117,7 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     <Button size="large" variant="contained" className={classes.button} fullWidth={true} endIcon={<AddIcon />} onClick={createProject}>
                         Nuevo Proyecto
                     </Button>
-                    <NewProjectDialog create={create} finishCreation={finishCreation} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />
+                    <NewProjectDialog create={create} finishCreation={finishCreation} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} updateCategories={props.updateCategories} />
                     <Divider />
                     <List>
                         {props.projects.map((project: Project) =>
@@ -132,7 +132,7 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     selectedIndex === -1 ?
                         (<h1>Seleccione un proyecto para ver sus detalles</h1>)
                         : (edit ?
-                            (<EditProject project={props.projects.filter(p => p.id === selectedIndex)[0]} cancelEdit={cancelEdit} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />)
+                            (<EditProject project={props.projects.filter(p => p.id === selectedIndex)[0]} cancelEdit={cancelEdit} categories={props.categories} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} updateCategories={props.updateCategories} />)
                             : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
                 }
                 <SnackbarMessage

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/CategoryService.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/CategoryService.tsx
@@ -1,0 +1,34 @@
+﻿import axios from 'axios';
+import { BASE_URL } from '../Constants'
+import Category from '../interfaces/Category';
+
+const CATEGORIES_URL = `${BASE_URL}api/Category/`
+
+class CategoryService {
+
+    static getAll = async () => {
+        const response = await axios.get(`${CATEGORIES_URL}GetAll`);
+        return response;
+    }
+
+    static get = async (id: number) => {
+        const response = await axios.get(`${CATEGORIES_URL}Get/${id}`);
+        return response;
+    }
+
+    static save = async (category: Category) => {
+        const response = await axios.post(`${CATEGORIES_URL}Save`, category);
+        return response;
+    }
+
+    static update = async (category: Category) => {
+        const response = await axios.put(`${CATEGORIES_URL}Delete/${category.id}`, category);
+        return response;
+    }
+
+    static delete = async (id: number) => {
+        const response = await axios.delete(`${CATEGORIES_URL}Delete/${id}`);
+        return response;
+    }
+
+}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/CategoryService.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/CategoryService.tsx
@@ -1,8 +1,8 @@
 ﻿import axios from 'axios';
-import { BASE_URL } from '../Constants'
+import { BASE_URL } from '../Constants';
 import Category from '../interfaces/Category';
 
-const CATEGORIES_URL = `${BASE_URL}api/Category/`
+const CATEGORIES_URL = `${BASE_URL}api/Categories/`;
 
 class CategoryService {
 
@@ -30,5 +30,6 @@ class CategoryService {
         const response = await axios.delete(`${CATEGORIES_URL}Delete/${id}`);
         return response;
     }
-
 }
+
+export default CategoryService;


### PR DESCRIPTION
## Tareas realizadas
- Se creó el componente de servicio de categorías con los métodos correspondientes.
- Se modificó el componente ManageProjects para obtener el listado de categorías real (a través del servicio creado) en lugar de las categorías de prueba que existían.
- En la creación y modificación de proyectos, ahora se seleccionan las categorías desde un dropdown, con la posibilidad de también agregar nuevas categorías.