### PR TITLE
[FIVE-215] Mejorar el código del servicio de artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -27,26 +27,17 @@ namespace FRF.Core.Services
         public async Task<List<Artifact>> GetAll()
         {
             var result = await _dataContext.Artifacts.Include(a => a.ArtifactType).Include(a => a.Project).ThenInclude(p => p.ProjectCategories).ThenInclude(pc => pc.Category).ToListAsync();
-            if (result == null)
-            {
-                return null;
-            }
             return _mapper.Map<List<Artifact>>(result);
         }
 
         public async Task<List<Artifact>> GetAllByProjectId(int projectId)
         {
-            var project = await _dataContext.Projects.Include(p => p.ProjectCategories).ThenInclude(pc => pc.Category).SingleOrDefaultAsync(p => p.Id == projectId);
-            if (project == null)
+            if (!await _dataContext.Projects.AnyAsync(p => p.Id == projectId))
             {
                 throw new System.ArgumentException("There is no project with Id = " + projectId, "projectId");
             }
 
             var result = await _dataContext.Artifacts.Include(a => a.ArtifactType).Include(a => a.Project).ThenInclude(p => p.ProjectCategories).ThenInclude(pc => pc.Category).Where(a => a.ProjectId == projectId).ToListAsync();
-            if (result == null)
-            {
-                return null;
-            }
             return _mapper.Map<List<Artifact>>(result);
         }
 
@@ -62,16 +53,12 @@ namespace FRF.Core.Services
 
         public async Task<Artifact> Save(Artifact artifact)
         {
-            //Gets the project associated to it from the database
-            var project = await _dataContext.Projects.Include(p => p.ProjectCategories).ThenInclude(pc => pc.Category).SingleOrDefaultAsync(p => p.Id == artifact.ProjectId);
-            if (project == null)
+            if(! await _dataContext.Projects.AnyAsync(p => p.Id == artifact.ProjectId))
             {
                 throw new System.ArgumentException("There is no project with Id = " + artifact.ProjectId, "artifact.ProjectId");
             }
 
-            //Gets the artifactType associated to it from the database
-            var artifactType = await _dataContext.ArtifactType.SingleOrDefaultAsync(at => at.Id == artifact.ArtifactTypeId);
-            if (artifactType == null)
+            if(! await _dataContext.ArtifactType.AnyAsync(at => at.Id == artifact.ArtifactTypeId))
             {
                 throw new System.ArgumentException("There is no ArtifactType with Id = " + artifact.ArtifactTypeId, "artifact.ArtifactTypeId");
             }
@@ -81,10 +68,7 @@ namespace FRF.Core.Services
             mappedArtifact.CreatedDate = DateTime.Now;
             mappedArtifact.ModifiedDate = null;
             mappedArtifact.ProjectId = artifact.ProjectId;
-            mappedArtifact.Project = project;
             mappedArtifact.ArtifactTypeId = artifact.ArtifactTypeId;
-            mappedArtifact.ArtifactType = artifactType;
-
 
             // Adds the artifact to the database, generating a unique Id for it
             await _dataContext.Artifacts.AddAsync(mappedArtifact);
@@ -104,16 +88,12 @@ namespace FRF.Core.Services
                 throw new System.ArgumentException("There is no artifact with Id = " + artifact.Id, "artifact,Id");
             }
 
-            //Gets the project associated to it from the database
-            var project = await _dataContext.Projects.Include(p => p.ProjectCategories).ThenInclude(pc => pc.Category).SingleOrDefaultAsync(p => p.Id == artifact.ProjectId);
-            if (project == null)
+            if (! await _dataContext.Projects.AnyAsync(p => p.Id == artifact.ProjectId))
             {
                 throw new System.ArgumentException("There is no project with Id = " + artifact.ProjectId, "artifact.ProjectId");
             }
 
-            //Gets the artifactType associated to it from the database
-            var artifactType = await _dataContext.ArtifactType.SingleOrDefaultAsync(at => at.Id == artifact.ArtifactTypeId);
-            if (artifactType == null)
+            if (!await _dataContext.ArtifactType.AnyAsync(at => at.Id == artifact.ArtifactTypeId))
             {
                 throw new System.ArgumentException("There is no ArtifactType with Id = " + artifact.ArtifactTypeId, "artifact.ArtifactTypeId");
             }
@@ -123,10 +103,8 @@ namespace FRF.Core.Services
             result.Provider = artifact.Provider;
             result.Settings = artifact.Settings;
             result.ModifiedDate = DateTime.Now;
-            result.ProjectId = project.Id;
-            result.Project = project;
+            result.ProjectId = artifact.ProjectId;
             result.ArtifactTypeId = artifact.ArtifactTypeId;
-            result.ArtifactType = artifactType;
 
             //Saves the updated aritfact in the database
             await _dataContext.SaveChangesAsync();
@@ -134,12 +112,16 @@ namespace FRF.Core.Services
             return _mapper.Map<Artifact>(result);
         }
 
-        public async Task Delete(int id)
+        public async Task<Artifact> Delete(int id)
         {
-            var artifactToDelete = await _dataContext.Artifacts.Include(a => a.ArtifactType).SingleOrDefaultAsync(a => a.Id == id); ;
+            var artifactToDelete = await _dataContext.Artifacts.SingleOrDefaultAsync(a => a.Id == id);
+            if (artifactToDelete == null)
+            {
+                return null;
+            }
             _dataContext.Artifacts.Remove(artifactToDelete);
             await _dataContext.SaveChangesAsync();
-            return;
+            return _mapper.Map<Artifact>(artifactToDelete);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
@@ -10,7 +10,7 @@ namespace FRF.Core.Services
         Task<List<Artifact>> GetAllByProjectId(int projectId);
         Task<Artifact> Get(int id);
         Task<Artifact> Update(Artifact artifact);
-        Task Delete(int id);
+        Task<Artifact> Delete(int id);
         Task<Artifact> Save(Artifact artifact);
     }
 }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -417,7 +417,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task Delete_Returns()
+        public async Task Delete_ReturnsArtifact()
         {
             // Arange
             var artifactType = CreateArtifactType();
@@ -425,10 +425,36 @@ namespace FRF.Core.Tests.Services
             var artifact = CreateArtifact(project, artifactType);
 
             // Act
-            await _classUnderTest.Delete(artifact.Id);
+            var result = await _classUnderTest.Delete(artifact.Id);
 
             // Assert
-            Assert.Null(await _dataAccess.Artifacts.FirstOrDefaultAsync(a => a.Id == artifact.Id));
+            Assert.IsType<Models.Artifact>(result);
+
+            Assert.Equal(artifact.Id, result.Id);
+            Assert.Equal(artifact.Name, result.Name);
+            Assert.Equal(artifact.Provider, result.Provider);
+            Assert.Equal(artifact.CreatedDate, result.CreatedDate);
+            Assert.Equal(artifact.ProjectId, result.ProjectId);
+            Assert.Equal(artifact.ArtifactTypeId, result.ArtifactTypeId);
+
+            Assert.Equal(artifact.Project.Id, result.Project.Id);
+            Assert.Equal(artifact.Project.Name, result.Project.Name);
+
+            Assert.Equal(artifact.ArtifactType.Id, result.ArtifactType.Id);
+            Assert.Equal(artifact.ArtifactType.Name, result.ArtifactType.Name);
+            Assert.Equal(artifact.ArtifactType.Description, result.ArtifactType.Description);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNull()
+        {
+            // Arange
+            var artifactType = CreateArtifactType();
+            var project = CreateProject();
+            var artifact = CreateArtifact(project, artifactType);
+
+            // Act/Assert
+            Assert.Null(await _classUnderTest.Delete(0));
         }
     }
 }


### PR DESCRIPTION
## Tareas realizadas

- Modificada la interfaz IArtifactsService para que el método delete devuelva una Task<Artifact>.
- Simplificados chequeos de existencia de projectos y tipos de artefactos al crear/modificar artefactos, y la existencia del proyecto al obtener el listado de artefactos asociados. En lugar de obtener el objeto de la base de datos (y en muchos casos con las relaciones a otras tablas incluidas) se verifica que exista algún elemento con el Id al cual se está intentando asociar.
- Simplificada la asociación entre artefactos con los proyectos y los tipos de artefactos en los métodos Save y Update.
- Modificado método Delete para devolver nulo en caso de no existir el artefacto a eliminar, o el artefacto eliminado en caso exitoso.
- Modificados tests del método Delete acorde a las modificaciones en el servicio.