### PR TITLE
[FIVE-266] (SignIn) Incorporación de ServiceResponse en SignInService y su controller

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -11,5 +11,8 @@
         // Relation errors
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
+
+        // User errors
+        public const int AuthenticationError = 20;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -13,6 +13,7 @@
         public const int RelationNotValid = 11;
 
         // User errors
-        public const int AuthenticationError = 20;
+        public const int InvalidCredentials = 20;
+        public const int AuthenticationServerCurrentlyUnavailable = 21;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ISignInService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ISignInService.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using FRF.Core.Models;
+using FRF.Core.Response;
 using System.Threading.Tasks;
-using FRF.Core.Models;
 
 namespace FRF.Core.Services
 {
     public interface ISignInService
     {
-        Task<Tuple<bool, string>> SignInAsync(UserSignIn userSignIn);
+        Task<ServiceResponse<string>> SignInAsync(UserSignIn userSignIn);
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/SignInService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignInService.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.Extensions.CognitoAuthentication;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using Microsoft.AspNetCore.Identity;
 using System;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace FRF.Core.Services
         /// </summary>
         /// <param name="userSignIn">User Object with email and password</param>
         /// <returns>If is a correct user, return true and user id otherwise return false</returns>
-        public async Task<Tuple<bool, string>> SignInAsync(UserSignIn userSignIn)
+        public async Task<ServiceResponse<string>> SignInAsync(UserSignIn userSignIn)
         {
             var userEmail = userSignIn.Email.Trim();
             var userPassword = userSignIn.Password.Trim();
@@ -30,13 +31,13 @@ namespace FRF.Core.Services
             {
                 //First Look if the email exist
                 var token = await _signInManager.UserManager.FindByEmailAsync(userEmail);
-                if (token == null) return new Tuple<bool, string>(false, "");
+                if (token == null) return new ServiceResponse<string>(new Error(ErrorCodes.AuthentificationError, ""));
 
                 var result = await _signInManager.PasswordSignInAsync(token, userPassword,
                     userSignIn.RememberMe, lockoutOnFailure: false);
                 return result.Succeeded
-                    ? new Tuple<bool, string>(true, token.UserID)
-                    : new Tuple<bool, string>(false, "");
+                    ? new ServiceResponse<string>(token.UserID)
+                    : new ServiceResponse<string>(new Error(ErrorCodes.AuthentificationError, ""));
             }
             catch (Exception e)
             {

--- a/FiveRockingFingers/FRF.Core/Services/SignInService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignInService.cs
@@ -2,7 +2,6 @@
 using FRF.Core.Models;
 using FRF.Core.Response;
 using Microsoft.AspNetCore.Identity;
-using System;
 using System.Threading.Tasks;
 
 namespace FRF.Core.Services
@@ -31,18 +30,18 @@ namespace FRF.Core.Services
             {
                 //First Look if the email exist
                 var token = await _signInManager.UserManager.FindByEmailAsync(userEmail);
-                if (token == null) return new ServiceResponse<string>(new Error(ErrorCodes.AuthentificationError, ""));
+                if (token == null) return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
 
                 var result = await _signInManager.PasswordSignInAsync(token, userPassword,
                     userSignIn.RememberMe, lockoutOnFailure: false);
                 return result.Succeeded
                     ? new ServiceResponse<string>(token.UserID)
-                    : new ServiceResponse<string>(new Error(ErrorCodes.AuthentificationError, ""));
+                    : new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
             }
-            catch (Exception e)
+            catch
             {
                 //throw message exception from AWS Cognito User Pool
-                throw new Exception(e.Message);
+                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
             }
         }
     }

--- a/FiveRockingFingers/FRF.Core/Services/SignInService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignInService.cs
@@ -30,18 +30,18 @@ namespace FRF.Core.Services
             {
                 //First Look if the email exist
                 var token = await _signInManager.UserManager.FindByEmailAsync(userEmail);
-                if (token == null) return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
+                if (token == null) return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, "There was an error with your email and/or password"));
 
                 var result = await _signInManager.PasswordSignInAsync(token, userPassword,
                     userSignIn.RememberMe, lockoutOnFailure: false);
                 return result.Succeeded
                     ? new ServiceResponse<string>(token.UserID)
-                    : new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
+                    : new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, "There was an error with your email and/or password"));
             }
             catch
             {
                 //throw message exception from AWS Cognito User Pool
-                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
+                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, "There was an error with the authentication server"));
             }
         }
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using FRF.Web.Dtos.Users;
 using Microsoft.AspNetCore.Authorization;
@@ -27,8 +28,9 @@ namespace FRF.Web.Controllers
         {
             var userSignIn = _mapper.Map<UserSignIn>(signInDto);
             var response = await _signInService.SignInAsync(userSignIn);
-            if (response.Success) return Ok(response.Value);
-            return BadRequest();
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized();
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
+            return Ok(response.Value);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
@@ -4,7 +4,6 @@ using FRF.Core.Services;
 using FRF.Web.Dtos.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Threading.Tasks;
 
 namespace FRF.Web.Controllers
@@ -27,8 +26,8 @@ namespace FRF.Web.Controllers
         public async Task<ActionResult> SignIn(SignInDTO signInDto)
         {
             var userSignIn = _mapper.Map<UserSignIn>(signInDto);
-            var (isAuthorize, token) =await _signInService.SignInAsync(userSignIn);
-            if (isAuthorize) return Ok(token);
+            var response = await _signInService.SignInAsync(userSignIn);
+            if (response.Success) return Ok(response.Value);
             return BadRequest();
         }
     }

--- a/test/FRF.Core.Tests/Services/SignInServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignInServiceTest.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Threading.Tasks;
-using Amazon.Extensions.CognitoAuthentication;
+﻿using Amazon.Extensions.CognitoAuthentication;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using Microsoft.AspNetCore.Identity;
 using Moq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace FRF.Core.Tests.Services
@@ -31,9 +31,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignInAsync(userSignin);
 
             // Assert
-            Assert.IsType<Tuple<bool, string>>(result);
-            Assert.False(result.Item1);
-            Assert.Equal(string.Empty, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.AuthentificationError, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
         }
@@ -55,9 +55,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignInAsync(userSignin);
 
             // Assert
-            Assert.IsType<Tuple<bool, string>>(result);
-            Assert.False(result.Item1);
-            Assert.Equal(string.Empty, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.AuthentificationError, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 
@@ -86,9 +86,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignInAsync(userSignin);
 
             // Assert
-            Assert.IsType<Tuple<bool, string>>(result);
-            Assert.True(result.Item1);
-            Assert.Equal(cognitoUser.UserID, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.True(result.Success);
+            Assert.Equal(cognitoUser.UserID, result.Value);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 

--- a/test/FRF.Core.Tests/Services/SignInServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignInServiceTest.cs
@@ -33,7 +33,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.False(result.Success);
-            Assert.Equal(ErrorCodes.AuthentificationError, result.Error.Code);
+            Assert.Equal(ErrorCodes.InvalidCredentials, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
         }
@@ -57,7 +57,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.False(result.Success);
-            Assert.Equal(ErrorCodes.AuthentificationError, result.Error.Code);
+            Assert.Equal(ErrorCodes.InvalidCredentials, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 


### PR DESCRIPTION
## Cambios realizados
- Se creó un nuevo tipo de error en ErrorCodes para representar el error de autenticación.
- Se modificó la interfaz del servicio de SignIn para que su método devuelva un objeto ServiceResponse.
- Se modificó el método del servicio de SignIn para que las posibles respuestas sean dicho objeto, reemplazando el uso de la Tupla.
- Se modificaron los tests acorde a los cambios en el servicio de SignIn y el uso de objetos ServiceResponse.
- Se modificó el método del controller de SignIn para adaptarlo a las nuevas respuestas del servicio.