### PR TITLE
[FIVE-266] (ProjectsService) Incorporación de ServiceResponse en ProyectsService

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/IProjectsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IProjectsService.cs
@@ -2,15 +2,16 @@
 using FRF.Core.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FRF.Core.Response;
 
 namespace FRF.Core.Services
 {
     public interface IProjectsService
     {
-        Task<List<Project>> GetAllAsync(Guid userId);
-        Task<Project> GetAsync(int id);
-        Task<Project> UpdateAsync(Project project);
-        Task<bool> DeleteAsync(int id);
-        Task<Project> SaveAsync(Project project);
+        Task<ServiceResponse<List<Project>>> GetAllAsync(Guid userId);
+        Task<ServiceResponse<Project>> GetAsync(int id);
+        Task<ServiceResponse<Project>> UpdateAsync(Project project);
+        Task<ServiceResponse<Project>> DeleteAsync(int id);
+        Task<ServiceResponse<Project>> SaveAsync(Project project);
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
@@ -59,7 +59,7 @@ namespace FRF.Core.Services
 
                 if (categoryToAdd == null) 
                     return new ServiceResponse<Project>(
-                        new Error(ErrorCodes.CategoryNotExists, "At least one of the categories selected doesn't exist")
+                        new Error(ErrorCodes.CategoryNotExists, "At least one of the selected categories doesn't exist")
                         );
 
                 categoryList.Add(categoryToAdd);
@@ -101,7 +101,8 @@ namespace FRF.Core.Services
             await _dataContext.Projects.AddAsync(mappedProject);
             await _dataContext.SaveChangesAsync();
 
-            return new ServiceResponse<Project>(_mapper.Map<Project>(mappedProject));
+            var result = _mapper.Map<Project>(mappedProject);
+            return new ServiceResponse<Project>(result);
         }
 
         public async Task<ServiceResponse<Project>> GetAsync(int id)
@@ -141,7 +142,7 @@ namespace FRF.Core.Services
                     await _dataContext.Categories.SingleOrDefaultAsync(c => c.Id == category.Category.Id);
                 if (categoryToAdd == null)
                     return new ServiceResponse<Project>(
-                        new Error(ErrorCodes.CategoryNotExists, "At least one of the categories selected doesn't exist")
+                        new Error(ErrorCodes.CategoryNotExists, "At least one of the selected categories doesn't exist")
                         );
 
                 categoryList.Add(categoryToAdd);
@@ -186,7 +187,9 @@ namespace FRF.Core.Services
             result.UsersByProject = mappedUBP;
 
             await _dataContext.SaveChangesAsync();
-            return new ServiceResponse<Project>(_mapper.Map<Project>(result));
+
+            var mappedProject = _mapper.Map<Project>(result);
+            return new ServiceResponse<Project>(mappedProject);
         }
 
         public async Task<ServiceResponse<Project>> DeleteAsync(int id)

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AutoMapper;
+﻿using AutoMapper;
 using FRF.Core.Models;
 using FRF.Core.Services;
 using FRF.Web.Dtos;
@@ -32,19 +31,19 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> GetAllAsync()
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
-            var projects = await _projectService.GetAllAsync(currentUserId);
+            var response = await _projectService.GetAllAsync(currentUserId);
 
-            var projectsDto = _mapper.Map<IEnumerable<ProjectDTO>>(projects);
+            var projectsDto = _mapper.Map<IEnumerable<ProjectDTO>>(response.Value);
             return Ok(projectsDto);
         }
 
         [HttpGet("{id}")]
         public async Task<IActionResult> GetAsync(int id)
         {
-            var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            var response = await _projectService.GetAsync(id);
+            if (!response.Success) return NotFound();
 
-            var projectDto = _mapper.Map<ProjectDTO>(project);
+            var projectDto = _mapper.Map<ProjectDTO>(response.Value);
             return Ok(projectDto);
         }
 
@@ -59,26 +58,26 @@ namespace FiveRockingFingers.Controllers
             if (project == null) return BadRequest();
 
             var projectSaved = await _projectService.SaveAsync(project);
-            if (projectSaved == null) return BadRequest();
+            if (!projectSaved.Success) return BadRequest();
 
-            var projectCreated = _mapper.Map<ProjectDTO>(projectSaved);
+            var projectCreated = _mapper.Map<ProjectDTO>(projectSaved.Value);
             return Ok(projectCreated);
         }
 
         [HttpPut]
         public async Task<IActionResult> UpdateAsync(int id, ProjectUpsertDTO projectDto)
         {
-            var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            var response = await _projectService.GetAsync(id);
+            if (!response.Success) return NotFound();
 
             //To improve
             if (!projectDto.Users.Any()) return BadRequest();
 
-            _mapper.Map(projectDto, project);
-            var updated = await _projectService.UpdateAsync(project);
-            if (updated == null) return BadRequest();
+            _mapper.Map(projectDto, response.Value);
+            var updated = await _projectService.UpdateAsync(response.Value);
+            if (!updated.Success) return BadRequest();
 
-            var updatedProject = _mapper.Map<ProjectDTO>(updated);
+            var updatedProject = _mapper.Map<ProjectDTO>(updated.Value);
             return Ok(updatedProject);
         }
 
@@ -86,10 +85,10 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> DeleteAsync(int id)
         {
             var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            if (!project.Success) return NotFound();
 
             var isDeleted = await _projectService.DeleteAsync(id);
-            if (!isDeleted) return NotFound();
+            if (!isDeleted.Success) return NotFound();
 
             return NoContent();
         }

--- a/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
@@ -1,11 +1,11 @@
 ﻿using AutoMapper;
 using FiveRockingFingers.Controllers;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using FRF.Web.Dtos;
 using FRF.Web.Dtos.Projects;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -93,7 +93,7 @@ namespace FRF.Web.Tests.Controllers
             var project = CreateProject(projectId);
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             // Act
             var result = await _classUnderTest.GetAsync(projectId);
@@ -116,6 +116,10 @@ namespace FRF.Web.Tests.Controllers
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
 
+            _projectsService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<Project>(new Error(ErrorCodes.ProjectNotExists, "Error message")));
+
             // Act
             var result = await _classUnderTest.GetAsync(projectId);
 
@@ -135,7 +139,7 @@ namespace FRF.Web.Tests.Controllers
             
             _projectsService
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(listOfMockProject);
+                .ReturnsAsync(new ServiceResponse<List<Project>>(listOfMockProject));
 
             // Act
             var result = await _classUnderTest.GetAllAsync();
@@ -157,7 +161,7 @@ namespace FRF.Web.Tests.Controllers
 
             _projectsService
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(listOfMockProjectEmpty);
+                .ReturnsAsync(new ServiceResponse<List<Project>>(listOfMockProjectEmpty));
 
             // Act
             var result = await _classUnderTest.GetAllAsync();
@@ -182,7 +186,7 @@ namespace FRF.Web.Tests.Controllers
 
             _projectsService
                 .Setup(mock => mock.SaveAsync(It.IsAny<Project>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             // Act
             var result = await _classUnderTest.SaveAsync(projectUpsertDTO);
@@ -200,7 +204,7 @@ namespace FRF.Web.Tests.Controllers
         }
 
         [Fact]
-        public async Task Save_WhenProjectUpsertDTOIsInvalid_ReturnsBadRequest()
+        public async Task Update_WhenProjectDoesntExist_BadRequest()
         {
             // Arrange
             var rnd = new Random();
@@ -208,29 +212,40 @@ namespace FRF.Web.Tests.Controllers
             var project = CreateProject(projectId);
             var projectUpsertDTO = CreateProjectUpsertDto(project);
 
-            // Act
-            var result = await _classUnderTest.SaveAsync(projectUpsertDTO);
-
-            // Assert
-            Assert.IsType<BadRequestResult>(result);
-
-            _projectsService.Verify(mock => mock.SaveAsync(project), Times.Never);
-        }
-
-        [Fact]
-        public async Task Update_WhenGivenIdIsDifferentFromProjectId_BadRequest()
-        {
-            // Arrange
-            var rnd = new Random();
-            var projectId = rnd.Next(1, 99999);
-            var project = CreateProject(projectId);
-            var projectUpsertDTO = CreateProjectUpsertDto(project);
+            _projectsService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<Project>(new Error(ErrorCodes.ProjectNotExists, "Error message")));
 
             // Act
-            var result = await _classUnderTest.UpdateAsync(9, projectUpsertDTO);
+            var result = await _classUnderTest.UpdateAsync(0, projectUpsertDTO);
 
             // Assert
             Assert.IsType<NotFoundResult>(result);
+
+            _projectsService.Verify(mock => mock.UpdateAsync(It.IsAny<Project>()), Times.Never);
+            _projectsService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Update_WhenGivenEmptyUserList_BadRequest()
+        {
+            // Arrange
+            var rnd = new Random();
+            var projectId = rnd.Next(1, 99999);
+            var project = CreateProject(projectId);
+            var projectUpsertDTO = CreateProjectUpsertDto(project);
+
+            projectUpsertDTO.Users.Clear();
+
+            _projectsService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<Project>(project));
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(project.Id, projectUpsertDTO);
+
+            // Assert
+            Assert.IsType<BadRequestResult>(result);
 
             _projectsService.Verify(mock => mock.UpdateAsync(It.IsAny<Project>()), Times.Never);
             _projectsService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
@@ -247,11 +262,11 @@ namespace FRF.Web.Tests.Controllers
 
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             _projectsService
                 .Setup(mock => mock.UpdateAsync(It.IsAny<Project>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             // Act
             var result = await _classUnderTest.UpdateAsync(projectId, projectUpsertDTO);
@@ -276,11 +291,11 @@ namespace FRF.Web.Tests.Controllers
 
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             _projectsService
                 .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
-                .ReturnsAsync(true);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
@@ -298,6 +313,10 @@ namespace FRF.Web.Tests.Controllers
             // Arrange
             var rnd = new Random();
             var projectId = rnd.Next(1, 99999);
+
+            _projectsService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<Project>(new Error(ErrorCodes.ProjectNotExists, "Error message")));
 
             // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
@@ -318,11 +337,11 @@ namespace FRF.Web.Tests.Controllers
 
             _projectsService
                 .Setup(mock => mock.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(project);
+                .ReturnsAsync(new ServiceResponse<Project>(project));
 
             _projectsService
                 .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
-                .ReturnsAsync(false);
+                .ReturnsAsync(new ServiceResponse<Project>(new Error(ErrorCodes.ProjectNotExists, "Error message")));
 
             // Act
             var result = await _classUnderTest.DeleteAsync(projectId);


### PR DESCRIPTION
## Cambios realizados
- Se modificó la interfaz del servicio de projectos para que todos los métodos devuelvan objetos ServiceResponse, y que el método delete devuelva el projecto eliminado dentro del ServiceResponse.
- Se modificaron los métodos del servicio de projectos y sus tests acorde a los cambios en la interfaz.