### PR TITLE
[FIVE-266] (ProjectsController) Modificación del controller de categorías para trabajar con nuevas respuestas del servicio

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
@@ -15,7 +15,7 @@ export default function ConfirmationDialog(props: { keepMounted: boolean, open: 
             props.resetView(project.id);
             try {
                 const response = await ProjectService.delete(project.id.toString());
-                if (response.status === 204) {
+                if (response.status === 200) {
                     props.openSnackbar({ message: "Se eliminó el proyecto con éxito", severity: "success" });
                     updateProjects();
                 } else if (response.status === 404) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
@@ -15,7 +15,7 @@ export default function ConfirmationDialog(props: { keepMounted: boolean, open: 
             props.resetView(project.id);
             try {
                 const response = await ProjectService.delete(project.id.toString());
-                if (response.status === 200) {
+                if (response.status === 204) {
                     props.openSnackbar({ message: "Se eliminó el proyecto con éxito", severity: "success" });
                     updateProjects();
                 } else if (response.status === 404) {

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AutoMapper;
+﻿using AutoMapper;
 using FRF.Core.Models;
 using FRF.Core.Services;
 using FRF.Web.Dtos;
@@ -32,19 +31,19 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> GetAllAsync()
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
-            var projects = await _projectService.GetAllAsync(currentUserId);
+            var response = await _projectService.GetAllAsync(currentUserId);
 
-            var projectsDto = _mapper.Map<IEnumerable<ProjectDTO>>(projects);
+            var projectsDto = _mapper.Map<IEnumerable<ProjectDTO>>(response.Value);
             return Ok(projectsDto);
         }
 
         [HttpGet("{id}")]
         public async Task<IActionResult> GetAsync(int id)
         {
-            var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            var response = await _projectService.GetAsync(id);
+            if (!response.Success) return NotFound();
 
-            var projectDto = _mapper.Map<ProjectDTO>(project);
+            var projectDto = _mapper.Map<ProjectDTO>(response.Value);
             return Ok(projectDto);
         }
 
@@ -59,26 +58,26 @@ namespace FiveRockingFingers.Controllers
             if (project == null) return BadRequest();
 
             var projectSaved = await _projectService.SaveAsync(project);
-            if (projectSaved == null) return BadRequest();
+            if (!projectSaved.Success) return BadRequest();
 
-            var projectCreated = _mapper.Map<ProjectDTO>(projectSaved);
+            var projectCreated = _mapper.Map<ProjectDTO>(projectSaved.Value);
             return Ok(projectCreated);
         }
 
         [HttpPut]
         public async Task<IActionResult> UpdateAsync(int id, ProjectUpsertDTO projectDto)
         {
-            var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            var response = await _projectService.GetAsync(id);
+            if (!response.Success) return NotFound();
 
             //To improve
             if (!projectDto.Users.Any()) return BadRequest();
 
-            _mapper.Map(projectDto, project);
-            var updated = await _projectService.UpdateAsync(project);
-            if (updated == null) return BadRequest();
+            _mapper.Map(projectDto, response.Value);
+            var updated = await _projectService.UpdateAsync(response.Value);
+            if (!updated.Success) return BadRequest();
 
-            var updatedProject = _mapper.Map<ProjectDTO>(updated);
+            var updatedProject = _mapper.Map<ProjectDTO>(updated.Value);
             return Ok(updatedProject);
         }
 
@@ -86,12 +85,12 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> DeleteAsync(int id)
         {
             var project = await _projectService.GetAsync(id);
-            if (project == null) return NotFound();
+            if (!project.Success) return NotFound();
 
             var isDeleted = await _projectService.DeleteAsync(id);
-            if (!isDeleted) return NotFound();
+            if (!isDeleted.Success) return NotFound();
 
-            return NoContent();
+            return Ok(isDeleted.Value);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -90,7 +90,7 @@ namespace FiveRockingFingers.Controllers
             var isDeleted = await _projectService.DeleteAsync(id);
             if (!isDeleted.Success) return NotFound();
 
-            return Ok(isDeleted.Value);
+            return NoContent();
         }
     }
 }

--- a/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
@@ -217,7 +217,7 @@ namespace FRF.Web.Tests.Controllers
                 .ReturnsAsync(new ServiceResponse<Project>(new Error(ErrorCodes.ProjectNotExists, "Error message")));
 
             // Act
-            var result = await _classUnderTest.UpdateAsync(project.Id + 1, projectUpsertDTO);
+            var result = await _classUnderTest.UpdateAsync(0, projectUpsertDTO);
 
             // Assert
             Assert.IsType<NotFoundResult>(result);
@@ -301,8 +301,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteAsync(projectId);
 
             // Assert
-            var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<Project>(okResult.Value);
+            Assert.IsType<NoContentResult>(result);
 
             _projectsService.Verify(mock => mock.GetAsync(It.Is<int>(p => p.Equals(projectId))), Times.Once);
             _projectsService.Verify(mock => mock.DeleteAsync(It.Is<int>(p => p.Equals(projectId))), Times.Once);


### PR DESCRIPTION
## Cambios realizados
- Se modificaron los métodos del controller de proyectos para adaptarlos a las nuevas respuestas del servicio. También se modificaron los tests de la misma manera.
- Se eliminaron los tests "Save_WhenProjectUpsertDTOIsInvalid_ReturnsBadRequest" y "Update_WhenGivenIdIsDifferentFromProjectId_BadRequest". El primero porque el chequeo de DTO se hace fuera del controller, y el segundo porque en algunos cambios de tickets anteriores se eliminó el ID en el ProjectUpsertDTO, por lo que no hay 2 Ids para comparar.
- Se crearon los tests "Update_WhenProjectDoesntExist_BadRequest" y "Update_WhenGivenEmptyUserList_BadRequest".
- Modificado el chequeo de status en ProjectsList al eliminar un proyecto (pasó de 204 a 200)