### PR TITLE
[FIVE-294] Corregir errores en página de administración de proyectos

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -56,15 +56,11 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
         id: props.project.id,
         projectCategories: props.project.projectCategories,
         users: props.project.users,
-        selectedCategories: [] as Category[]
+        selectedCategories: props.project.projectCategories.map(pc => pc.category)
     });
 
     React.useEffect(() => {
         setTempCategories([...props.categories]);
-        setState({ ...state, selectedCategories: [] });
-        state.projectCategories.forEach(pc => {
-            state.selectedCategories.push(pc.category);
-        });
     }, [props.categories.length])
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -158,16 +158,18 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                 {
                     selectedIndex === -1 ?
                         (<h1>Seleccione un proyecto para ver sus detalles</h1>)
-                        : (edit ?
-                            (<EditProject
-                                project={props.projects.filter(p => p.id === selectedIndex)[0]}
-                                cancelEdit={cancelEdit}
-                                categories={props.categories}
-                                openSnackbar={manageOpenSnackbar}
-                                updateProjects={props.updateProjects}
-                                updateCategories={props.updateCategories}
-                                fillProjectCategories={fillProjectCategories} />)
-                            : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
+                        : props.projects.filter(p => p.id === selectedIndex)[0] ?
+                            (edit ?
+                                (<EditProject
+                                    project={props.projects.filter(p => p.id === selectedIndex)[0]}
+                                    cancelEdit={cancelEdit}
+                                    categories={props.categories}
+                                    openSnackbar={manageOpenSnackbar}
+                                    updateProjects={props.updateProjects}
+                                    updateCategories={props.updateCategories}
+                                    fillProjectCategories={fillProjectCategories} />)
+                                : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
+                            : setSelectedIndex(-1)
                 }
                 <SnackbarMessage
                     message={snackbarSettings.message}


### PR DESCRIPTION
## Tareas a realizar:
Se deben corregir dos errores en la página de administración de proyectos:
- Al editar un proyecto sin modificar sus categorías (ni agregar ni eliminar) se desasocian todas las categorías del proyecto.
- Cuando un usuario desvincula un proyecto de si mismo ocurre un error en el frontend dejando la pantalla en blanco por unos segundos, y luego mostrando un error de typescript (la modificación se hace de manera correcta en el backend).

## Cambios realizados
- Se modificó el estado inicial de selectedCategories en EditProject para que coincida con las que están asociadas al proyecto.
- Se agregó un chequeo al momento de renderizar los detalles de proyectos en ProjectsList. Si el índice seleccionado no exíste en los proyectos asociados al usuario, cambia automáticamente a -1.