### PR TITLE
[FIVE-266] (SignUp) Incorporación de ServiceResponse en SignUpService y su controller

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -13,6 +13,7 @@
         public const int RelationNotValid = 11;
 
         // Users
-        public const int SignUpError = 22;
+        public const int InvalidCredentials = 20;
+        public const int AuthenticationServerCurrentlyUnavailable = 21;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -11,5 +11,8 @@
         // Relation errors
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
+
+        // Users
+        public const int SignUpError = 22;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ISignUpService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ISignUpService.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using FRF.Core.Models;
+using FRF.Core.Response;
 using System.Threading.Tasks;
-using FRF.Core.Models;
 
 namespace FRF.Core.Services
 {
     public interface ISignUpService
     {
-        Task<Tuple<bool, string>> SignUpAsync(User newUser);
+        Task<ServiceResponse<string>> SignUpAsync(User newUser);
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
@@ -39,7 +39,7 @@ namespace FRF.Core.Services
                 var response = await _userManager.CreateAsync(newCognitoUser, newUser.Password);
 
                 if (!response.Succeeded)
-                    return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
+                    return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, "There was an error with your email and/or password"));
 
                 //Auto validate the new user. They will not be included in the production build
                 await _cognitoIdentity.AdminUpdateUserAttributesAsync(new AdminUpdateUserAttributesRequest
@@ -60,17 +60,17 @@ namespace FRF.Core.Services
 
                 var token = await _signInManager.UserManager.FindByEmailAsync(newUser.Email);
                 if (token == null)
-                    return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
+                    return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, "There was an error with the Authentication service"));
 
                 var result =
                     await _signInManager.PasswordSignInAsync(token, newUser.Password, false, false);
                 return result.Succeeded
                     ? new ServiceResponse<string>(token.UserID)
-                    : new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
+                    : new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, "There was an error with the Authentication service"));
             }
             catch
             {
-                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
+                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, "There was an error with the Authentication service"));
 
             }
         }

--- a/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
@@ -3,6 +3,7 @@ using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Extensions.CognitoAuthentication;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using Microsoft.AspNetCore.Identity;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ namespace FRF.Core.Services
             _pool = pool;
         }
 
-        public async Task<Tuple<bool, string>> SignUpAsync(User newUser)
+        public async Task<ServiceResponse<string>> SignUpAsync(User newUser)
         {
             try
             {
@@ -38,7 +39,7 @@ namespace FRF.Core.Services
                 var response = await _userManager.CreateAsync(newCognitoUser, newUser.Password);
 
                 if (!response.Succeeded)
-                    return new Tuple<bool, string>(false, "");
+                    return new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
 
                 //Auto validate the new user. They will not be included in the production build
                 await _cognitoIdentity.AdminUpdateUserAttributesAsync(new AdminUpdateUserAttributesRequest
@@ -58,13 +59,14 @@ namespace FRF.Core.Services
                 });
 
                 var token = await _signInManager.UserManager.FindByEmailAsync(newUser.Email);
-                if (token == null) return new Tuple<bool, string>(false, "");
+                if (token == null)
+                    return new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
 
                 var result =
                     await _signInManager.PasswordSignInAsync(token, newUser.Password, false, false);
                 return result.Succeeded
-                    ? new Tuple<bool, string>(true, token.UserID)
-                    : new Tuple<bool, string>(false, "");
+                    ? new ServiceResponse<string>(token.UserID)
+                    : new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
             }
             catch (Exception e)
             {

--- a/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
@@ -39,7 +39,7 @@ namespace FRF.Core.Services
                 var response = await _userManager.CreateAsync(newCognitoUser, newUser.Password);
 
                 if (!response.Succeeded)
-                    return new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
+                    return new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, ""));
 
                 //Auto validate the new user. They will not be included in the production build
                 await _cognitoIdentity.AdminUpdateUserAttributesAsync(new AdminUpdateUserAttributesRequest
@@ -60,18 +60,18 @@ namespace FRF.Core.Services
 
                 var token = await _signInManager.UserManager.FindByEmailAsync(newUser.Email);
                 if (token == null)
-                    return new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
+                    return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
 
                 var result =
                     await _signInManager.PasswordSignInAsync(token, newUser.Password, false, false);
                 return result.Succeeded
                     ? new ServiceResponse<string>(token.UserID)
-                    : new ServiceResponse<string>(new Error(ErrorCodes.SignUpError, ""));
+                    : new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
             }
-            catch (Exception e)
+            catch
             {
-                //throw exception from cognito user pool
-                throw new Exception("Sign up failed: " + e.Message);
+                return new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, ""));
+
             }
         }
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using FRF.Web.Dtos.Users;
 using Microsoft.AspNetCore.Authorization;
@@ -28,7 +29,8 @@ namespace FRF.Web.Controllers
         {
             var userSignUp = _mapper.Map<User>(signUpDto);
             var response = await _signUpService.SignUpAsync(userSignUp);
-            if (!response.Success) return BadRequest();
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized();
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
             return Ok(response.Value);
         }
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
@@ -4,7 +4,6 @@ using FRF.Core.Services;
 using FRF.Web.Dtos.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Threading.Tasks;
 
 namespace FRF.Web.Controllers
@@ -28,9 +27,9 @@ namespace FRF.Web.Controllers
         public async Task<ActionResult<string>> SignUp(SignUpDTO signUpDto)
         {
             var userSignUp = _mapper.Map<User>(signUpDto);
-            var (isAuthorize, token) = await _signUpService.SignUpAsync(userSignUp);
-            if (!isAuthorize) return BadRequest();
-            return Ok(token);
+            var response = await _signUpService.SignUpAsync(userSignUp);
+            if (!response.Success) return BadRequest();
+            return Ok(response.Value);
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Extensions.CognitoAuthentication;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using Microsoft.AspNetCore.Identity;
 using Moq;
@@ -27,7 +27,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task SignUpAsync_WhenSignUpFail_ReturnFalse()
+        public async Task SignUpAsync_WhenSignUpFail_ReturnError()
         {
             // Arrange
             var newUser = CreateUser();
@@ -41,8 +41,10 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignUpAsync(newUser);
 
             // Assert
-            Assert.False(result.Item1);
-            Assert.Equal(string.Empty, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
+
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
             _signInManagerMock.Verify(
                 mock => mock.PasswordSignInAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), false, false),
@@ -50,7 +52,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task SignUpAsync_WhenAutoVerificationFail_ReturnFalse()
+        public async Task SignUpAsync_WhenAutoVerificationFail_ReturnError()
         {
             // Arrange
             var newUser = CreateUser();
@@ -68,8 +70,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignUpAsync(newUser);
 
             // Assert
-            Assert.False(result.Item1);
-            Assert.Equal(string.Empty, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
 
@@ -107,9 +110,10 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignUpAsync(newUser);
 
             // Assert
-            Assert.False(result.Item1);
-            Assert.Equal(string.Empty, result.Item2);
-
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
+            
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
 
             _cognitoClientMock.Verify(
@@ -160,9 +164,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.SignUpAsync(newUser);
 
             // Assert
-            Assert.IsType<Tuple<bool, string>>(result);
-            Assert.True(result.Item1);
-            Assert.Equal(cognitoUser.UserID, result.Item2);
+            Assert.IsType<ServiceResponse<string>>(result);
+            Assert.True(result.Success);
+            Assert.Equal(cognitoUser.UserID, result.Value);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 

--- a/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
@@ -43,7 +43,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.False(result.Success);
-            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
+            Assert.Equal(ErrorCodes.InvalidCredentials, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
             _signInManagerMock.Verify(
@@ -72,7 +72,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.False(result.Success);
-            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
+            Assert.Equal(ErrorCodes.AuthenticationServerCurrentlyUnavailable, result.Error.Code);
 
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
 
@@ -112,7 +112,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.False(result.Success);
-            Assert.Equal(ErrorCodes.SignUpError, result.Error.Code);
+            Assert.Equal(ErrorCodes.AuthenticationServerCurrentlyUnavailable, result.Error.Code);
             
             _userManagerMock.Verify(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()), Times.Once);
 


### PR DESCRIPTION
## Cambios realizados
- Se creó un nuevo código de error para los servicios (SignUpError = 22).
- Se modificó la interfaz del servicio de SignUp para que el método trabaje con objetos ServiceResponse.
- Se realizaron los cambios en el servicio de SignUp y en sus tests de acuerdo a los cambios en la interfaz.
- Se modificó el controller de SignUp para trabajar con las nuevas respuestas del servicio.