### PR TITLE
[FIVE-266] (AwsArtifactsProvider) Incorporación de ServiceResponse en AwsArtifactsProviderService y su controller

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -11,5 +11,8 @@
         // Relation errors
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
+
+        // External errors
+        public const int AmazonApiError = 30;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
@@ -11,6 +11,7 @@ using Amazon.Pricing.Model;
 using Amazon;
 using FRF.Core.Models;
 using Microsoft.Extensions.Configuration;
+using FRF.Core.Response;
 
 namespace FRF.Core.Services
 {
@@ -33,7 +34,7 @@ namespace FRF.Core.Services
         /// Get all the artifacts names with the service code from aws pricing api.
         /// </summary>
         /// <returns>List of KeyValuePair</returns>
-        public async Task<List<KeyValuePair<string, string>>> GetNamesAsync()
+        public async Task<ServiceResponse<List<KeyValuePair<string, string>>>> GetNamesAsync()
         {
             var artifactsNames = new Dictionary<string, string>();
             var httpClient = _httpClientFactory.CreateClient();
@@ -41,7 +42,8 @@ namespace FRF.Core.Services
             var response = await httpClient.GetAsync(_awsPricingOptions.ApiUrl);
             if (!response.IsSuccessStatusCode)
             {
-                return null;
+                return new ServiceResponse<List<KeyValuePair<string, string>>>(
+                    new Error(ErrorCodes.AmazonApiError, "There was an error connecting to the Amazon API"));
             }
 
             var pricingList = await response.Content.ReadAsStringAsync();
@@ -56,10 +58,10 @@ namespace FRF.Core.Services
                 artifactsNames.Add(serviceCode, name);
             }
 
-            return artifactsNames.ToList();
+            return new ServiceResponse<List<KeyValuePair<string, string>>>(artifactsNames.ToList());
         }
 
-        public async Task<List<ProviderArtifactSetting>> GetAttributesAsync(string serviceCode)
+        public async Task<ServiceResponse<List<ProviderArtifactSetting>>> GetAttributesAsync(string serviceCode)
         {
             var attributes = new List<ProviderArtifactSetting>();
             var response = await _pricingClient.DescribeServicesAsync(new DescribeServicesRequest
@@ -70,7 +72,7 @@ namespace FRF.Core.Services
 
             if(response == null)
             {
-                return attributes;
+                return new ServiceResponse<List<ProviderArtifactSetting>>(attributes);
             }
 
             foreach (var service in response.Services)
@@ -84,7 +86,8 @@ namespace FRF.Core.Services
                     attributes.Add(attribute);
                 }
             }
-            return attributes;
+
+            return new ServiceResponse<List<ProviderArtifactSetting>>(attributes);
         }
 
         private async Task<List<string>> GetAttributeValue(string attributeName, string serviceCode)
@@ -110,7 +113,7 @@ namespace FRF.Core.Services
             return attributeValues;
         }
 
-        public async Task<List<PricingTerm>> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode)
+        public async Task<ServiceResponse<List<PricingTerm>>> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode)
         {
             var filters = new List<Filter>();
 
@@ -137,7 +140,7 @@ namespace FRF.Core.Services
 
             if(response == null)
             {
-                return pricingDetailsList;
+                return new ServiceResponse<List<PricingTerm>>(pricingDetailsList);
             }
 
             foreach (var price in response.PriceList)
@@ -171,7 +174,8 @@ namespace FRF.Core.Services
                     }
                 }
             }
-            return pricingDetailsList;
+
+            return new ServiceResponse<List<PricingTerm>>(pricingDetailsList);
         }
 
         private PricingTerm CreatePricingTerm(string sku, string termName, KeyValuePair<string, JToken> termOption)

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsProviderService.cs
@@ -1,5 +1,5 @@
 ﻿using FRF.Core.Models;
-using Newtonsoft.Json.Linq;
+using FRF.Core.Response;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,8 +10,8 @@ namespace FRF.Core.Services
     /// </summary>
     public interface IArtifactsProviderService
     {
-        Task<List<KeyValuePair<string, string>>> GetNamesAsync();
-        Task<List<ProviderArtifactSetting>> GetAttributesAsync(string serviceCode);
-        Task<List<PricingTerm>> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode);
+        Task<ServiceResponse<List<KeyValuePair<string, string>>>> GetNamesAsync();
+        Task<ServiceResponse<List<ProviderArtifactSetting>>> GetAttributesAsync(string serviceCode);
+        Task<ServiceResponse<List<PricingTerm>>> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode);
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
@@ -29,28 +29,30 @@ namespace FRF.Web.Controllers
         [HttpGet]
         public async Task<IActionResult> GetNamesAsync()
         {
-            var productsNames = await _artifactsProviderService.GetNamesAsync();
-            if (productsNames==null)
+            var response = await _artifactsProviderService.GetNamesAsync();
+            if (!response.Success)
             {
                 return StatusCode(503);
             }
-            return Ok(productsNames);
+            return Ok(response.Value);
         }
 
         [HttpGet]
         public async Task<IActionResult> GetAttributesAsync(string serviceCode)
         {
-            var attributes = await _artifactsProviderService.GetAttributesAsync(serviceCode);
+            var response = await _artifactsProviderService.GetAttributesAsync(serviceCode);
 
-            return Ok(_mapper.Map<List<ProviderArtifactSettingDTO>>(attributes));
+            var attributes = _mapper.Map<List<ProviderArtifactSettingDTO>>(response.Value);
+            return Ok(attributes);
         }
 
         [HttpPost]
         public async Task<IActionResult> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode)
         {
-            var products = await _artifactsProviderService.GetProductsAsync(settings, serviceCode);
+            var response = await _artifactsProviderService.GetProductsAsync(settings, serviceCode);
 
-            return Ok(_mapper.Map<List<PricingTermDTO>>(products));
+            var products = _mapper.Map<List<PricingTermDTO>>(response.Value);
+            return Ok(products);
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -259,7 +260,7 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(resultValue[0].PricingDimension.Currency, currency);
             Assert.Equal(resultValue[0].PricingDimension.Description, decription);
             Assert.Equal(resultValue[0].PricingDimension.EndRange, endRangeFloat);
-            Assert.Equal(resultValue[0].PricingDimension.PricePerUnit, float.Parse(pricePerUnit));
+            Assert.Equal(resultValue[0].PricingDimension.PricePerUnit, float.Parse(pricePerUnit, CultureInfo.InvariantCulture));
             Assert.Equal(resultValue[0].PricingDimension.RateCode, rateCode);
             Assert.Equal(resultValue[0].PricingDimension.Unit, unit);
         }

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -3,6 +3,7 @@ using Amazon.Pricing;
 using Amazon.Pricing.Model;
 using FRF.Core.Base;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -67,7 +68,10 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetNamesAsync();
 
             // Assert
-            var response = Assert.IsType<List<KeyValuePair<string, string>>>(result);
+            Assert.IsType<ServiceResponse<List<KeyValuePair<string, string>>>>(result);
+            Assert.True(result.Success);
+            var response = result.Value;
+            //var response = Assert.IsType<List<KeyValuePair<string, string>>>(result);
 
             Assert.NotEmpty(response);
             _httpClientFactory.Verify(mock => mock.CreateClient(string.Empty), Times.Once);
@@ -135,10 +139,14 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetAttributesAsync(serviceCode);
 
             // Assert
-            Assert.IsType<List<ProviderArtifactSetting>>(result);
-            Assert.NotEmpty(result);
-            Assert.Equal(result[0].Name.Key, service.AttributeNames[0]);
-            Assert.Equal(result[0].Values[0], attributeValue.Value);
+            Assert.IsType<ServiceResponse<List<ProviderArtifactSetting>>>(result);
+            Assert.True(result.Success);
+
+            var settingsList = result.Value;
+            Assert.NotEmpty(settingsList);
+
+            Assert.Equal(settingsList[0].Name.Key, service.AttributeNames[0]);
+            Assert.Equal(settingsList[0].Values[0], attributeValue.Value);
             _client.Verify(mock => mock.DescribeServicesAsync(It.IsAny<DescribeServicesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
             _client.Verify(mock => mock.GetAttributeValuesAsync(It.IsAny<GetAttributeValuesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -153,8 +161,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetAttributesAsync(serviceCode);
 
             // Assert
-            Assert.IsType<List<ProviderArtifactSetting>>(result);
-            Assert.Empty(result);
+            Assert.IsType<ServiceResponse<List<ProviderArtifactSetting>>>(result);
+            Assert.True(result.Success);
+            Assert.Empty(result.Value);
         }
 
         [Fact]
@@ -237,20 +246,22 @@ namespace FRF.Core.Tests.Services
             float.TryParse(beginRange, out float beginRangeFloat);
             float.TryParse(endRange, out float endRangeFloat);
 
-            Assert.IsType<List<PricingTerm>>(result);
-            Assert.NotEmpty(result);
-            Assert.Equal(result[0].Sku, sku);
-            Assert.Equal(result[0].Term, term);
-            Assert.Equal(result[0].PurchaseOption, purchaseOption);
-            Assert.Equal(result[0].OfferingClass, offeringClass);
-            Assert.Equal(result[0].LeaseContractLength, leaseContractLength);
-            Assert.Equal(result[0].PricingDimension.BeginRange, beginRangeFloat);
-            Assert.Equal(result[0].PricingDimension.Currency, currency);
-            Assert.Equal(result[0].PricingDimension.Description, decription);
-            Assert.Equal(result[0].PricingDimension.EndRange, endRangeFloat);
-            Assert.Equal(result[0].PricingDimension.PricePerUnit, float.Parse(pricePerUnit));
-            Assert.Equal(result[0].PricingDimension.RateCode, rateCode);
-            Assert.Equal(result[0].PricingDimension.Unit, unit);
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            var resultValue = result.Value;
+            Assert.NotEmpty(resultValue);
+
+            Assert.Equal(resultValue[0].Sku, sku);
+            Assert.Equal(resultValue[0].Term, term);
+            Assert.Equal(resultValue[0].PurchaseOption, purchaseOption);
+            Assert.Equal(resultValue[0].OfferingClass, offeringClass);
+            Assert.Equal(resultValue[0].LeaseContractLength, leaseContractLength);
+            Assert.Equal(resultValue[0].PricingDimension.BeginRange, beginRangeFloat);
+            Assert.Equal(resultValue[0].PricingDimension.Currency, currency);
+            Assert.Equal(resultValue[0].PricingDimension.Description, decription);
+            Assert.Equal(resultValue[0].PricingDimension.EndRange, endRangeFloat);
+            Assert.Equal(resultValue[0].PricingDimension.PricePerUnit, float.Parse(pricePerUnit));
+            Assert.Equal(resultValue[0].PricingDimension.RateCode, rateCode);
+            Assert.Equal(resultValue[0].PricingDimension.Unit, unit);
         }
 
         [Fact]
@@ -267,8 +278,9 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetProductsAsync(settings, serviceCode);
 
             // Assert
-            Assert.IsType<List<PricingTerm>>(result);
-            Assert.Empty(result);
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            Assert.True(result.Success);
+            Assert.Empty(result.Value);
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -72,7 +72,6 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<List<KeyValuePair<string, string>>>>(result);
             Assert.True(result.Success);
             var response = result.Value;
-            //var response = Assert.IsType<List<KeyValuePair<string, string>>>(result);
 
             Assert.NotEmpty(response);
             _httpClientFactory.Verify(mock => mock.CreateClient(string.Empty), Times.Once);

--- a/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using FRF.Core.Services;
 using FRF.Web.Controllers;
 using FRF.Web.Dtos.Artifacts;
@@ -102,7 +103,7 @@ namespace FRF.Web.Tests.Controllers
             var artifactList = CreateArtifactsNamesList();
             _artifactProviderService
                 .Setup(mock => mock.GetNamesAsync())
-                .ReturnsAsync(artifactList);
+                .ReturnsAsync(new ServiceResponse<List<KeyValuePair<string, string>>>(artifactList));
 
             // Act
             var result = await _classUnderTest.GetNamesAsync();
@@ -122,10 +123,10 @@ namespace FRF.Web.Tests.Controllers
         public async Task GetNamesAsync_ReturnsServiceUnavailable()
         {
             // Arrange
-            List<KeyValuePair<string, string>> artifactList = null;
             _artifactProviderService
                 .Setup(mock => mock.GetNamesAsync())
-                .ReturnsAsync(artifactList);
+                .ReturnsAsync(new ServiceResponse<List<KeyValuePair<string, string>>>(
+                    new Error(ErrorCodes.AmazonApiError, "Error message")));
             // Act
             var result = await _classUnderTest.GetNamesAsync();
 
@@ -144,7 +145,7 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactProviderService
                 .Setup(mock => mock.GetAttributesAsync(It.IsAny<string>()))
-                .ReturnsAsync(artifactSettings);
+                .ReturnsAsync(new ServiceResponse<List<ProviderArtifactSetting>>(artifactSettings));
 
             // Act
             var result = await _classUnderTest.GetAttributesAsync(serviceCode);
@@ -173,7 +174,7 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactProviderService
                 .Setup(mock => mock.GetProductsAsync(It.IsAny<List<KeyValuePair<string, string>>>(), It.IsAny<string>()))
-                .ReturnsAsync(pricingTermList);
+                .ReturnsAsync(new ServiceResponse<List<PricingTerm>>(pricingTermList));
 
             // Act
             var result = await _classUnderTest.GetProductsAsync(artifactSettingsList, serviceCode);


### PR DESCRIPTION
## Cambios realizados
- Se creó un nuevo código de error (AmazonApiError = 30)
- Se modificó la interfaz IArtifactsProviderService para que los métodos trabajen con objetos ServiceResponse.
- Se realizaron las modificaciones en el servicio AwsArtifactsProviderService y sus tests acorde a los cambios en la interfaz.
- Se realizaron las modificaciones en el controller AwsArtifactsProviderController y sus tests acorde a los cambios en el servicio.