### PR TITLE
[FIVE-295] Crear interfaz de precios de artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Core/FRF.Core.csproj
+++ b/FiveRockingFingers/FRF.Core/FRF.Core.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="..\FRF.DataAccess\FRF.DataAccess.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Models\AwsArtifacts\" />
+  </ItemGroup>
+
 </Project>

--- a/FiveRockingFingers/FRF.Core/Models/Artifact.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Artifact.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 
 namespace FRF.Core.Models
 {
-    public class Artifact
+    public class Artifact : IArtifactPricing
     {
         public int Id { get; set; }
         public string Name { get; set; }
@@ -15,5 +15,10 @@ namespace FRF.Core.Models
         public Project Project { get; set; }
         public int ArtifactTypeId { get; set; }
         public ArtifactType ArtifactType { get; set; }
+
+        public decimal GetPrice()
+        {
+            return 100;
+        }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/IArtifactPricing.cs
+++ b/FiveRockingFingers/FRF.Core/Models/IArtifactPricing.cs
@@ -1,0 +1,7 @@
+﻿namespace FRF.Core.Models
+{
+    public interface IArtifactPricing
+    {
+        decimal GetPrice();
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/BudgetService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/BudgetService.cs
@@ -1,0 +1,31 @@
+﻿using FRF.Core.Response;
+using System.Threading.Tasks;
+
+namespace FRF.Core.Services
+{
+    public class BudgetService : IBudgetService
+    {
+        private readonly IArtifactsService _artifactsService;
+
+        public BudgetService(IArtifactsService artifactsService)
+        {
+            _artifactsService = artifactsService;
+        }
+
+        public async Task<ServiceResponse<decimal>> GetBudget(int projectId)
+        {
+            var budget = 0m;
+
+            var result = await _artifactsService.GetAllByProjectId(projectId);
+
+            if(!result.Success) return new ServiceResponse<decimal>(new Error(ErrorCodes.ProjectNotExists, result.Error.Message));
+
+            foreach (var artifact in result.Value)
+            {
+                budget += artifact.GetPrice();
+            }
+
+            return new ServiceResponse<decimal>(budget);
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/IBudgetService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IBudgetService.cs
@@ -1,0 +1,10 @@
+﻿using FRF.Core.Response;
+using System.Threading.Tasks;
+
+namespace FRF.Core.Services
+{
+    public interface IBudgetService
+    {
+        Task<ServiceResponse<decimal>> GetBudget(int projectId);
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace FRF.Web.Controllers
 {
     [ApiController]
-    [Route("api/[controller]/[action]")]
+    [Route("api")]
     [Authorize]
     public class BudgetController : ControllerBase
     {
@@ -17,7 +17,7 @@ namespace FRF.Web.Controllers
             _budgetService = budgetService;
         }
 
-        [HttpGet("{projectId}")]
+        [HttpGet("/project/{projectId}/budget")]
         public async Task<IActionResult> GetBudget(int projectId)
         {
             var response = await _budgetService.GetBudget(projectId);

--- a/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
@@ -1,0 +1,30 @@
+﻿using FRF.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]/[action]")]
+    [Authorize]
+    public class BudgetController : ControllerBase
+    {
+        private readonly IBudgetService _budgetService;
+
+        public BudgetController(IBudgetService budgetService)
+        {
+            _budgetService = budgetService;
+        }
+
+        [HttpGet("{projectId}")]
+        public async Task<IActionResult> GetBudget(int projectId)
+        {
+            var response = await _budgetService.GetBudget(projectId);
+
+            if (!response.Success) return NotFound();
+
+            return Ok(response.Value);
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Startup.cs
+++ b/FiveRockingFingers/FRF.Web/Startup.cs
@@ -85,10 +85,11 @@ namespace FRF.Web
 			services.AddTransient<IArtifactsService, ArtifactsService>();
 			services.AddTransient<ICategoriesService, CategoriesService>();
 			services.AddTransient<IArtifactsProviderService, AwsArtifactsProviderService>();
+			services.AddTransient<IBudgetService, BudgetService>();
 
-            
-			
-            services.AddSwaggerGen(c =>
+
+
+			services.AddSwaggerGen(c =>
 			{
 				c.SwaggerDoc("v1", new OpenApiInfo {Title = "Five Rocking Fingers", Version = "v1"});
 				c.CustomSchemaIds(i => i.FullName);

--- a/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
@@ -78,7 +78,7 @@ namespace FRF.Core.Tests.Services
             //Assert
             Assert.IsType<ServiceResponse<decimal>>(response);
             Assert.True(response.Success);
-            Assert.Equal(response.Value, artifact.GetPrice());
+            Assert.Equal(artifact.GetPrice(), response.Value);
             _artifactsService.Verify(mock => mock.GetAllByProjectId(It.IsAny<int>()), Times.Once);
         }
 
@@ -96,7 +96,7 @@ namespace FRF.Core.Tests.Services
             //Assert
             Assert.IsType<ServiceResponse<decimal>>(response);
             Assert.False(response.Success);
-            Assert.Equal(response.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, response.Error.Code);
             _artifactsService.Verify(mock => mock.GetAllByProjectId(It.IsAny<int>()), Times.Once);
         }
     }

--- a/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
@@ -1,0 +1,103 @@
+﻿using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.Core.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Core.Tests.Services
+{
+    public class BudgetServiceTests
+    {
+        private readonly BudgetService _classUnderTest;
+        private readonly Mock<IArtifactsService> _artifactsService;
+
+        public BudgetServiceTests()
+        {
+            _artifactsService = new Mock<IArtifactsService>();
+            _classUnderTest = new BudgetService(_artifactsService.Object);
+        }
+
+        private ArtifactType CreateArtifactType()
+        {
+            var artifactType = new ArtifactType();
+            artifactType.Name = "[Mock] Artifact type name";
+            artifactType.Description = "[Mock] Artifact type description";
+
+            return artifactType;
+        }
+
+        private Project CreateProject()
+        {
+            var project = new Project();
+            project.Name = "[MOCK] Project name";
+            project.CreatedDate = DateTime.Now;
+            project.ProjectCategories = new List<ProjectCategory>();
+            return project;
+        }
+
+        private Artifact CreateArtifact(Project project, ArtifactType artifactType)
+        {
+            var random = new Random();
+            var artifact = new Artifact()
+            {
+                Name = "[Mock] Artifact name " + random.Next(500),
+                Provider = "[Mock] AWS",
+                CreatedDate = DateTime.Now,
+                Project = project,
+                ProjectId = project.Id,
+                ArtifactType = artifactType,
+                ArtifactTypeId = artifactType.Id
+            };
+
+            return artifact;
+        }
+
+        [Fact]
+        public async Task GetBudget_ReturnsBudget()
+        {
+            //Arrange
+            var artifactType = CreateArtifactType();
+            var project = CreateProject();
+            var artifact = CreateArtifact(project, artifactType);
+
+            var artifactsList = new List<Artifact>
+            {
+                artifact
+            };
+
+            _artifactsService.Setup(mock => mock.GetAllByProjectId(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<List<Artifact>>(artifactsList));
+
+            //Act
+            var response = await _classUnderTest.GetBudget(project.Id);
+
+            //Assert
+            Assert.IsType<ServiceResponse<decimal>>(response);
+            Assert.True(response.Success);
+            Assert.Equal(response.Value, artifact.GetPrice());
+            _artifactsService.Verify(mock => mock.GetAllByProjectId(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetBudget_ReturnsError()
+        {
+            //Arrange
+            var projectId = 0;
+            _artifactsService.Setup(mock => mock.GetAllByProjectId(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<List<Artifact>>(new Error(ErrorCodes.ProjectNotExists, "[Mock] Message")));
+
+            //Act
+            var response = await _classUnderTest.GetBudget(projectId);
+
+            //Assert
+            Assert.IsType<ServiceResponse<decimal>>(response);
+            Assert.False(response.Success);
+            Assert.Equal(response.Error.Code, ErrorCodes.ProjectNotExists);
+            _artifactsService.Verify(mock => mock.GetAllByProjectId(It.IsAny<int>()), Times.Once);
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
@@ -1,0 +1,62 @@
+﻿using FRF.Core.Response;
+using FRF.Core.Services;
+using FRF.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Web.Tests.Controllers
+{
+    public class BudgetControllerTests
+    {
+        private readonly Mock<IBudgetService> _budgetService;
+
+        private readonly BudgetController _classUnderTest;
+
+        public BudgetControllerTests()
+        {
+            _budgetService = new Mock<IBudgetService>();
+            _classUnderTest = new BudgetController(_budgetService.Object);
+        }
+
+        [Fact]
+        public async Task GetBudget_ReturnsOk()
+        {
+            //Arrange
+            var budget = 10m;
+            var projectId = 1;
+            _budgetService.Setup(mock => mock.GetBudget(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<decimal>(budget));
+
+            //Act
+            var result = await _classUnderTest.GetBudget(projectId);
+
+            //Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<decimal>(okResult.Value);
+            Assert.Equal(returnValue, budget);
+            _budgetService.Verify(mock => mock.GetBudget(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetBudget_ReturnsNotFound()
+        {
+            //Arrange
+            var budget = 10m;
+            var projectId = 1;
+            _budgetService.Setup(mock => mock.GetBudget(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<decimal>(new Error(ErrorCodes.ProjectNotExists, "[Mock] Message")));
+
+            //Act
+            var result = await _classUnderTest.GetBudget(projectId);
+
+            //Assert
+            var notFoundResult = Assert.IsType<NotFoundResult>(result);
+            _budgetService.Verify(mock => mock.GetBudget(It.IsAny<int>()), Times.Once);
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
@@ -38,7 +38,7 @@ namespace FRF.Web.Tests.Controllers
             //Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
             var returnValue = Assert.IsType<decimal>(okResult.Value);
-            Assert.Equal(returnValue, budget);
+            Assert.Equal(budget, returnValue);
             _budgetService.Verify(mock => mock.GetBudget(It.IsAny<int>()), Times.Once);
         }
 
@@ -46,7 +46,6 @@ namespace FRF.Web.Tests.Controllers
         public async Task GetBudget_ReturnsNotFound()
         {
             //Arrange
-            var budget = 10m;
             var projectId = 1;
             _budgetService.Setup(mock => mock.GetBudget(It.IsAny<int>()))
                 .ReturnsAsync(new ServiceResponse<decimal>(new Error(ErrorCodes.ProjectNotExists, "[Mock] Message")));


### PR DESCRIPTION
### Tareas realizadas

- Se creó la interfaz IArtifactPricing para el calcular el precio de un artifacto
- Se implementó la interfaz IArtifactPricing en el modelo de Core, Artifact
- Se creó la interfaz IBudgetService, el BudgetController, BudgetService y sus tests