### PR TITLE
[FIVE-266] (UserService) Incorporación de ServiceResponse en UserService y su controller

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -11,8 +11,14 @@
         // Relation errors
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
+        public const int RelationNotExists = 12;
 
-        // Users
-        public const int UserNotExists = 21;
+        // User errors
+        public const int InvalidCredentials = 20;
+        public const int AuthenticationServerCurrentlyUnavailable = 21;
+        public const int UserNotExists = 22;
+
+        // External errors
+        public const int AmazonApiError = 30;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -11,5 +11,8 @@
         // Relation errors
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
+
+        // Users
+        public const int UserNotExists = 21;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/IUserService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IUserService.cs
@@ -1,4 +1,5 @@
 ﻿using FRF.Core.Models;
+using FRF.Core.Response;
 using System;
 using System.Threading.Tasks;
 
@@ -8,8 +9,8 @@ namespace FRF.Core.Services
     {
         
         Task Logout();
-        Task<Guid> GetCurrentUserIdAsync();
-        Task<UsersProfile> GetUserPublicProfileAsync(string email);
-        Task<UsersProfile> GetUserPublicProfileAsync(Guid userId);
+        Task<ServiceResponse<Guid>> GetCurrentUserIdAsync();
+        Task<ServiceResponse<UsersProfile>> GetUserPublicProfileAsync(string email);
+        Task<ServiceResponse<UsersProfile>> GetUserPublicProfileAsync(Guid userId);
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
@@ -39,10 +39,10 @@ namespace FRF.Core.Services
 
             foreach (var user in projects.SelectMany(project => project.UsersByProject))
             {
-                var userPublicProfile =await _userService.GetUserPublicProfileAsync(user.UserId);
-                if (userPublicProfile == null) continue;
-                user.Fullname = userPublicProfile.Fullname;
-                user.Email = userPublicProfile.Email;
+                var response = await _userService.GetUserPublicProfileAsync(user.UserId);
+                if (!response.Success) continue;
+                user.Fullname = response.Value.Fullname;
+                user.Email = response.Value.Email;
             }
 
             return new ServiceResponse<List<Project>>(projects);
@@ -107,9 +107,9 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<Project>> GetAsync(int id)
         {
-            var userId =await _userService.GetCurrentUserIdAsync();
+            var userId = await _userService.GetCurrentUserIdAsync();
             var result = await _dataContext.UsersByProject
-                .Where(up => up.UserId == userId)
+                .Where(up => up.UserId == userId.Value)
                 .Include(pr=>pr.Project)
                 .ThenInclude(c=>c.ProjectCategories)
                 .ThenInclude(ca=>ca.Category).Include(pp=>pp.Project)
@@ -124,10 +124,10 @@ namespace FRF.Core.Services
             var project = _mapper.Map<Project>(result.Project);
             foreach (var user in project.UsersByProject)
             {
-                var userPublicProfile = await _userService.GetUserPublicProfileAsync(user.UserId);
-                if (userPublicProfile == null) continue;
-                user.Fullname = userPublicProfile.Fullname;
-                user.Email = userPublicProfile.Email;
+                var response = await _userService.GetUserPublicProfileAsync(user.UserId);
+                if (!response.Success) continue;
+                user.Fullname = response.Value.Fullname;
+                user.Email = response.Value.Email;
             }
 
             return new ServiceResponse<Project>(project);
@@ -196,7 +196,7 @@ namespace FRF.Core.Services
         {
             var userId = await _userService.GetCurrentUserIdAsync();
             var projectToDelete = await _dataContext.UsersByProject
-                .Where(ubp => ubp.UserId == userId)
+                .Where(ubp => ubp.UserId == userId.Value)
                 .Include(pr => pr.Project)
                 .Select(ubp=> ubp.Project)
                 .SingleOrDefaultAsync(p => p.Id == id);

--- a/FiveRockingFingers/FRF.Core/Services/UserService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/UserService.cs
@@ -28,7 +28,7 @@ namespace FRF.Core.Services
             var currentUser = _signInManager.Context.User;
             var result = await _userManager.GetUserAsync(currentUser);
             if (result == null)
-                return new ServiceResponse<Guid>(new Error(ErrorCodes.UserNotExists, ""));
+                return new ServiceResponse<Guid>(new Error(ErrorCodes.UserNotExists, "There was an error getting the user's Id"));
 
             var userId = new Guid(result.UserID);
             return new ServiceResponse<Guid>(userId);
@@ -38,7 +38,7 @@ namespace FRF.Core.Services
         {
             var response = await _userManager.FindByEmailAsync(email);
             if (response == null)
-                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, ""));
+                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, "There was an error getting the user's profile"));
 
             var user = new UsersProfile
             {
@@ -54,7 +54,7 @@ namespace FRF.Core.Services
         {
             var response = await _userManager.FindByIdAsync(userId.ToString());
             if (response == null)
-                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, ""));
+                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, "There was an error getting the user's profile"));
 
             var user = new UsersProfile
             {

--- a/FiveRockingFingers/FRF.Core/Services/UserService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/UserService.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.Extensions.CognitoAuthentication;
 using FRF.Core.Models;
+using FRF.Core.Response;
 using Microsoft.AspNetCore.Identity;
 using System;
 using System.Threading.Tasks;
@@ -22,20 +23,22 @@ namespace FRF.Core.Services
            await _signInManager.SignOutAsync();
         }
 
-        public async Task<Guid> GetCurrentUserIdAsync()
+        public async Task<ServiceResponse<Guid>> GetCurrentUserIdAsync()
         {
             var currentUser = _signInManager.Context.User;
             var result = await _userManager.GetUserAsync(currentUser);
-            if (result == null) return Guid.Empty;
+            if (result == null)
+                return new ServiceResponse<Guid>(new Error(ErrorCodes.UserNotExists, ""));
 
             var userId = new Guid(result.UserID);
-            return userId;
+            return new ServiceResponse<Guid>(userId);
         }
 
-        public async Task<UsersProfile> GetUserPublicProfileAsync(string email)
+        public async Task<ServiceResponse<UsersProfile>> GetUserPublicProfileAsync(string email)
         {
             var response = await _userManager.FindByEmailAsync(email);
-            if (response == null) return null;
+            if (response == null)
+                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, ""));
 
             var user = new UsersProfile
             {
@@ -44,13 +47,14 @@ namespace FRF.Core.Services
                 UserId = new Guid(response.UserID)
             };
 
-            return user;
+            return new ServiceResponse<UsersProfile>(user);
         }
 
-        public async Task<UsersProfile> GetUserPublicProfileAsync(Guid userId)
+        public async Task<ServiceResponse<UsersProfile>> GetUserPublicProfileAsync(Guid userId)
         {
             var response = await _userManager.FindByIdAsync(userId.ToString());
-            if (response == null) return null;
+            if (response == null)
+                return new ServiceResponse<UsersProfile>(new Error(ErrorCodes.UserNotExists, ""));
 
             var user = new UsersProfile
             {
@@ -59,7 +63,7 @@ namespace FRF.Core.Services
                 UserId = new Guid(response.UserID)
             };
 
-            return user;
+            return new ServiceResponse<UsersProfile>(user);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -31,7 +31,7 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> GetAllAsync()
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
-            var response = await _projectService.GetAllAsync(currentUserId);
+            var response = await _projectService.GetAllAsync(currentUserId.Value);
 
             var projectsDto = _mapper.Map<IEnumerable<ProjectDTO>>(response.Value);
             return Ok(projectsDto);
@@ -52,7 +52,7 @@ namespace FiveRockingFingers.Controllers
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
 
-            projectDto.Users.Add(new UserProfileUpsertDTO() {UserId = currentUserId});
+            projectDto.Users.Add(new UserProfileUpsertDTO() {UserId = currentUserId.Value});
 
             var project = _mapper.Map<Project>(projectDto);
             if (project == null) return BadRequest();

--- a/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
@@ -54,9 +54,9 @@ namespace FRF.Web.Controllers
             if (string.IsNullOrWhiteSpace(email)) return BadRequest();
             
             var userProfile = await _userService.GetUserPublicProfileAsync(email); 
-            if (userProfile == null) return NotFound();
+            if (!userProfile.Success) return NotFound();
 
-            var userPublicProfile = _mapper.Map<UserProfileDTO>(userProfile);
+            var userPublicProfile = _mapper.Map<UserProfileDTO>(userProfile.Value);
             
             return Ok(userPublicProfile);
         }

--- a/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
@@ -94,7 +94,7 @@ namespace FRF.Core.Tests.Services
             var userProfile = CreateUsersProfile();
             _userService
                 .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(userProfile);
+                .ReturnsAsync(new ServiceResponse<UsersProfile>(userProfile));
 
             // Act
             var result = await _classUnderTest.GetAllAsync(userByProject.UserId);
@@ -145,10 +145,10 @@ namespace FRF.Core.Tests.Services
 
             _userService
                 .Setup(mock => mock.GetCurrentUserIdAsync())
-                .ReturnsAsync(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba"));
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba")));
             _userService
                 .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(userProfile);
+                .ReturnsAsync(new ServiceResponse<UsersProfile>(userProfile));
 
             // Act
             var result = await _classUnderTest.GetAsync(project.Id);
@@ -180,6 +180,10 @@ namespace FRF.Core.Tests.Services
         {
             // Arange
             var projectId = 0;
+
+            _userService
+                .Setup(mock => mock.GetCurrentUserIdAsync())
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid()));
 
             // Act
             var result = await _classUnderTest.GetAsync(projectId);
@@ -407,7 +411,7 @@ namespace FRF.Core.Tests.Services
             CreateUserByProject(project);
             _userService
                 .Setup(mock => mock.GetCurrentUserIdAsync())
-                .ReturnsAsync(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba"));
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba")));
 
             // Act
             var result = await _classUnderTest.DeleteAsync(project.Id);
@@ -425,7 +429,7 @@ namespace FRF.Core.Tests.Services
             var projectId = 0;
             _userService
                 .Setup(mock => mock.GetCurrentUserIdAsync())
-                .ReturnsAsync(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba"));
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba")));
             // Act
             var result = await _classUnderTest.DeleteAsync(projectId);
 

--- a/test/FRF.Core.Tests/Services/UserServiceServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/UserServiceServiceTest.cs
@@ -73,7 +73,7 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetUserPublicProfileAsync(It.IsAny<string>());
 
             // Assert
-            Assert.IsType<ServiceResponse<Guid>>(result);
+            Assert.IsType<ServiceResponse<UsersProfile>>(result);
             Assert.False(result.Success);
             Assert.Equal(ErrorCodes.UserNotExists, result.Error.Code);
 
@@ -98,7 +98,6 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(cognitoUser.Attributes["email"], result.Value.Email);
             Assert.Equal($"{cognitoUser.Attributes["name"]} {cognitoUser.Attributes["family_name"]}", result.Value.Fullname);
 
-            Assert.IsType<UsersProfile>(result);
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
         }
 
@@ -115,7 +114,7 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetUserPublicProfileAsync(It.IsAny<string>());
 
             // Assert
-            Assert.IsType<ServiceResponse<Guid>>(result);
+            Assert.IsType<ServiceResponse<UsersProfile>>(result);
             Assert.False(result.Success);
             Assert.Equal(ErrorCodes.UserNotExists, result.Error.Code);
         }
@@ -133,7 +132,7 @@ namespace FRF.Core.Tests.Services
             var result = await _classUnderTest.GetUserPublicProfileAsync(new Guid(cognitoUser.UserID));
 
             // Assert
-            Assert.IsType<ServiceResponse<Guid>>(result);
+            Assert.IsType<ServiceResponse<UsersProfile>>(result);
             _userManagerMock.Verify(mock => mock.FindByIdAsync(It.IsAny<string>()), Times.Once);
 
             Assert.Equal(cognitoUser.UserID, result.Value.UserId.ToString());

--- a/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
@@ -136,7 +136,11 @@ namespace FRF.Web.Tests.Controllers
             var sizeOfList = 5;
             var listOfMockProject = new List<Project>();
             for (var i = 0; i < sizeOfList; i++) listOfMockProject.Add(CreateProject(i));
-            
+
+            _userService
+                .Setup(mock => mock.GetCurrentUserIdAsync())
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid()));
+
             _projectsService
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
                 .ReturnsAsync(new ServiceResponse<List<Project>>(listOfMockProject));
@@ -149,7 +153,7 @@ namespace FRF.Web.Tests.Controllers
             var returnValue = Assert.IsType<List<ProjectDTO>>(okResult.Value);
 
             Assert.Equal(sizeOfList, returnValue.Count);
-            //_userService.Verify(mock => mock.GetCurrentUserIdAsync(), Times.Once);
+            _userService.Verify(mock => mock.GetCurrentUserIdAsync(), Times.Once);
             _projectsService.Verify(mock => mock.GetAllAsync(It.IsAny<Guid>()), Times.Once);
         }
 
@@ -158,6 +162,10 @@ namespace FRF.Web.Tests.Controllers
         {
             // Arrange
             var listOfMockProjectEmpty = new List<Project>();
+
+            _userService
+                .Setup(mock => mock.GetCurrentUserIdAsync())
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid()));
 
             _projectsService
                 .Setup(mock => mock.GetAllAsync(It.IsAny<Guid>()))
@@ -170,7 +178,7 @@ namespace FRF.Web.Tests.Controllers
             var okResult = Assert.IsType<OkObjectResult>(result);
             var returnValue = Assert.IsType<List<ProjectDTO>>(okResult.Value);
 
-            //_userService.Verify(mock => mock.GetCurrentUserIdAsync(), Times.Once);
+            _userService.Verify(mock => mock.GetCurrentUserIdAsync(), Times.Once);
             Assert.Empty(returnValue);
             _projectsService.Verify(mock => mock.GetAllAsync(It.IsAny<Guid>()), Times.Once);
         }
@@ -183,6 +191,10 @@ namespace FRF.Web.Tests.Controllers
             var projectId = rnd.Next(1, 99999);
             var project = CreateProject(projectId);
             var projectUpsertDTO = CreateProjectUpsertDto(project);
+
+            _userService
+                .Setup(mock => mock.GetCurrentUserIdAsync())
+                .ReturnsAsync(new ServiceResponse<Guid>(new Guid()));
 
             _projectsService
                 .Setup(mock => mock.SaveAsync(It.IsAny<Project>()))


### PR DESCRIPTION
## Cambios realizados
- Se creó un nuevo código asociado a error (UserNotExists = 22).
- Se modificó la interfaz del servicio User para que los métodos devuelvan un ServiceResponse.
- Se modificó el servicio y sus tests de acuerdo a los cambios en la intefaz.
-  Se adaptaron el servicio y controller de proyectos a las nuevas respuestas del servicio de usuarios.