### PR TITLE
[FIVE-299] (AwsArtifactsProvider) Revisar las URLs de endpoints para que sigan las buenas practicas de una api REST

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/AwsArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/AwsArtifactService.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { BASE_URL } from '../Constants';
 import KeyValueStringPair from '../interfaces/KeyValueStringPair';
 
-const AWS_ARTIFACTS_PROVIDER_URL = `${BASE_URL}awsArtifactsProvider`;
+const AWS_ARTIFACTS_PROVIDER_URL = `${BASE_URL}aws-artifacts-provider`;
 
 export default class AwsArtifactsService {
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/AwsArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/AwsArtifactService.ts
@@ -2,25 +2,25 @@ import axios from 'axios'
 import { BASE_URL } from '../Constants';
 import KeyValueStringPair from '../interfaces/KeyValueStringPair';
 
-const AWS_ARTIFACTS_PROVIDER_URL = `${BASE_URL}AwsArtifactsProvider/`;
+const AWS_ARTIFACTS_PROVIDER_URL = `${BASE_URL}awsArtifactsProvider`;
 
 export default class AwsArtifactsService {
 
     static GetNamesAsync = async () => {
         try {
-            return await axios.get(`${AWS_ARTIFACTS_PROVIDER_URL}GetNames`);
+            return await axios.get(`${AWS_ARTIFACTS_PROVIDER_URL}/names`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
     }
 
     static GetAttibutesAsync = async (serviceCode: string) => {
-        const response = await axios.get(`${AWS_ARTIFACTS_PROVIDER_URL}GetAttributes?serviceCode=${serviceCode}`);
+        const response = await axios.get(`${AWS_ARTIFACTS_PROVIDER_URL}/attributes?serviceCode=${serviceCode}`);
         return response;
     }
 
     static GetProductsAsync = async (serviceCode: string, artifactSettings: KeyValueStringPair[]) => {
-        const response = await axios.post(`${AWS_ARTIFACTS_PROVIDER_URL}GetProducts?serviceCode=${serviceCode}`, artifactSettings);
+        const response = await axios.post(`${AWS_ARTIFACTS_PROVIDER_URL}/products?serviceCode=${serviceCode}`, artifactSettings);
         return response;
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace FRF.Web.Controllers
 {
-    [Route("api/awsArtifactsProvider")]
+    [Route("api/aws-artifacts-provider")]
     [ApiController]
     [Authorize]
     public class AwsArtifactsProviderController : ControllerBase

--- a/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace FRF.Web.Controllers
 {
-    [Route("api/[controller]/[action]")]
+    [Route("api/awsArtifactsProvider")]
     [ApiController]
     [Authorize]
     public class AwsArtifactsProviderController : ControllerBase
@@ -26,7 +26,7 @@ namespace FRF.Web.Controllers
         /// Retrieve all the artifact names from AWS provider.
         /// </summary>
         /// <returns></returns>
-        [HttpGet]
+        [HttpGet("names")]
         public async Task<IActionResult> GetNamesAsync()
         {
             var response = await _artifactsProviderService.GetNamesAsync();
@@ -37,7 +37,7 @@ namespace FRF.Web.Controllers
             return Ok(response.Value);
         }
 
-        [HttpGet]
+        [HttpGet("attributes")]
         public async Task<IActionResult> GetAttributesAsync(string serviceCode)
         {
             var response = await _artifactsProviderService.GetAttributesAsync(serviceCode);
@@ -46,7 +46,7 @@ namespace FRF.Web.Controllers
             return Ok(attributes);
         }
 
-        [HttpPost]
+        [HttpPost("products")]
         public async Task<IActionResult> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode)
         {
             var response = await _artifactsProviderService.GetProductsAsync(settings, serviceCode);


### PR DESCRIPTION
Cambios realizados

-Se modificó las URLs de los endpoints del controller AwsArtifactsProviderController para que sigan las buenas prácticas de una api REST