### PR TITLE
[Five-301] Modificar como se guardan los precios dentro de las settings de un artefacto

### DIFF
--- a/FiveRockingFingers/FRF.Core/Models/PricingDimension.cs
+++ b/FiveRockingFingers/FRF.Core/Models/PricingDimension.cs
@@ -12,6 +12,6 @@ namespace FRF.Core.Models
         public string RateCode { get; set; }
         public float BeginRange { get; set; }
         public string Currency { get; set; }
-        public float PricePerUnit { get; set; }
+        public decimal PricePerUnit { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/PricingTerm.cs
+++ b/FiveRockingFingers/FRF.Core/Models/PricingTerm.cs
@@ -8,8 +8,7 @@ namespace FRF.Core.Models
     {
         public string Sku { get; set; }
         public string Term { get; set; }
-        public PricingDimension PricingDimension { get; set; }
-        public PricingDimension PricingDetail { get; set; }
+        public List<PricingDimension> PricingDimensions { get; set; }
         public string LeaseContractLength { get; set; }
         public string OfferingClass { get; set; }
         public string PurchaseOption { get; set; }

--- a/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
@@ -185,25 +185,19 @@ namespace FRF.Core.Services
             var offeringClass = (string)termOptionProperties.SelectToken("termAttributes.OfferingClass");
             var purchaseOption = (string)termOptionProperties.SelectToken("termAttributes.PurchaseOption");
             var termPriceDimensions = termOptionProperties.SelectToken("priceDimensions").ToObject<JObject>().Properties().ToList();
-            var termPriceDimension = termPriceDimensions[0];
-            var pricingDimension = ExtractPricingDimension(termPriceDimension);
-            var pricingDetails = new PricingDimension();
-            if (termPriceDimensions.Count > 1)
+            var pricingDimensions = new List<PricingDimension>();
+
+            foreach(var termPriceDimension in termPriceDimensions)
             {
-                var termPriceDetail = termPriceDimensions[1];
-                pricingDetails = ExtractPricingDimension(termPriceDetail);
-            }
-            else
-            {
-                pricingDetails = null;
+                var pricingDimension = ExtractPricingDimension(termPriceDimension);
+                pricingDimensions.Add(pricingDimension);
             }
 
             var pricingTerm = new PricingTerm()
             {
                 Sku = sku,
                 Term = termName,
-                PricingDimension = pricingDimension,
-                PricingDetail = pricingDetails,
+                PricingDimensions = pricingDimensions,
                 LeaseContractLength = leaseContractLength,
                 OfferingClass = offeringClass,
                 PurchaseOption = purchaseOption
@@ -215,7 +209,11 @@ namespace FRF.Core.Services
         private PricingDimension ExtractPricingDimension(JProperty termPriceDimension)
         {
             float.TryParse((string)termPriceDimension.Value.SelectToken("beginRange"), out float beginRange);
-            float.TryParse((string)termPriceDimension.Value.SelectToken("endRange"), out float endRange);
+
+            if(!float.TryParse((string)termPriceDimension.Value.SelectToken("endRange"), out float endRange))
+            {
+                endRange = -1;
+            }
 
             var pricingDetails = new PricingDimension()
             {

--- a/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
@@ -223,7 +223,7 @@ namespace FRF.Core.Services
                 RateCode = (string)termPriceDimension.Value.SelectToken("rateCode"),
                 BeginRange = beginRange,
                 Currency = termPriceDimension.Value.SelectToken("pricePerUnit").ToObject<JObject>().Properties().ElementAt(0).Name,
-                PricePerUnit = (float)termPriceDimension.Value.SelectToken("pricePerUnit").ToObject<JObject>().Properties().ElementAt(0).Value,
+                PricePerUnit = (decimal)termPriceDimension.Value.SelectToken("pricePerUnit").ToObject<JObject>().Properties().ElementAt(0).Value,
             };
 
             return pricingDetails;

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingDimensionDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingDimensionDTO.cs
@@ -12,6 +12,6 @@ namespace FRF.Web.Dtos.Artifacts
         public string RateCode { get; set; }
         public float BeginRange { get; set; }
         public string Currency { get; set; }
-        public float PricePerUnit { get; set; }
+        public decimal PricePerUnit { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingTermDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingTermDTO.cs
@@ -8,8 +8,7 @@ namespace FRF.Web.Dtos.Artifacts
     {
         public string Sku { get; set; }
         public string Term { get; set; }
-        public PricingDimensionDTO PricingDimension { get; set; }
-        public PricingDimensionDTO PricingDetail { get; set; }
+        public List<PricingDimensionDTO> PricingDimensions { get; set; }
         public string LeaseContractLength { get; set; }
         public string OfferingClass { get; set; }
         public string PurchaseOption { get; set; }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/XmlResolver.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/XmlResolver.cs
@@ -27,7 +27,7 @@ namespace FRF.Web.Dtos.Artifacts
 
         private Dictionary<string, string> GetKeyValuePair(XElement xelement, Dictionary<string, string> settings)
         {
-            if(xelement.HasElements)
+            if(xelement.HasElements && !settings.ContainsKey(xelement.Name.ToString()))
             {
                 settings.Add(xelement.Name.ToString(), "");
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -9,6 +9,7 @@ import KeyValueStringPair from '../../interfaces/KeyValueStringPair';
 import PricingTerm from '../../interfaces/PricingTerm';
 import ArtifactService from '../../services/ArtifactService';
 import AwsArtifactService from '../../services/AwsArtifactService';
+import PricingDimension from '../../interfaces/PricingDimension';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -79,9 +80,30 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
         for (let i = 0; i < props.settingsList.length; i++) {
             settingsObject[props.settingsList[i].name] = props.settingsList[i].value;
         }
-        Object.assign(settingFinalObject, settingsObject, awsPricingDimensionList[index]);
+        Object.assign(settingFinalObject, settingsObject, createPricingTermObject(index));
 
         return settingFinalObject;
+    }
+
+    const createPricingTermObject = (index: number) => {
+        let awsPricingDimension = awsPricingDimensionList[index];
+        let pricingTermObject: { sku: string, term: string, leaseContractLength: string, offeringClass: string, purchaseOption: string, pricingDimension: { [key: string]: PricingDimension }} = {
+            sku: awsPricingDimension.sku,
+            term: awsPricingDimension.term,
+            leaseContractLength: awsPricingDimension.leaseContractLength,
+            offeringClass: awsPricingDimension.offeringClass,
+            purchaseOption: awsPricingDimension.purchaseOption,
+            pricingDimension: {}
+        };
+        let pricingDimensionObject: { [key: string]: PricingDimension } = {};
+
+        awsPricingDimension.pricingDimensions.forEach((pricingDimension, i) => {
+            pricingDimensionObject[`range${i}`] = pricingDimension;
+        });
+
+        pricingTermObject.pricingDimension = pricingDimensionObject;
+
+        return pricingTermObject;
     }
 
     const createPropertieLabel = (propertie: string, value: string | null) => {
@@ -96,12 +118,12 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
     const pricingTermToString = (pricingTerm: PricingTerm) => {
         return (
             <React.Fragment>
-                {createPropertieLabel("Unit", pricingTerm.pricingDimension.unit)}
+                {createPropertieLabel("Unit", pricingTerm.pricingDimensions[0].unit)}
                 {createPropertieLabel("Lease Contract Length", pricingTerm.leaseContractLength)}
                 {createPropertieLabel("Purchase Option", pricingTerm.purchaseOption)}
-                {createPropertieLabel("Description", pricingTerm.pricingDimension.description)}
-                {createPropertieLabel("Currency", pricingTerm.pricingDimension.currency)}
-                {createPropertieLabel("Price per unit", pricingTerm.pricingDimension.pricePerUnit.toString())}
+                {createPropertieLabel("Description", pricingTerm.pricingDimensions[0].description)}
+                {createPropertieLabel("Currency", pricingTerm.pricingDimensions[0].currency)}
+                {createPropertieLabel("Price per unit", pricingTerm.pricingDimensions[0].pricePerUnit.toString())}
                 {createPropertieLabel("Term", pricingTerm.term)}
                 <hr/>
             </React.Fragment>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -123,7 +123,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
                 {createPropertieLabel("Purchase Option", pricingTerm.purchaseOption)}
                 {createPropertieLabel("Description", pricingTerm.pricingDimensions[0].description)}
                 {createPropertieLabel("Currency", pricingTerm.pricingDimensions[0].currency)}
-                {createPropertieLabel("Price per unit", pricingTerm.pricingDimensions[0].pricePerUnit.toString())}
+                {createPropertieLabel("Price per unit", pricingTerm.pricingDimensions[0].pricePerUnit.toFixed(10))}
                 {createPropertieLabel("Term", pricingTerm.term)}
                 <hr/>
             </React.Fragment>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -100,12 +100,12 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
                 }
                 {provider !== 'Custom' && props.awsPricingTerm !== null ?
                     <React.Fragment>
-                        {createPropertieLabel("Unit", props.awsPricingTerm.pricingDimension.unit)}
+                        {createPropertieLabel("Unit", props.awsPricingTerm.pricingDimensions[0].unit)}
                         {createPropertieLabel("Lease Contract Length", props.awsPricingTerm.leaseContractLength)}
                         {createPropertieLabel("Purchase Option", props.awsPricingTerm.purchaseOption)}
-                        {createPropertieLabel("Description", props.awsPricingTerm.pricingDimension.description)}
-                        {createPropertieLabel("Currency", props.awsPricingTerm.pricingDimension.currency)}
-                        {createPropertieLabel("Price per unit", props.awsPricingTerm.pricingDimension.pricePerUnit.toString())}
+                        {createPropertieLabel("Description", props.awsPricingTerm.pricingDimensions[0].description)}
+                        {createPropertieLabel("Currency", props.awsPricingTerm.pricingDimensions[0].currency)}
+                        {createPropertieLabel("Price per unit", props.awsPricingTerm.pricingDimensions[0].pricePerUnit.toString())}
                         {createPropertieLabel("Term", props.awsPricingTerm.term)}
                     </React.Fragment>
                     : null

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -105,7 +105,7 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
                         {createPropertieLabel("Purchase Option", props.awsPricingTerm.purchaseOption)}
                         {createPropertieLabel("Description", props.awsPricingTerm.pricingDimensions[0].description)}
                         {createPropertieLabel("Currency", props.awsPricingTerm.pricingDimensions[0].currency)}
-                        {createPropertieLabel("Price per unit", props.awsPricingTerm.pricingDimensions[0].pricePerUnit.toString())}
+                        {createPropertieLabel("Price per unit", props.awsPricingTerm.pricingDimensions[0].pricePerUnit.toFixed(10))}
                         {createPropertieLabel("Term", props.awsPricingTerm.term)}
                     </React.Fragment>
                     : null

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/PricingTerm.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/PricingTerm.ts
@@ -3,8 +3,7 @@
 export default interface PricingTerm {
     sku: string;
     term: string;
-    pricingDimension: PricingDimension;
-    pricingDetail: PricingDimension;
+    pricingDimensions: PricingDimension[];
     leaseContractLength: string;
     offeringClass: string;
     purchaseOption: string;

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -253,18 +253,18 @@ namespace FRF.Core.Tests.Services
             var resultValue = result.Value;
             Assert.NotEmpty(resultValue);
 
-            Assert.Equal(resultValue[0].Sku, sku);
-            Assert.Equal(resultValue[0].Term, term);
-            Assert.Equal(resultValue[0].PurchaseOption, purchaseOption);
-            Assert.Equal(resultValue[0].OfferingClass, offeringClass);
-            Assert.Equal(resultValue[0].LeaseContractLength, leaseContractLength);
-            Assert.Equal(resultValue[0].PricingDimensions[0].BeginRange, beginRangeFloat);
-            Assert.Equal(resultValue[0].PricingDimensions[0].Currency, currency);
-            Assert.Equal(resultValue[0].PricingDimensions[0].Description, description);
-            Assert.Equal(resultValue[0].PricingDimensions[0].EndRange, endRangeFloat);
-            Assert.Equal(resultValue[0].PricingDimensions[0].PricePerUnit, float.Parse(pricePerUnit, CultureInfo.InvariantCulture));
-            Assert.Equal(resultValue[0].PricingDimensions[0].RateCode, rateCode);
-            Assert.Equal(resultValue[0].PricingDimensions[0].Unit, unit);
+            Assert.Equal(sku, resultValue[0].Sku);
+            Assert.Equal(term, resultValue[0].Term);
+            Assert.Equal(purchaseOption, resultValue[0].PurchaseOption);
+            Assert.Equal(offeringClass, resultValue[0].OfferingClass);
+            Assert.Equal(leaseContractLength, resultValue[0].LeaseContractLength);
+            Assert.Equal(beginRangeFloat, resultValue[0].PricingDimensions[0].BeginRange);
+            Assert.Equal(currency, resultValue[0].PricingDimensions[0].Currency);
+            Assert.Equal(description, resultValue[0].PricingDimensions[0].Description);
+            Assert.Equal(endRangeFloat, resultValue[0].PricingDimensions[0].EndRange);
+            Assert.Equal(decimal.Parse(pricePerUnit, CultureInfo.InvariantCulture), resultValue[0].PricingDimensions[0].PricePerUnit);
+            Assert.Equal(rateCode, resultValue[0].PricingDimensions[0].RateCode);
+            Assert.Equal(unit, resultValue[0].PricingDimensions[0].Unit);
         }
 
         [Fact]

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -244,10 +244,7 @@ namespace FRF.Core.Tests.Services
 
             // Assert
             float.TryParse(beginRange, out float beginRangeFloat);
-            if(!float.TryParse(endRange, out float endRangeFloat))
-            {
-                endRangeFloat = -1;
-            }
+            var endRangeFloat = -1f;
 
             Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
             var resultValue = result.Value;

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -175,7 +175,7 @@ namespace FRF.Core.Tests.Services
             var term = "[Mock] Term";
             var unit = "[Mock] Unit";
             var endRange = "inf";
-            var decription = "[Mock] Description";
+            var description = "[Mock] Description";
             var rateCode = "[Mock] Rate Code";
             var beginRange = "10";
             var currency = "[Mock] Currency";
@@ -210,7 +210,7 @@ namespace FRF.Core.Tests.Services
                     "{ \"" + rateCode + "\":" +
                     "{ \"unit\":\"" + unit +"\"," +
                     "\"endRange\":\"" + endRange + "\"," +
-                    "\"description\":\"" + decription + "\"," +
+                    "\"description\":\"" + description + "\"," +
                     "\"appliesTo\":[]," +
                     "\"rateCode\":\"" + rateCode +"\"," +
                     "\"beginRange\":\"" + beginRange + "\"," +
@@ -244,7 +244,10 @@ namespace FRF.Core.Tests.Services
 
             // Assert
             float.TryParse(beginRange, out float beginRangeFloat);
-            float.TryParse(endRange, out float endRangeFloat);
+            if(!float.TryParse(endRange, out float endRangeFloat))
+            {
+                endRangeFloat = -1;
+            }
 
             Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
             var resultValue = result.Value;
@@ -255,13 +258,13 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(resultValue[0].PurchaseOption, purchaseOption);
             Assert.Equal(resultValue[0].OfferingClass, offeringClass);
             Assert.Equal(resultValue[0].LeaseContractLength, leaseContractLength);
-            Assert.Equal(resultValue[0].PricingDimension.BeginRange, beginRangeFloat);
-            Assert.Equal(resultValue[0].PricingDimension.Currency, currency);
-            Assert.Equal(resultValue[0].PricingDimension.Description, decription);
-            Assert.Equal(resultValue[0].PricingDimension.EndRange, endRangeFloat);
-            Assert.Equal(resultValue[0].PricingDimension.PricePerUnit, float.Parse(pricePerUnit, CultureInfo.InvariantCulture));
-            Assert.Equal(resultValue[0].PricingDimension.RateCode, rateCode);
-            Assert.Equal(resultValue[0].PricingDimension.Unit, unit);
+            Assert.Equal(resultValue[0].PricingDimensions[0].BeginRange, beginRangeFloat);
+            Assert.Equal(resultValue[0].PricingDimensions[0].Currency, currency);
+            Assert.Equal(resultValue[0].PricingDimensions[0].Description, description);
+            Assert.Equal(resultValue[0].PricingDimensions[0].EndRange, endRangeFloat);
+            Assert.Equal(resultValue[0].PricingDimensions[0].PricePerUnit, float.Parse(pricePerUnit, CultureInfo.InvariantCulture));
+            Assert.Equal(resultValue[0].PricingDimensions[0].RateCode, rateCode);
+            Assert.Equal(resultValue[0].PricingDimensions[0].Unit, unit);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
@@ -66,7 +66,7 @@ namespace FRF.Web.Tests.Controllers
                 RateCode = "[Mock] Rate code",
                 BeginRange = 0f,
                 Currency = "[Mock] Currency",
-                PricePerUnit = 99.99f
+                PricePerUnit = 99.99m
             };
             var pricingDimension2 = new PricingDimension
             {
@@ -76,7 +76,7 @@ namespace FRF.Web.Tests.Controllers
                 RateCode = "[Mock] Rate code 2",
                 BeginRange = 0f,
                 Currency = "[Mock] Currency 2",
-                PricePerUnit = 99.99f
+                PricePerUnit = 99.99m
             };
             var pricingDimensions = new List<PricingDimension>
             {

--- a/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
@@ -58,7 +58,7 @@ namespace FRF.Web.Tests.Controllers
 
         private List<PricingTerm> CreatePricingTermList()
         {
-            var pricingDimension = new PricingDimension
+            var pricingDimension1 = new PricingDimension
             {
                 Unit = "[Mock] Unit",
                 EndRange = 100000f,
@@ -68,7 +68,7 @@ namespace FRF.Web.Tests.Controllers
                 Currency = "[Mock] Currency",
                 PricePerUnit = 99.99f
             };
-            var pricingDetail = new PricingDimension
+            var pricingDimension2 = new PricingDimension
             {
                 Unit = "[Mock] Unit 2",
                 EndRange = 100000f,
@@ -78,12 +78,17 @@ namespace FRF.Web.Tests.Controllers
                 Currency = "[Mock] Currency 2",
                 PricePerUnit = 99.99f
             };
+            var pricingDimensions = new List<PricingDimension>
+            {
+                pricingDimension1,
+                pricingDimension2
+            };
+
             var pricingTerm = new PricingTerm()
             {
                 Sku = "[Mock] Sku",
                 Term = "[Mock] Term",
-                PricingDimension = pricingDimension,
-                PricingDetail = pricingDetail,
+                PricingDimensions = pricingDimensions,
                 LeaseContractLength = "[Mock] Contract length",
                 OfferingClass = "[Mock] Offering class",
                 PurchaseOption = "[Mock] Purchase option"
@@ -188,20 +193,20 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(pricingTermList[0].LeaseContractLength, returnValue[0].LeaseContractLength);
             Assert.Equal(pricingTermList[0].OfferingClass, returnValue[0].OfferingClass);
             Assert.Equal(pricingTermList[0].PurchaseOption, returnValue[0].PurchaseOption);
-            Assert.Equal(pricingTermList[0].PricingDimension.BeginRange, returnValue[0].PricingDimension.BeginRange);
-            Assert.Equal(pricingTermList[0].PricingDimension.Currency, returnValue[0].PricingDimension.Currency);
-            Assert.Equal(pricingTermList[0].PricingDimension.Description, returnValue[0].PricingDimension.Description);
-            Assert.Equal(pricingTermList[0].PricingDimension.EndRange, returnValue[0].PricingDimension.EndRange);
-            Assert.Equal(pricingTermList[0].PricingDimension.PricePerUnit, returnValue[0].PricingDimension.PricePerUnit);
-            Assert.Equal(pricingTermList[0].PricingDimension.RateCode, returnValue[0].PricingDimension.RateCode);
-            Assert.Equal(pricingTermList[0].PricingDimension.Unit, returnValue[0].PricingDimension.Unit);
-            Assert.Equal(pricingTermList[0].PricingDetail.BeginRange, returnValue[0].PricingDetail.BeginRange);
-            Assert.Equal(pricingTermList[0].PricingDetail.Currency, returnValue[0].PricingDetail.Currency);
-            Assert.Equal(pricingTermList[0].PricingDetail.Description, returnValue[0].PricingDetail.Description);
-            Assert.Equal(pricingTermList[0].PricingDetail.EndRange, returnValue[0].PricingDetail.EndRange);
-            Assert.Equal(pricingTermList[0].PricingDetail.PricePerUnit, returnValue[0].PricingDetail.PricePerUnit);
-            Assert.Equal(pricingTermList[0].PricingDetail.RateCode, returnValue[0].PricingDetail.RateCode);
-            Assert.Equal(pricingTermList[0].PricingDetail.Unit, returnValue[0].PricingDetail.Unit);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].BeginRange, returnValue[0].PricingDimensions[0].BeginRange);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].Currency, returnValue[0].PricingDimensions[0].Currency);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].Description, returnValue[0].PricingDimensions[0].Description);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].EndRange, returnValue[0].PricingDimensions[0].EndRange);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].PricePerUnit, returnValue[0].PricingDimensions[0].PricePerUnit);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].RateCode, returnValue[0].PricingDimensions[0].RateCode);
+            Assert.Equal(pricingTermList[0].PricingDimensions[0].Unit, returnValue[0].PricingDimensions[0].Unit);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].BeginRange, returnValue[0].PricingDimensions[1].BeginRange);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].Currency, returnValue[0].PricingDimensions[1].Currency);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].Description, returnValue[0].PricingDimensions[1].Description);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].EndRange, returnValue[0].PricingDimensions[1].EndRange);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].PricePerUnit, returnValue[0].PricingDimensions[1].PricePerUnit);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].RateCode, returnValue[0].PricingDimensions[1].RateCode);
+            Assert.Equal(pricingTermList[0].PricingDimensions[1].Unit, returnValue[0].PricingDimensions[1].Unit);
             _artifactProviderService.Verify(mock => mock.GetProductsAsync(artifactSettingsList, serviceCode), Times.Once);
         }
     }


### PR DESCRIPTION
Cambios realizados

-Se modificó el modelo PricingTerm, el DTO PricingTermDTO y le interfaz del frontend PricingTerm para que el atributo PricingDimension sea una lista
-Se modificó el componente AwsPricingDimension.tsx para que guarde todos los términos de la sección PricingDimension para los productos que devuelve la api de Amazon
-Se modificó el servicio AwsArtifactsProviderService para considerar los cambios en los modelos de PricingTerm y para que en el campo endRange se guarde -1 en el caso que la api de Amazon devuelva "Inf"
-Se corrigieron los tests de la clase AwsArtifactsProviderControllerTest según los cambios realizados en la clase PricingTerm
-Se corrigieron los tests de la clase AwsArtifactsProviderServiceTest según los cambios realizados en la clase PricingTerm