### PR TITLE
[FIVE-303] (Backend) Modificar tablas Artifacts, ArtifactType, y Providers en Base de Datos

### DIFF
--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -35,6 +35,7 @@ namespace FRF.Core
                 .ForMember(dest => dest.Id, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ArtifactsRelation, ArtifactsRelation>()
                 .ReverseMap();
+            CreateMap<DataAccess.EntityModels.Provider, Provider>();
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Artifact.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Artifact.cs
@@ -7,7 +7,6 @@ namespace FRF.Core.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public string Provider { get; set; }
         public XElement Settings { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? ModifiedDate { get; set; }

--- a/FiveRockingFingers/FRF.Core/Models/ArtifactType.cs
+++ b/FiveRockingFingers/FRF.Core/Models/ArtifactType.cs
@@ -8,5 +8,7 @@ namespace FRF.Core.Models
         public string Name { get; set; }
         public string Description { get; set; }
         public ICollection<Artifact> Artifacs { get; set; }
+        public Provider Provider { get; set; }
+        public string RequiredFields { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Provider.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Provider.cs
@@ -1,8 +1,11 @@
-﻿namespace FRF.Core.Models
+﻿using System.Collections.Generic;
+
+namespace FRF.Core.Models
 {
     public class Provider
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public ICollection<ArtifactType> ArtifactType { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Provider.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Provider.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Core.Models
+{
+    public class Provider
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -34,7 +34,7 @@ namespace FRF.Core.Services
 
         private Artifact MapArtifact(EntityModels.Artifact artifact)
         {
-            switch (artifact.Provider)
+            switch (artifact.ArtifactType.Provider.Name)
             {
                 case ArtifactTypes.Custom:
                     return _mapper.Map<CustomArtifact>(artifact);
@@ -93,6 +93,7 @@ namespace FRF.Core.Services
         {
             var artifacts = await _dataContext.Artifacts
                 .Include(a => a.ArtifactType)
+                    .ThenInclude(a => a.Provider)
                 .Include(a => a.Project)
                     .ThenInclude(p => p.ProjectCategories)
                         .ThenInclude(pc => pc.Category)
@@ -111,6 +112,7 @@ namespace FRF.Core.Services
 
             var artifacts = await _dataContext.Artifacts
                 .Include(a => a.ArtifactType)
+                    .ThenInclude(a => a.Provider)
                 .Include(a => a.Project)
                     .ThenInclude(p => p.ProjectCategories)
                         .ThenInclude(pc => pc.Category)
@@ -126,6 +128,7 @@ namespace FRF.Core.Services
         {
             var artifact = await _dataContext.Artifacts
                 .Include(a => a.ArtifactType)
+                    .ThenInclude(a => a.Provider)
                 .Include(a => a.Project)
                     .ThenInclude(p => p.ProjectCategories)
                         .ThenInclude(pc => pc.Category)
@@ -165,7 +168,15 @@ namespace FRF.Core.Services
             // Saves changes
             await _dataContext.SaveChangesAsync();
 
-            return new ServiceResponse<Artifact>(MapArtifact(mappedArtifact));
+            var response = await _dataContext.Artifacts
+                .Include(a => a.ArtifactType)
+                    .ThenInclude(a => a.Provider)
+                .Include(a => a.Project)
+                    .ThenInclude(p => p.ProjectCategories)
+                        .ThenInclude(pc => pc.Category)
+                .SingleOrDefaultAsync(a => a.Id == mappedArtifact.Id);
+
+            return new ServiceResponse<Artifact>(MapArtifact(response));
         }
 
         public async Task<ServiceResponse<Artifact>> Update(Artifact artifact)
@@ -193,7 +204,6 @@ namespace FRF.Core.Services
 
             //Updates the artifact
             result.Name = artifact.Name;
-            result.Provider = artifact.Provider;
             result.Settings = artifact.Settings;
             result.ModifiedDate = DateTime.Now;
             result.ProjectId = artifact.ProjectId;
@@ -202,7 +212,15 @@ namespace FRF.Core.Services
             //Saves the updated aritfact in the database
             await _dataContext.SaveChangesAsync();
 
-            var mappedArtifact = MapArtifact(result);
+            var response = await _dataContext.Artifacts
+                .Include(a => a.ArtifactType)
+                    .ThenInclude(a => a.Provider)
+                .Include(a => a.Project)
+                    .ThenInclude(p => p.ProjectCategories)
+                        .ThenInclude(pc => pc.Category)
+                .SingleOrDefaultAsync(a => a.Id == result.Id);
+
+            var mappedArtifact = MapArtifact(response);
             return new ServiceResponse<Artifact>(mappedArtifact);
         }
 

--- a/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
+++ b/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
@@ -15,6 +15,7 @@ namespace FRF.DataAccess
         public DbSet<Artifact> Artifacts { get; set; }
         public DbSet<ArtifactType> ArtifactType { get; set; }
         public DbSet<ArtifactsRelation> ArtifactsRelation { get; set; }
+        public DbSet<Provider> Providers { get; set; }
 
         public DataAccessContext(DbContextOptions<DataAccessContext> options, IConfiguration configuration) : base(options)
         {

--- a/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_ProvidersAndUpdateArtifacts-ArtifactType.sql
+++ b/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_ProvidersAndUpdateArtifacts-ArtifactType.sql
@@ -1,0 +1,18 @@
+USE FiveRockingFingers
+
+CREATE TABLE Providers (
+	Id INT NOT NULL PRIMARY KEY IDENTITY(1,1),
+	Name NVARCHAR(50) NOT NULL
+)
+
+ALTER TABLE Artifacts
+DROP COLUMN Provider
+
+ALTER TABLE ArtifactType
+ADD RequiredFields NVARCHAR(MAX)
+
+ALTER TABLE ArtifactType
+ADD ProviderId INT NOT NULL
+
+ALTER TABLE ArtifactType
+ADD FOREIGN KEY (ProviderId) REFERENCES Providers(Id)

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Artifact.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Artifact.cs
@@ -10,7 +10,6 @@ namespace FRF.DataAccess.EntityModels
         [Key]
         public int Id { get; set; }
         public string Name { get; set; }
-        public string Provider { get; set; }
         #nullable enable
         public string? SettingsXML { get; set; }
         #nullable disable

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/ArtifactType.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/ArtifactType.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text;
 
 namespace FRF.DataAccess.EntityModels
 {
@@ -12,5 +10,7 @@ namespace FRF.DataAccess.EntityModels
         public string Name { get; set; }
         public string Description { get; set; }
         public ICollection<Artifact> Artifacs { get; set; }
+        public Provider Provider { get; set; }
+        public string RequiredFields { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Provider.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Provider.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace FRF.DataAccess.EntityModels
+{
+    public class Provider
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Provider.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Provider.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace FRF.DataAccess.EntityModels
 {
@@ -7,5 +8,6 @@ namespace FRF.DataAccess.EntityModels
         [Key]
         public int Id { get; set; }
         public string Name { get; set; }
+        public ICollection<ArtifactType> ArtifactType { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactDTO.cs
@@ -1,7 +1,4 @@
-﻿using FRF.Core.Models;
-using System.ComponentModel.DataAnnotations;
-using System.Xml.Linq;
-using System;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
 
 namespace FRF.Web.Dtos.Artifacts
@@ -11,7 +8,6 @@ namespace FRF.Web.Dtos.Artifacts
         public int Id { get; set; }
         [Required(ErrorMessage = "The artifact needs a name")]
         public string Name { get; set; }
-        public string Provider { get; set; }
         public Dictionary<string, string> Settings { get; set; }
         public int ProjectId { get; set; }
         public ArtifactTypeDTO ArtifactType { get; set; }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactTypeDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactTypeDTO.cs
@@ -5,5 +5,7 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public ProviderDTO Provider { get; set; }
+        public string RequiredFields { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactUpsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactUpsertDTO.cs
@@ -5,7 +5,6 @@ namespace FRF.Web.Dtos.Artifacts
     public class ArtifactUpsertDTO
     {
         public string Name { get; set; }
-        public string Provider { get; set; }
         public XElement? Settings { get; set; }
         public int ProjectId { get; set; }
         public int ArtifactTypeId { get; set; }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ProviderDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ProviderDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Web.Dtos.Artifacts
+{
+    public class ProviderDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
@@ -44,6 +44,7 @@ namespace FRF.Web.Dtos
             CreateMap<PricingDimension, PricingDimensionDTO>();
             CreateMap<ArtifactsRelationInsertDTO, ArtifactsRelation>();
             CreateMap<ArtifactsRelationUpdateDTO, ArtifactsRelation>();
+            CreateMap<Provider, ProviderDTO>();
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -34,11 +34,22 @@ namespace FRF.Core.Tests.Services
             _classUnderTest = new ArtifactsService(_dataAccess, _mapper);
         }
 
-        private ArtifactType CreateArtifactType()
+        private Provider CreateProvider()
+        {
+            var provider = new Provider();
+            provider.Name = "[Mock] Provider name";
+            _dataAccess.Providers.Add(provider);
+            _dataAccess.SaveChanges();
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
         {
             var artifactType = new ArtifactType();
             artifactType.Name = "[Mock] Artifact type name";
             artifactType.Description = "[Mock] Artifact type description";
+            artifactType.Provider = provider;
             _dataAccess.ArtifactType.Add(artifactType);
             _dataAccess.SaveChanges();
 
@@ -63,7 +74,6 @@ namespace FRF.Core.Tests.Services
             var artifact = new Artifact()
             {
                 Name = "[Mock] Artifact name "+ random.Next(500),
-                Provider = "[Mock] AWS",
                 CreatedDate = DateTime.Now,
                 Project = project,
                 ProjectId = project.Id,
@@ -96,7 +106,8 @@ namespace FRF.Core.Tests.Services
         public async Task GetAllAsync_ReturnsList()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -110,7 +121,6 @@ namespace FRF.Core.Tests.Services
 
             Assert.Equal(artifact.Id, resultValue.Id);
             Assert.Equal(artifact.Name, resultValue.Name);
-            Assert.Equal(artifact.Provider, resultValue.Provider);
             Assert.Equal(artifact.CreatedDate, resultValue.CreatedDate);
             Assert.Equal(artifact.ProjectId, resultValue.ProjectId);
             Assert.Equal(artifact.ArtifactTypeId, resultValue.ArtifactTypeId);
@@ -121,6 +131,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifact.ArtifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(artifact.ArtifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(artifact.ArtifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(artifact.ArtifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(artifact.ArtifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
@@ -139,7 +152,8 @@ namespace FRF.Core.Tests.Services
         public async Task GetAllByProjectIdAsync_ReturnList()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -153,7 +167,6 @@ namespace FRF.Core.Tests.Services
 
             Assert.Equal(artifact.Id, resultValue.Id);
             Assert.Equal(artifact.Name, resultValue.Name);
-            Assert.Equal(artifact.Provider, resultValue.Provider);
             Assert.Equal(artifact.CreatedDate, resultValue.CreatedDate);
             Assert.Equal(artifact.ProjectId, resultValue.ProjectId);
             Assert.Equal(artifact.ArtifactTypeId, resultValue.ArtifactTypeId);
@@ -164,6 +177,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifact.ArtifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(artifact.ArtifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(artifact.ArtifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(artifact.ArtifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(artifact.ArtifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
@@ -186,7 +202,8 @@ namespace FRF.Core.Tests.Services
         public async Task GetAllByProjectIdAsync_ReturnEmptyList()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
 
             // Act
@@ -202,7 +219,8 @@ namespace FRF.Core.Tests.Services
         public async Task GetAsync_ReturnsArtifact()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -216,7 +234,6 @@ namespace FRF.Core.Tests.Services
 
             Assert.Equal(artifact.Id, resultValue.Id);
             Assert.Equal(artifact.Name, resultValue.Name);
-            Assert.Equal(artifact.Provider, resultValue.Provider);
             Assert.Equal(artifact.CreatedDate, resultValue.CreatedDate);
             Assert.Equal(artifact.ProjectId, resultValue.ProjectId);
             Assert.Equal(artifact.ArtifactTypeId, resultValue.ArtifactTypeId);
@@ -227,6 +244,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifact.ArtifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(artifact.ArtifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(artifact.ArtifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(artifact.ArtifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(artifact.ArtifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
@@ -249,12 +269,12 @@ namespace FRF.Core.Tests.Services
         public async Task SaveAsync_ReturnsArtifact()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
 
             var artifactToSave = new CoreModels.Artifact();
             artifactToSave.Name = "[Mock] Artifact name 1";
-            artifactToSave.Provider = "[Mock] AWS";
             artifactToSave.ProjectId = project.Id;
             artifactToSave.ArtifactTypeId = artifactType.Id;
 
@@ -267,7 +287,6 @@ namespace FRF.Core.Tests.Services
             var resultValue = Assert.IsType<CoreModels.Artifact>(result.Value);
 
             Assert.Equal(artifactToSave.Name, resultValue.Name);
-            Assert.Equal(artifactToSave.Provider, resultValue.Provider);
             Assert.Null(resultValue.ModifiedDate);
             Assert.Equal(artifactToSave.ProjectId, resultValue.ProjectId);
             Assert.Equal(artifactToSave.ArtifactTypeId, resultValue.ArtifactTypeId);
@@ -278,17 +297,20 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(artifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(artifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(artifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(artifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
         public async Task SaveAsync_ExceptionNoProjectWithId()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifactToSave = new CoreModels.Artifact()
             {
                 Name = "[Mock] Artifact name 1",
-                Provider = "[Mock] AWS",
                 CreatedDate = DateTime.Now,
                 ProjectId = 999,
                 Project = new CoreModels.Project(),
@@ -319,7 +341,6 @@ namespace FRF.Core.Tests.Services
             var artifactToSave = new CoreModels.Artifact() 
             { 
                 Name = "[Mock] Artifact name 1",
-                Provider = "[Mock] AWS",
                 CreatedDate = DateTime.Now,
                 ProjectId = project.Id,
                 Project = new CoreModels.Project {
@@ -346,7 +367,8 @@ namespace FRF.Core.Tests.Services
         public async Task UpdateAsync_ReturnsArtifact()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -362,7 +384,8 @@ namespace FRF.Core.Tests.Services
             var newArtifactType = new ArtifactType()
             {
                 Name = "[Mock] Artifact type name",
-                Description = "[Mock] Artifact type description"
+                Description = "[Mock] Artifact type description",
+                Provider = provider
             };
             _dataAccess.ArtifactType.Add(newArtifactType);
             _dataAccess.SaveChanges();
@@ -371,7 +394,6 @@ namespace FRF.Core.Tests.Services
             {
                 Id = artifact.Id,
                 Name = "[Mock] Updated name",
-                Provider = "[Mock] Updated provider",
                 CreatedDate = DateTime.Now,
                 ProjectId = newProject.Id,
                 Project = _mapper.Map<CoreModels.Project>(newProject),
@@ -389,7 +411,6 @@ namespace FRF.Core.Tests.Services
 
             Assert.Equal(artifactToUpdate.Id, resultValue.Id);
             Assert.Equal(artifactToUpdate.Name, resultValue.Name);
-            Assert.Equal(artifactToUpdate.Provider, resultValue.Provider);
             Assert.Equal(artifact.CreatedDate, resultValue.CreatedDate);
             Assert.NotEqual(artifactToUpdate.CreatedDate, resultValue.CreatedDate); // This because it shouldn't allow CreatedDate change
             Assert.NotNull(resultValue.ModifiedDate);
@@ -402,19 +423,22 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(newArtifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(newArtifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(newArtifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(newArtifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(newArtifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
         public async Task UpdateAsync_ExceptionNoArtifactWithId()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifactToUpdate = new CoreModels.Artifact()
             {
                 Id = 1,
                 Name = "[Mock] Updated name",
-                Provider = "[Mock] Updated provider",
                 CreatedDate = DateTime.Now,
                 ProjectId = project.Id,
                 ArtifactTypeId = artifactType.Id
@@ -434,7 +458,8 @@ namespace FRF.Core.Tests.Services
         public async Task UpdateAsync_ExceptionNoProjectWithId()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -442,7 +467,6 @@ namespace FRF.Core.Tests.Services
             {
                 Id = artifact.Id,
                 Name = "[Mock] Updated name",
-                Provider = "[Mock] Updated provider",
                 CreatedDate = DateTime.Now,
                 ProjectId = 999,
                 ArtifactTypeId = artifactType.Id
@@ -462,7 +486,8 @@ namespace FRF.Core.Tests.Services
         public async Task UpdateAsync_ExceptionNoArtifactTypeWithId()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -470,7 +495,6 @@ namespace FRF.Core.Tests.Services
             {
                 Id = artifact.Id,
                 Name = "[Mock] Updated name",
-                Provider = "[Mock] Updated provider",
                 CreatedDate = DateTime.Now,
                 ProjectId = project.Id,
                 ArtifactTypeId = 999
@@ -490,7 +514,8 @@ namespace FRF.Core.Tests.Services
         public async Task Delete_ReturnsArtifact()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -504,7 +529,6 @@ namespace FRF.Core.Tests.Services
 
             Assert.Equal(artifact.Id, resultValue.Id);
             Assert.Equal(artifact.Name, resultValue.Name);
-            Assert.Equal(artifact.Provider, resultValue.Provider);
             Assert.Equal(artifact.CreatedDate, resultValue.CreatedDate);
             Assert.Equal(artifact.ProjectId, resultValue.ProjectId);
             Assert.Equal(artifact.ArtifactTypeId, resultValue.ArtifactTypeId);
@@ -515,13 +539,17 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifact.ArtifactType.Id, resultValue.ArtifactType.Id);
             Assert.Equal(artifact.ArtifactType.Name, resultValue.ArtifactType.Name);
             Assert.Equal(artifact.ArtifactType.Description, resultValue.ArtifactType.Description);
+
+            Assert.Equal(artifactType.Provider.Id, resultValue.ArtifactType.Provider.Id);
+            Assert.Equal(artifactType.Provider.Name, resultValue.ArtifactType.Provider.Name);
         }
 
         [Fact]
         public async Task Delete_ReturnsNull()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact = CreateArtifact(project, artifactType);
 
@@ -544,7 +572,8 @@ namespace FRF.Core.Tests.Services
             var i = 0;
             while (i < 3)
             {
-                var artifactType = CreateArtifactType();
+                var provider = CreateProvider();
+                var artifactType = CreateArtifactType(provider);
                 var project = CreateProject();
                 var artifact = CreateArtifact(project, artifactType);
                 var artifact1Id = artifact.Id;
@@ -613,7 +642,8 @@ namespace FRF.Core.Tests.Services
             var i = 0;
             while (i < 3)
             {
-                var artifactType = CreateArtifactType();
+                var provider = CreateProvider();
+                var artifactType = CreateArtifactType(provider);
                 var project = CreateProject();
                 var artifact1 = CreateArtifact(project, artifactType);
                 var artifact2 = CreateArtifact(project, artifactType);
@@ -655,7 +685,8 @@ namespace FRF.Core.Tests.Services
             var i = 0;
             while (i < 3)
             {
-                var artifactType = CreateArtifactType();
+                var provider = CreateProvider();
+                var artifactType = CreateArtifactType(provider);
                 var project = CreateProject();
                 var artifact = CreateArtifact(project, artifactType);
                 var artifact1Id = artifact.Id;
@@ -693,7 +724,8 @@ namespace FRF.Core.Tests.Services
             // Arange
             var artifactsRelationUpdated = new List<ArtifactsRelation>();
             var artifactsRelationInDb = new List<DataAccess.EntityModels.ArtifactsRelation>();
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifactBase = CreateArtifact(project, artifactType);
             var artifactIdToUpdate = artifactBase.Id;
@@ -743,7 +775,8 @@ namespace FRF.Core.Tests.Services
             var i = 0;
             while (i < 3)
             {
-                var artifactType = CreateArtifactType();
+                var provider = CreateProvider();
+                var artifactType = CreateArtifactType(provider);
                 var artifact = CreateArtifact(project, artifactType);
                 var artifact1Id = artifact.Id;
                 var artifact2Id = artifact1Id++;
@@ -794,7 +827,8 @@ namespace FRF.Core.Tests.Services
         {
             // Arange
             var project = CreateProject();
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(project, artifactType);
             var artifact2 = CreateArtifact(project, artifactType);
             var artifactRelation = CreateArtifactsRelationModel(artifact1.Id, artifact2.Id);
@@ -855,7 +889,8 @@ namespace FRF.Core.Tests.Services
         {
             // Arange
             var project = CreateProject();
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(project, artifactType);
             var artifact2 = CreateArtifact(project, artifactType);
             var artifactRelation = CreateArtifactsRelationModel(artifact1.Id, artifact2.Id);

--- a/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/BudgetServiceTests.cs
@@ -4,7 +4,6 @@ using FRF.Core.Services;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -45,7 +44,6 @@ namespace FRF.Core.Tests.Services
             var artifact = new Artifact()
             {
                 Name = "[Mock] Artifact name " + random.Next(500),
-                Provider = "[Mock] AWS",
                 CreatedDate = DateTime.Now,
                 Project = project,
                 ProjectId = project.Id,

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -79,12 +79,23 @@ namespace FRF.Web.Tests.Controllers
             return artifactRelation;
         }
 
-        private ArtifactType CreateArtifactType()
+        private Provider CreateProvider()
+        {
+            var provider = new Provider
+            {
+                Name = "[Mock] Provider name"
+            };
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
         {
             var artifactType = new ArtifactType
             {
                 Name = "[Mock] Artifact type name",
-                Description = "[Mock] Artifact type description"
+                Description = "[Mock] Artifact type description",
+                Provider = provider
             };
 
             return artifactType;
@@ -109,7 +120,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = id,
                 Name = "[Mock] Artifact name",
-                Provider = "[Mock] AWS",
                 CreatedDate = DateTime.Now,
                 Project = project,
                 ProjectId = project.Id,
@@ -141,12 +151,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -154,7 +167,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -202,12 +214,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -215,7 +230,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -263,12 +277,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -276,7 +293,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -347,12 +363,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -360,7 +379,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -377,7 +395,6 @@ namespace FRF.Web.Tests.Controllers
             var artifactUpsertDTO = new ArtifactUpsertDTO
             {
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -401,7 +418,6 @@ namespace FRF.Web.Tests.Controllers
             AssertCompareArtifactArtifactDTO(artifact, returnValue);
             _artifactsService.Verify(mock => mock.Save(It.Is<Artifact>(a => 
                 a.Name == artifactUpsertDTO.Name
-                && a.Provider == artifactUpsertDTO.Provider
                 && a.ProjectId == artifactUpsertDTO.ProjectId
                 && a.ArtifactTypeId == artifactUpsertDTO.ArtifactTypeId)), Times.Once);
         }
@@ -422,12 +438,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -435,7 +454,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -452,7 +470,6 @@ namespace FRF.Web.Tests.Controllers
             var artifactUpsertDTO = new ArtifactUpsertDTO
             {
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -501,18 +518,20 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactUpdate = new ArtifactUpsertDTO
             {
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -550,12 +569,15 @@ namespace FRF.Web.Tests.Controllers
                 ModifiedDate = null
             };
 
+            var provider = CreateProvider();
+
             var artifactTypeId = 1;
             var artifactType = new ArtifactType
             {
                 Id = artifactTypeId,
                 Name = "Artifact Type 1",
-                Description = "Description of Artifact Type 1"
+                Description = "Description of Artifact Type 1",
+                Provider = provider
             };
 
             var artifactId = 1;
@@ -563,7 +585,6 @@ namespace FRF.Web.Tests.Controllers
             {
                 Id = artifactId,
                 Name = "Artifact 1",
-                Provider = "AWS",
                 Settings = new XElement("Root",
                                 new XElement("Child1", 1),
                                 new XElement("Child2", 2),
@@ -663,7 +684,8 @@ namespace FRF.Web.Tests.Controllers
             // Arrange
             var projectId = 1;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(1, project, artifactType);
             var artifact2 = CreateArtifact(2, project, artifactType);
             var artifactsRelationsList = new List<ArtifactsRelation>();
@@ -695,7 +717,8 @@ namespace FRF.Web.Tests.Controllers
         {
             // Arrange
             var project = CreateProject(1);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(1, project, artifactType);
 
             _artifactsService
@@ -718,7 +741,8 @@ namespace FRF.Web.Tests.Controllers
             // Arrange
             var projectId = 1;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(1, project, artifactType);
             var artifact2 = CreateArtifact(2, project, artifactType);
             var artifactsRelationsList = new List<ArtifactsRelation>();
@@ -769,7 +793,8 @@ namespace FRF.Web.Tests.Controllers
             // Arrange
             var projectId = 1;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(1, project, artifactType);
             var artifact2 = CreateArtifact(2, project, artifactType);
             var artifactRelation = CreateArtifactsRelation(artifact1, artifact2);
@@ -812,7 +837,8 @@ namespace FRF.Web.Tests.Controllers
             var artifact1Id = 1;
             var artifact2Id = 2;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(artifact1Id, project, artifactType);
             var artifact2 = CreateArtifact(artifact2Id, project, artifactType);
             var artifactRelation = CreateArtifactsRelation(artifact1, artifact2);
@@ -862,7 +888,8 @@ namespace FRF.Web.Tests.Controllers
             var artifact1Id = 1;
             var artifact2Id = 2;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(artifact1Id, project, artifactType);
             var artifact2 = CreateArtifact(artifact2Id, project, artifactType);
             var artifactRelation = CreateArtifactsRelation(artifact1, artifact2);
@@ -899,7 +926,8 @@ namespace FRF.Web.Tests.Controllers
             var artifact1Id = 1;
             var artifact2Id = 2;
             var project = CreateProject(projectId);
-            var artifactType = CreateArtifactType();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(artifact1Id, project, artifactType);
             var artifact2 = CreateArtifact(artifact2Id, project, artifactType);
             var artifactRelation = CreateArtifactsRelation(artifact1, artifact2);
@@ -951,11 +979,12 @@ namespace FRF.Web.Tests.Controllers
         {
             Assert.Equal(artifact.Id, artifactDTO.Id);
             Assert.Equal(artifact.Name, artifactDTO.Name);
-            Assert.Equal(artifact.Provider, artifactDTO.Provider);
             Assert.Equal(artifact.ProjectId, artifactDTO.ProjectId);
             Assert.Equal(artifact.ArtifactType.Id, artifactDTO.ArtifactType.Id);
             Assert.Equal(artifact.ArtifactType.Name, artifactDTO.ArtifactType.Name);
             Assert.Equal(artifact.ArtifactType.Description, artifactDTO.ArtifactType.Description);
+            Assert.Equal(artifact.ArtifactType.Provider.Id, artifactDTO.ArtifactType.Provider.Id);
+            Assert.Equal(artifact.ArtifactType.Provider.Name, artifactDTO.ArtifactType.Provider.Name);
         }
     }
 }


### PR DESCRIPTION
## Descripción
En base a la necesidad de guardar la información acerca de que artefacto específico se está almacenando para luego poder instanciar un objeto específico para cada uno con su cálculo del precio, se resolvió modificar la base de datos como se puede ver en la imagen (lo que se encuentra en rojo es eliminación y en verde lo nuevo). Con estas modificaciones, todo artefacto tiene asociado un ArtifactType (no se estaba usando ese campo hasta el momento), los ArtifactType tienen un nombre que representa el servicio específico, y tienen asociado un proveedor (de haberse mantenido esa columna en Artifacts no había una relación directa entre los proveedores y sus servicios o artefactos, por lo que la información podía volverse incoherente).
![ChangesDB](https://user-images.githubusercontent.com/71275374/106797976-1ae1ab00-663c-11eb-9fc6-e49af38d8320.png)



## Tareas a realizar
- Crear la tabla **Providers** con un campo “_Id_” como clave primaria, y un campo “_Name_” para almacenar los nombres (varchar).
- En la tabla **Artifacts** se debe eliminar la columna “_Provider_”.
- En la tabla **ArtifactType** se deben agregar las columnas “_RequiredFields_” (nvarchar) y “_ProviderId_” (foreign key de la tabla Providers).

## Cambios realizados
Además de realizar los cambios en la base de datos como se específica más arriba, se realizaron los cambios necesarios para que la aplicación pudiera seguir funcionando de manera correcta. Esto significa actualizar los EntityModels, Models y Dtos de Artefactos y ArtifactTypes, además de un EntityModel, Model y Dto para trabajar con los Providers (junto con sus mapeos necesarios).

Por último, se actualizó el servicio de artefactos, y los test de dicho servicio, del servicio de presupuestos, y de el controller de artefactos. Durante las pruebas del servicio de artefactos se detectaron problemas con las respuestas del Update y Save y se corrigieron (esto se daba porque se intentaba instanciar un objeto específico en base al proveedor del artefacto, pero no se tenía esa información luego de crearlo o modificarlo).

En otra historia se encontrarán las modificaciones necesarias sobre el FrontEnd para adaptarlo a estos cambios.