### PR TITLE
[FIVE-307] Corrección de respuesta en controller UserController

### DIFF
--- a/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
@@ -29,9 +29,9 @@ namespace FRF.Web.Controllers
         {
             var email = HttpContext.User.FindFirst(ClaimTypes.Email).Value;
             var userPublicProfile = await _userService.GetUserPublicProfileAsync(email);
-            if (userPublicProfile == null) return BadRequest();
+            if (!userPublicProfile.Success) return BadRequest();
             
-            return Ok(userPublicProfile);
+            return Ok(userPublicProfile.Value);
         }
 
         [HttpGet("logout")]

--- a/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
@@ -30,8 +30,9 @@ namespace FRF.Web.Controllers
             var email = HttpContext.User.FindFirst(ClaimTypes.Email).Value;
             var userPublicProfile = await _userService.GetUserPublicProfileAsync(email);
             if (!userPublicProfile.Success) return BadRequest();
-            
-            return Ok(userPublicProfile.Value);
+
+            var mappedProfile = _mapper.Map<UserProfileDTO>(userPublicProfile.Value);
+            return Ok(mappedProfile);
         }
 
         [HttpGet("logout")]

--- a/test/FRF.Web.Tests/Controllers/UserControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/UserControllerTests.cs
@@ -1,0 +1,177 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.Core.Services;
+using FRF.Web.Controllers;
+using FRF.Web.Dtos.Projects;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Web.Tests.Controllers
+{
+    public class UserControllerTests
+    {
+        private readonly IMapper _mapper = MapperBuilder.Build();
+        private readonly Mock<IUserService> _userService;
+
+        private readonly UserController _classUnderTest;
+
+        public UserControllerTests()
+        {
+            _userService = new Mock<IUserService>();
+            _classUnderTest = new UserController(_userService.Object, _mapper);
+        }
+
+        private void AddUserToContext(HttpContext context, UsersProfile user)
+        {
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>()
+            {
+                new Claim(ClaimTypes.Email, user.Email),
+            }));
+
+            context.User = userPrincipal;
+        }
+
+        [Fact]
+        public async Task GetUserPublicProfileAsync_ReturnsOk()
+        {
+            // Arrange
+            var userProfile = new UsersProfile
+            {
+                Email = "any@email.com",
+                Fullname = "John Doe",
+                UserId = new System.Guid()
+            };
+
+            var context = new ControllerContext 
+            {
+                HttpContext = new DefaultHttpContext() 
+            };
+
+            AddUserToContext(context.HttpContext, userProfile);
+
+            _userService
+                .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ServiceResponse<Core.Models.UsersProfile>(userProfile));
+
+            _classUnderTest.ControllerContext = context;
+
+            // Act
+            var result = await _classUnderTest.GetUserPublicProfileAsync();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<UserProfileDTO>(okResult.Value);
+
+            Assert.Equal(userProfile.Email, resultValue.Email);
+            Assert.Equal(userProfile.Fullname, resultValue.Fullname);
+            Assert.Equal(userProfile.UserId, resultValue.UserId);
+
+            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUserPublicProfileAsync_ReturnsBadRequest()
+        {
+            // Arrange
+            var userProfile = new UsersProfile
+            {
+                Email = "any@email.com",
+                Fullname = "John Doe",
+                UserId = new System.Guid()
+            };
+
+            var context = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            AddUserToContext(context.HttpContext, userProfile);
+
+            _userService
+                .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ServiceResponse<Core.Models.UsersProfile>(new Error(ErrorCodes.UserNotExists, "[Mock] Error Message")));
+
+            _classUnderTest.ControllerContext = context;
+
+            // Act
+            var result = await _classUnderTest.GetUserPublicProfileAsync();
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestResult>(result);
+            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SearchUserAsync_ReturnsOk()
+        {
+            // Arrange
+            var userProfile = new UsersProfile
+            {
+                Email = "any@email.com",
+                Fullname = "John Doe",
+                UserId = new System.Guid()
+            };
+
+            _userService
+                .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ServiceResponse<Core.Models.UsersProfile>(userProfile));
+
+            // Act
+            var result = await _classUnderTest.SearchUserAsync(userProfile.Email);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<UserProfileDTO>(okResult.Value);
+
+            Assert.Equal(userProfile.Email, resultValue.Email);
+            Assert.Equal(userProfile.Fullname, resultValue.Fullname);
+            Assert.Equal(userProfile.UserId, resultValue.UserId);
+
+            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SearchUserAsync_ReturnBadRequest()
+        {
+            // Arrange
+            var userEmail = "";
+
+            // Act
+            var result = await _classUnderTest.SearchUserAsync(userEmail);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestResult>(result);
+            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task SearchUserAsync_ReturnsNotFound()
+        {
+            // Arrange
+            var userProfile = new UsersProfile
+            {
+                Email = "any@email.com",
+                Fullname = "John Doe",
+                UserId = new System.Guid()
+            };
+
+            _userService
+                .Setup(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ServiceResponse<Core.Models.UsersProfile>(new Error(ErrorCodes.UserNotExists, "[Mock] Error Message")));
+
+            // Act
+            var result = await _classUnderTest.SearchUserAsync(userProfile.Email);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundResult>(result);
+            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Descripción
El método _GetUserPublicProfileAsync_ no se había adaptado a las nuevas respuestas de servicio, con lo que seguía chequeando si la respuesta era nula, y en caso contrario enviando la información para su uso en el frontend. Luego del cambio en el PR #88, el servicio estaba entregando un objeto ServiceResponse, con lo que esta lógica no funcionaba, ya que nunca se iba a tener una respuesta nula, y en caso de éxito, la información relevante para el frontend se encontraba dentro de la propiedad _Value_ de este objeto.
## Cambio realizado
- Se corrige el método GetUserPublicProfileAsync para que trabaje con los objetos ServiceResponse