### PR TITLE
[FIVE-300] Modificar métodos Assert..Equals en test donde esten los parámetros estén invertidos.

### DIFF
--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -756,7 +756,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
             Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
-
+            Assert.Null(response.Value);
             Assert.Equal(artifactsRelationToSave[0].Artifact1Property, artifactsRelationInDb[0].Artifact1Property);
             Assert.Equal(artifactsRelationToSave[0].Artifact2Property, artifactsRelationInDb[0].Artifact2Property);
             Assert.Equal(artifactsRelationToSave[0].Artifact2Id, artifactsRelationInDb[0].Artifact2Id);
@@ -798,7 +798,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
             Assert.Equal(response.Error.Code, ErrorCodes.ArtifactNotExists);
-
+            Assert.Null(response.Value);
             Assert.Equal(artifactsRelationUpdated[0].Artifact1Property, artifactsRelationInDb[0].Artifact1Property);
             Assert.Equal(artifactsRelationUpdated[0].Artifact2Property, artifactsRelationInDb[0].Artifact2Property);
             Assert.Equal(artifactsRelationUpdated[0].Artifact2Id, artifactsRelationInDb[0].Artifact2Id);

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -799,10 +799,10 @@ namespace FRF.Core.Tests.Services
             Assert.NotNull(response.Error);
             Assert.Equal(response.Error.Code, ErrorCodes.ArtifactNotExists);
 
-            Assert.Equal(artifactsRelationInDb[0].Artifact1Property, artifactsRelationUpdated[0].Artifact1Property);
-            Assert.Equal(artifactsRelationInDb[0].Artifact2Property, artifactsRelationUpdated[0].Artifact2Property);
-            Assert.Equal(artifactsRelationInDb[0].Artifact2Id, artifactsRelationUpdated[0].Artifact2Id);
-            Assert.Equal(artifactsRelationInDb[0].Artifact1Id, artifactsRelationUpdated[0].Artifact1Id);
+            Assert.Equal(artifactsRelationUpdated[0].Artifact1Property, artifactsRelationInDb[0].Artifact1Property);
+            Assert.Equal(artifactsRelationUpdated[0].Artifact2Property, artifactsRelationInDb[0].Artifact2Property);
+            Assert.Equal(artifactsRelationUpdated[0].Artifact2Id, artifactsRelationInDb[0].Artifact2Id);
+            Assert.Equal(artifactsRelationUpdated[0].Artifact1Id, artifactsRelationInDb[0].Artifact1Id);
         }
 
         [Fact]

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -200,7 +200,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<List<CoreModels.Artifact>>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ArtifactNotExists);
+            Assert.Equal(ErrorCodes.ArtifactNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.InvalidArtifactSettings);
+            Assert.Equal(ErrorCodes.InvalidArtifactSettings, result.Error.Code);
         }
 
         [Fact]
@@ -363,7 +363,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -393,7 +393,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ArtifactTypeNotExists);
+            Assert.Equal(ErrorCodes.ArtifactTypeNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -512,7 +512,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.InvalidArtifactSettings);
+            Assert.Equal(ErrorCodes.InvalidArtifactSettings, result.Error.Code);
         }
 
         [Fact]
@@ -538,7 +538,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ArtifactNotExists);
+            Assert.Equal(ErrorCodes.ArtifactNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -566,7 +566,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -594,7 +594,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ArtifactTypeNotExists);
+            Assert.Equal(ErrorCodes.ArtifactTypeNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -647,7 +647,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.ArtifactNotExists);
+            Assert.Equal(ErrorCodes.ArtifactNotExists, result.Error.Code);
         }
         
         [Fact]
@@ -717,7 +717,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(response.Error.Code, ErrorCodes.RelationNotValid);
+            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
         }
 
         [Fact]
@@ -755,12 +755,12 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(response.Error.Code, ErrorCodes.RelationAlreadyExisted);
+            Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
 
-            Assert.Equal(artifactsRelationInDb[0].Artifact1Property, artifactsRelationToSave[0].Artifact1Property);
-            Assert.Equal(artifactsRelationInDb[0].Artifact2Property, artifactsRelationToSave[0].Artifact2Property);
-            Assert.Equal(artifactsRelationInDb[0].Artifact2Id, artifactsRelationToSave[0].Artifact2Id);
-            Assert.Equal(artifactsRelationInDb[0].Artifact1Id, artifactsRelationToSave[0].Artifact1Id);
+            Assert.Equal(artifactsRelationToSave[0].Artifact1Property, artifactsRelationInDb[0].Artifact1Property);
+            Assert.Equal(artifactsRelationToSave[0].Artifact2Property, artifactsRelationInDb[0].Artifact2Property);
+            Assert.Equal(artifactsRelationToSave[0].Artifact2Id, artifactsRelationInDb[0].Artifact2Id);
+            Assert.Equal(artifactsRelationToSave[0].Artifact1Id, artifactsRelationInDb[0].Artifact1Id);
         }
 
         [Fact]
@@ -906,7 +906,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(response.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, response.Error.Code);
         }
 
         [Fact]
@@ -931,12 +931,12 @@ namespace FRF.Core.Tests.Services
             Assert.True(response.Success);
             Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
             var resultValue = Assert.IsAssignableFrom<IList<ArtifactsRelation>>(response.Value);
-            Assert.Equal(resultValue[0].Id, artifactRelationMapped.Id);
-            Assert.Equal(resultValue[0].Artifact1Id, artifactRelation.Artifact1Id);
-            Assert.Equal(resultValue[0].Artifact2Id, artifactRelation.Artifact2Id);
-            Assert.Equal(resultValue[0].RelationTypeId, artifactRelation.RelationTypeId);
-            Assert.Equal(resultValue[0].Artifact1Property, artifactRelation.Artifact1Property);
-            Assert.Equal(resultValue[0].Artifact2Property, artifactRelation.Artifact2Property);
+            Assert.Equal(artifactRelationMapped.Id, resultValue[0].Id);
+            Assert.Equal(artifactRelation.Artifact1Id, resultValue[0].Artifact1Id);
+            Assert.Equal(artifactRelation.Artifact2Id, resultValue[0].Artifact2Id);
+            Assert.Equal(artifactRelation.RelationTypeId, resultValue[0].RelationTypeId);
+            Assert.Equal(artifactRelation.Artifact1Property, resultValue[0].Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, resultValue[0].Artifact2Property);
         }
 
         [Fact]
@@ -952,7 +952,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(response.Error.Code, ErrorCodes.RelationNotExists);
+            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
         }
 
         [Fact]
@@ -968,7 +968,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<ArtifactsRelation>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(response.Error.Code, ErrorCodes.RelationNotExists);
+            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
         }
 
         [Fact]
@@ -993,12 +993,12 @@ namespace FRF.Core.Tests.Services
             Assert.True(response.Success);
             Assert.IsType<ServiceResponse<ArtifactsRelation>>(response);
             var resultValue = Assert.IsAssignableFrom<ArtifactsRelation>(response.Value);
-            Assert.Equal(resultValue.Id, artifactRelationMapped.Id);
-            Assert.Equal(resultValue.Artifact1Id, artifactRelation.Artifact1Id);
-            Assert.Equal(resultValue.Artifact2Id, artifactRelation.Artifact2Id);
-            Assert.Equal(resultValue.RelationTypeId, artifactRelation.RelationTypeId);
-            Assert.Equal(resultValue.Artifact1Property, artifactRelation.Artifact1Property);
-            Assert.Equal(resultValue.Artifact2Property, artifactRelation.Artifact2Property);
+            Assert.Equal(artifactRelationMapped.Id, resultValue.Id);
+            Assert.Equal(artifactRelation.Artifact1Id, resultValue.Artifact1Id);
+            Assert.Equal(artifactRelation.Artifact2Id, resultValue.Artifact2Id);
+            Assert.Equal(artifactRelation.RelationTypeId, resultValue.RelationTypeId);
+            Assert.Equal(artifactRelation.Artifact1Property, resultValue.Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, resultValue.Artifact2Property);
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -145,8 +145,8 @@ namespace FRF.Core.Tests.Services
             var settingsList = result.Value;
             Assert.NotEmpty(settingsList);
 
-            Assert.Equal(settingsList[0].Name.Key, service.AttributeNames[0]);
-            Assert.Equal(settingsList[0].Values[0], attributeValue.Value);
+            Assert.Equal(service.AttributeNames[0], settingsList[0].Name.Key);
+            Assert.Equal(attributeValue.Value, settingsList[0].Values[0]);
             _client.Verify(mock => mock.DescribeServicesAsync(It.IsAny<DescribeServicesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
             _client.Verify(mock => mock.GetAttributeValuesAsync(It.IsAny<GetAttributeValuesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -355,7 +355,7 @@ namespace FRF.Core.Tests.Services
 
             Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
             var resultValue = result.Value;
-            Assert.Equal(expected:5,resultValue.Count);
+            Assert.Equal(expected:4,resultValue.Count);
             _client.Verify(mock => mock.GetProductsAsync(It.IsAny<GetProductsRequest>(), It.IsAny<CancellationToken>()), Times.AtMost(5));
             foreach (var pricingTerm in resultValue)
             {

--- a/test/FRF.Core.Tests/Services/CategoriesServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/CategoriesServiceTests.cs
@@ -87,9 +87,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(category.Id, resultValue.Id);
             Assert.Single(resultValue.ProjectCategories);
 
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Name, project.Name);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Budget, project.Budget);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Id, project.Id);
+            Assert.Equal(project.Name, resultValue.ProjectCategories[0].Project.Name);
+            Assert.Equal(project.Budget, resultValue.ProjectCategories[0].Project.Budget);
+            Assert.Equal(project.Id, resultValue.ProjectCategories[0].Project.Id);
         }
 
         [Fact]
@@ -124,9 +124,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(category.Id, resultValue.Id);
             Assert.Single(resultValue.ProjectCategories);
 
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Name, project.Name);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Budget, project.Budget);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Id, project.Id);
+            Assert.Equal(project.Name, resultValue.ProjectCategories[0].Project.Name);
+            Assert.Equal(project.Budget, resultValue.ProjectCategories[0].Project.Budget);
+            Assert.Equal(project.Id, resultValue.ProjectCategories[0].Project.Id);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Category>>(result);
             Assert.False(result.Success);
             Assert.NotNull(result.Error);
-            Assert.Equal(result.Error.Code, ErrorCodes.CategoryNotExists);
+            Assert.Equal(ErrorCodes.CategoryNotExists,result.Error.Code);
         }
 
         [Fact]
@@ -164,8 +164,8 @@ namespace FRF.Core.Tests.Services
             Assert.True(result.Success);
             var resultValue = result.Value;
 
-            Assert.Equal(resultValue.Name, categoryToSave.Name);
-            Assert.Equal(resultValue.Description, categoryToSave.Description);
+            Assert.Equal(categoryToSave.Name, resultValue.Name);
+            Assert.Equal(categoryToSave.Description, resultValue.Description);
             Assert.Empty(resultValue.ProjectCategories);
         }
 
@@ -191,19 +191,19 @@ namespace FRF.Core.Tests.Services
             Assert.True(result.Success);
             var resultValue = result.Value;
 
-            Assert.Equal(resultValue.Id, category.Id);
-            Assert.Equal(resultValue.Id, updatedCategory.Id);
+            Assert.Equal(category.Id, resultValue.Id);
+            Assert.Equal(updatedCategory.Id, resultValue.Id);
 
-            Assert.Equal(resultValue.Name, category.Name);
-            Assert.Equal(resultValue.Name, updatedCategory.Name);
+            Assert.Equal(category.Name, resultValue.Name);
+            Assert.Equal(updatedCategory.Name, resultValue.Name);
 
-            Assert.Equal(resultValue.Description, category.Description);
-            Assert.Equal(resultValue.Description, updatedCategory.Description);
+            Assert.Equal(category.Description, resultValue.Description);
+            Assert.Equal(updatedCategory.Description,resultValue.Description);
 
             Assert.Single(resultValue.ProjectCategories);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Name, project.Name);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Budget, project.Budget);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Id, project.Id);
+            Assert.Equal(project.Name, resultValue.ProjectCategories[0].Project.Name);
+            Assert.Equal(project.Budget, resultValue.ProjectCategories[0].Project.Budget);
+            Assert.Equal(project.Id, resultValue.ProjectCategories[0].Project.Id);
         }
 
         [Fact]
@@ -226,9 +226,9 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(category.Id, resultValue.Id);
             Assert.Single(resultValue.ProjectCategories);
 
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Name, project.Name);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Budget, project.Budget);
-            Assert.Equal(resultValue.ProjectCategories[0].Project.Id, project.Id);
+            Assert.Equal(project.Name, resultValue.ProjectCategories[0].Project.Name);
+            Assert.Equal(project.Budget, resultValue.ProjectCategories[0].Project.Budget);
+            Assert.Equal(project.Id, resultValue.ProjectCategories[0].Project.Id);
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
@@ -192,7 +192,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -264,7 +264,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
-            Assert.Equal(result.Error.Code, ErrorCodes.CategoryNotExists);
+            Assert.Equal(ErrorCodes.CategoryNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -354,7 +354,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
-            Assert.Equal(result.Error.Code, ErrorCodes.CategoryNotExists);
+            Assert.Equal(ErrorCodes.CategoryNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -401,7 +401,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
 
         [Fact]
@@ -437,7 +437,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
-            Assert.Equal(result.Error.Code, ErrorCodes.ProjectNotExists);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
         }
     }
 }

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -704,11 +704,11 @@ namespace FRF.Web.Tests.Controllers
             var returnValue = Assert.IsAssignableFrom<IList<ArtifactsRelationDTO>>(okResult.Value);
             AssertCompareArtifactArtifactDTO(artifact1, returnValue[0].Artifact1);
             AssertCompareArtifactArtifactDTO(artifact2, returnValue[0].Artifact2);
-            Assert.Equal(returnValue[0].Artifact1Id, artifact1.Id);
-            Assert.Equal(returnValue[0].Artifact2Id, artifact2.Id);
-            Assert.Equal(returnValue[0].Artifact1Property, artifactRelation.Artifact1Property);
-            Assert.Equal(returnValue[0].Artifact2Property, artifactRelation.Artifact2Property);
-            Assert.Equal(returnValue[0].RelationTypeId, artifactRelation.RelationTypeId);
+            Assert.Equal(artifact1.Id, returnValue[0].Artifact1Id);
+            Assert.Equal(artifact2.Id, returnValue[0].Artifact2Id);
+            Assert.Equal(artifactRelation.Artifact1Property, returnValue[0].Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, returnValue[0].Artifact2Property);
+            Assert.Equal(artifactRelation.RelationTypeId, returnValue[0].RelationTypeId);
             _artifactsService.Verify(mock => mock.GetAllRelationsOfAnArtifactAsync(It.IsAny<int>()), Times.Once);
         }
 
@@ -761,11 +761,11 @@ namespace FRF.Web.Tests.Controllers
             var returnValue = Assert.IsAssignableFrom<IList<ArtifactsRelationDTO>>(okResult.Value);
             AssertCompareArtifactArtifactDTO(artifact1, returnValue[0].Artifact1);
             AssertCompareArtifactArtifactDTO(artifact2, returnValue[0].Artifact2);
-            Assert.Equal(returnValue[0].Artifact1Id, artifact1.Id);
-            Assert.Equal(returnValue[0].Artifact2Id, artifact2.Id);
-            Assert.Equal(returnValue[0].Artifact1Property, artifactRelation.Artifact1Property);
-            Assert.Equal(returnValue[0].Artifact2Property, artifactRelation.Artifact2Property);
-            Assert.Equal(returnValue[0].RelationTypeId, artifactRelation.RelationTypeId);
+            Assert.Equal(artifact1.Id, returnValue[0].Artifact1Id);
+            Assert.Equal(artifact2.Id, returnValue[0].Artifact2Id);
+            Assert.Equal(artifactRelation.Artifact1Property, returnValue[0].Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, returnValue[0].Artifact2Property);
+            Assert.Equal(artifactRelation.RelationTypeId, returnValue[0].RelationTypeId);
             _artifactsService.Verify(mock => mock.GetAllRelationsByProjectIdAsync(It.IsAny<int>()), Times.Once);
         }
 
@@ -872,11 +872,11 @@ namespace FRF.Web.Tests.Controllers
             var returnValue = Assert.IsAssignableFrom<IList<ArtifactsRelationDTO>>(okResult.Value);
             AssertCompareArtifactArtifactDTO(artifact1, returnValue[0].Artifact1);
             AssertCompareArtifactArtifactDTO(artifact2, returnValue[0].Artifact2);
-            Assert.Equal(returnValue[0].Artifact1Id, artifact1.Id);
-            Assert.Equal(returnValue[0].Artifact2Id, artifact2.Id);
-            Assert.Equal(returnValue[0].Artifact1Property, artifactRelation.Artifact1Property);
-            Assert.Equal(returnValue[0].Artifact2Property, artifactRelation.Artifact2Property);
-            Assert.Equal(returnValue[0].RelationTypeId, artifactRelation.RelationTypeId);
+            Assert.Equal(artifact1.Id, returnValue[0].Artifact1Id);
+            Assert.Equal(artifact2.Id, returnValue[0].Artifact2Id);
+            Assert.Equal(artifactRelation.Artifact1Property, returnValue[0].Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, returnValue[0].Artifact2Property);
+            Assert.Equal(artifactRelation.RelationTypeId, returnValue[0].RelationTypeId);
             _artifactsService.Verify(mock => mock.UpdateRelationAsync(It.IsAny<int>(), It.IsAny<IList<ArtifactsRelation>>()), Times.Once);
         }
 

--- a/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
@@ -195,7 +195,6 @@ namespace FRF.Web.Tests.Controllers
             Assert.Equal(oldCategory.Id, returnValue.Id);
             Assert.Equal(updatedCategory.Name, returnValue.Name);
             Assert.Equal(updatedCategory.Description, returnValue.Description);
-            Assert.Equal(oldCategory.ProjectCategories, oldCategory.ProjectCategories);
 
             _categoriesService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
             _categoriesService.Verify(mock => mock.UpdateAsync(It.IsAny<Category>()), Times.Once);


### PR DESCRIPTION
### Descripción: 
Teniendo en cuenta el método `Assert.Equal<T>(T expected, T actual)` correspondiente a la herramienta XUnit, la cual es utilizada en este proyecto para realizar Unit Test, donde:
***expected: El valor esperado***
***actual: El valor a comparar***
Se encontraron que varias implementaciones no respetaban dicha estructura.

### Tareas Realizadas:
- Se modificaron test donde la estructura (Expected , Actual) de los métodos Assert.Equals estaban invertidas.