### PR TITLE
[FIVE-306] Corrección de validaciones en componente EditArtifactRelation

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -123,6 +123,7 @@ const ArtifactsTable = (props: { projectId: number }) => {
                 setSnackbarSettings={setSnackbarSettings}
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
+                updateList = {{update: false}}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -15,9 +15,9 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
     const [openSnackbar, setOpenSnackbar] = React.useState(false);
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
-    const [updateList, setUpdateList] = React.useState(false);
+    const [updateList, setUpdateList] = React.useState(true);
     const [showNewArtifactsRelation, setShowNewArtifactsRelation] = React.useState(false);
-
+    
     const getArtifactsRelations = async () => {
         try {
             const response = await ArtifactService.getRelations(props.artifactId);
@@ -49,25 +49,27 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
             manageOpenSnackbar({ message: "Hubo un error al cargar los artefactos", severity: "error" });
         }
     }
+
+    React.useEffect(() => {
+        getArtifactsRelations();
+        getArtifacts();
+        setUpdateList(false);
+    }, [updateList]);
+
     const openNewArtifactsRelation = () => {
         setShowNewArtifactsRelation(true);
     }
     const closeNewArtifactsRelation = () => {
         setShowNewArtifactsRelation(false);
     }
-    React.useEffect(() => {
-        getArtifactsRelations();
-        getArtifacts();
-    }, [updateList]);
-
+    
     const manageOpenSnackbar = (settings: SnackbarSettings) => {
         setSnackbarSettings(settings);
         setOpenSnackbar(true);
     }
 
     const handleUpdateList = () => {
-        getArtifactsRelations();
-        getArtifacts();
+        setUpdateList(true);
     }
 
     return (
@@ -99,9 +101,9 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                                     updateList={handleUpdateList} 
                                     artifactsRelations={artifactsRelations}/>
                             )
-                            : <td colSpan={6}><Typography align="center" variant="h5" gutterBottom>
+                            : <tr><td colSpan={6}><Typography align="center" variant="h5" gutterBottom>
                                 Artefacto sin relaciones
-                      </Typography></td> : null}
+                      </Typography></td></tr> : null}
                 </tbody>
             </Table>
             <SnackbarMessage
@@ -118,6 +120,7 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setSnackbarSettings={setSnackbarSettings}
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
+                updateList={{update: true, setUpdate: handleUpdateList}}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -51,9 +51,11 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
     }
 
     React.useEffect(() => {
-        getArtifactsRelations();
-        getArtifacts();
-        setUpdateList(false);
+       if (updateList) {
+         getArtifactsRelations();
+         getArtifacts();
+         setUpdateList(false);
+       }
     }, [updateList]);
 
     const openNewArtifactsRelation = () => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import RelationCard from './RelationCard';
-import Typography from '@material-ui/core/Typography/Typography';
 
 const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, artifactRelationToDelete: ArtifactRelation, openSnackbar: Function, updateList: Function }) => {
     const [relationList, setRelationList] = React.useState<ArtifactRelation[]>([]);
@@ -16,7 +15,7 @@ const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, arti
             const response = await ArtifactService.deleteRelation(props.artifactRelationToDelete.id!)
             if (response.status == 204) {
                 props.openSnackbar({ message: "La relacion ha sido borrado con éxito", severity: "success" });
-                props.updateList();
+                props.updateList(true);
             }
             else {
                 props.openSnackbar({ message: "Hubo un error al borrar la relacion", severity: "error" });
@@ -40,7 +39,7 @@ const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, arti
     }
 
     return (
-        <div>
+        <>
             <Dialog
                 open={props.open}
                 onClose={handleClose}
@@ -71,7 +70,7 @@ const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, arti
                     </Button>
                 </DialogActions>
             </Dialog>
-        </div>
+        </>
     );
 }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -56,18 +56,19 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     const [relationTypeId, setRelationTypeId] = React.useState<number>(props.artifactRelations.relationTypeId);
     const [relation, setRelation] = React.useState<ArtifactRelation>(props.artifactRelations);
     const [isErrorRelationRepeated, setIsErrorRelationRepeated] = React.useState<boolean>(false);
+    const [isErrorEmptyField, setIsErrorEmptyField] = React.useState<boolean>(false);
+    const [updateEdit, setUpdateEdit] = React.useState<boolean>(true);
 
     const updateArtifactsSettings = () => {
-        (artifact1 !== null && artifact1 !== undefined) ?
-            setArtifact1Settings(artifact1.settings) : setArtifact1Settings({});
-        
-         (artifact2 !== null && artifact2 !== undefined) ?
-            setArtifact2Settings(artifact2.settings) : setArtifact2Settings({});
+            props.updateList(true);
+            setArtifact1Settings(artifact1!.settings);
+            setArtifact2Settings(artifact2!.settings);
     }
 
     React.useEffect(() => {
         updateArtifactsSettings();
-    }, [artifact1, artifact2, relation])
+        setUpdateEdit(false);
+    }, [updateEdit, artifact1, artifact2, relation])
 
     const areRelationsEqual = (relation: ArtifactRelation) => {
         if (artifact1 === null || artifact2 === null || setting1 === null || setting2 === null) {
@@ -100,7 +101,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
         return flag;
     }
 
-    const handleClose = () => {
+    const resetState = () => {
         setArtifact1(props.artifactRelations.artifact1);
         setArtifact2(props.artifactRelations.artifact2);
         updateArtifactsSettings();
@@ -109,11 +110,28 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
         setRelationTypeId(props.artifactRelations.relationTypeId);
         setRelation(props.artifactRelations);
         setIsErrorRelationRepeated(false);
+        setIsErrorEmptyField(false);
+    }
+
+    const handleClose = () => {
+        setUpdateEdit(true);
+        resetState();
         props.closeEditArtifactsRelation();
     }
 
-    const handleConfirm = async () => {
+    const isFieldEmpty = () => {
+        if (artifact1 === null || artifact2 === null || setting1 === null || setting2 === null || relationTypeId === -1) {
+            return true;
+        }
+        return false;
+    }
 
+    const handleConfirm = async () => {
+        if (isFieldEmpty()) {
+            setIsErrorEmptyField(true);
+            return;
+        }
+        setIsErrorEmptyField(false);
         if (isRelationRepeated()) {
             setIsErrorRelationRepeated(true);
             return;
@@ -239,7 +257,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                                     }}
                                     onChange={(event) => handleSettingChange(event)}
                                     defaultValue={''}
-                                    value={setting1 !== null ? setting1.key : ''}
+                                    value={setting1 ? setting1.key : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -252,7 +270,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting1 !== null ? setting1?.value : null}</FormHelperText>
+                        <FormHelperText>{setting1 ? setting1?.value : null}</FormHelperText>
                     </FormControl>
                     <FormControl className={classes.selectDirection} error={Boolean(errors.artifactType)}>
                         <InputLabel htmlFor="type-select">Dirección</InputLabel>
@@ -296,7 +314,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                                     }}
                                     onChange={(event) => handleSettingChange(event)}
                                     defaultValue={''}
-                                    value={setting2 !== null ? setting2.key : ''}
+                                    value={setting2 ? setting2.key : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -309,7 +327,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting2 !== null ? setting2?.value : null}</FormHelperText>
+                        <FormHelperText>{setting2 ? setting2?.value : null}</FormHelperText>
                     </FormControl>
                     {errors.settings ?
                         <Typography gutterBottom className={classes.error}>
@@ -324,6 +342,11 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                     {isErrorRelationRepeated ?
                         <Typography gutterBottom className={classes.error}>
                             La relación ya existe
+                        </Typography> : null
+                    }
+                    {isErrorEmptyField ?
+                        <Typography gutterBottom className={classes.error}>
+                            Todos los campos deben ser completados para modificar una relación
                         </Typography> : null
                     }
                 </form>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -116,7 +116,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
         props.closeEditArtifactsRelation();
     }
 
-    const isFieldEmpty = () => {
+    const hasFieldsEmpty = () => {
         if (artifact1 === null || artifact2 === null || setting1 === null || setting2 === null || relationTypeId === -1) {
             return true;
         }
@@ -124,7 +124,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     }
 
     const handleConfirm = async () => {
-        if (isFieldEmpty()) {
+        if (hasFieldsEmpty()) {
             setIsErrorEmptyField(true);
             return;
         }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -57,7 +57,6 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     const [relation, setRelation] = React.useState<ArtifactRelation>(props.artifactRelations);
     const [isErrorRelationRepeated, setIsErrorRelationRepeated] = React.useState<boolean>(false);
     const [isErrorEmptyField, setIsErrorEmptyField] = React.useState<boolean>(false);
-    const [updateEdit, setUpdateEdit] = React.useState<boolean>(true);
 
     const updateArtifactsSettings = () => {
             props.updateList(true);
@@ -67,8 +66,7 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
 
     React.useEffect(() => {
         updateArtifactsSettings();
-        setUpdateEdit(false);
-    }, [updateEdit, artifact1, artifact2, relation])
+    }, [artifact1, artifact2, relation])
 
     const areRelationsEqual = (relation: ArtifactRelation) => {
         if (artifact1 === null || artifact2 === null || setting1 === null || setting2 === null) {
@@ -102,9 +100,9 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     }
 
     const resetState = () => {
+        updateArtifactsSettings();
         setArtifact1(props.artifactRelations.artifact1);
         setArtifact2(props.artifactRelations.artifact2);
-        updateArtifactsSettings();
         setSetting1(null);
         setSetting2(null);
         setRelationTypeId(props.artifactRelations.relationTypeId);
@@ -114,7 +112,6 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     }
 
     const handleClose = () => {
-        setUpdateEdit(true);
         resetState();
         props.closeEditArtifactsRelation();
     }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -12,6 +12,11 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
 
+interface handlerUpdateList{
+    update: boolean,
+    setUpdate?: Function
+}
+
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         container: {
@@ -43,7 +48,7 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[] }) => {
+const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
 
     const classes = useStyles();
     const { handleSubmit, errors, control } = useForm();
@@ -58,7 +63,6 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
     const [isErrorRelationRepeated, setIsErrorRelationRepeated] = React.useState<boolean>(false);
     const [isErrorEmptyField, setIsErrorEmptyField] = React.useState<boolean>(false);
     const [isErrorOneRelationCreated, setIsErrorOneRelationCreated] = React.useState<boolean>(false);
-
 
     React.useEffect(() => {
         updateArtifactsSettings();
@@ -146,6 +150,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
             if (response.status === 200) {
                 props.setSnackbarSettings({ message: "Las relaciones han sido creadas con éxito", severity: "success" });
                 props.setOpenSnackbar(true);
+                if(props.updateList.update && props.updateList.setUpdate) props.updateList.setUpdate();
             } else {
                 props.setSnackbarSettings({ message: "Hubo un error al crear las relaciones", severity: "error" });
                 props.setOpenSnackbar(true);

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -212,7 +212,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         return relationList.length > 0;
     }
 
-    const isFieldEmpty = () => {
+    const hasFieldsEmpty = () => {
         if (artifact1 === null || artifact2 === null || setting1 === null || setting2 === null || relationTypeId === -1) {
             return true;
         }
@@ -223,7 +223,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         if (isErrorOneRelationCreated) {
             setIsErrorOneRelationCreated(false);
         }
-        if (isFieldEmpty()) {
+        if (hasFieldsEmpty()) {
             setIsErrorEmptyField(true);
             return;
         }


### PR DESCRIPTION
### Descripción:
Nos encontramos con un bug: cuando el usuario ingresaba a editar una relación de artefactos, seleccionaba una setting, luego cancelaba la edición y trataba de editar otra, permanecían las settings de los artefactos previamente seleccionados. También se encontró que al crearse una relación, no se actualizaba de manera automática la lista de relaciones.

### Tareas realizadas:
- Se modificó hook useEffect para renderizar ArtifactsRelationTable cuando se cancela una modificación de relación, como también cuando se crea una relación nueva.
- Se agregó inteface handlerUpdateList dentro de componente NewArtifactsRelation para poder recibir por props una Function y un boolean. Si él boolean es true significa que el componente es hijo de ArtifactsRelationTable e implementara la Function de renderizado. Caso contrario solo creará las relaciones solicitadas.