### PR TITLE
[Five-302] (Models) Crear implementacion de precios para Artifact AWS EC2

### DIFF
--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -40,6 +40,10 @@ namespace FRF.Core
                 .ForMember(dest => dest.Id, act => act.Ignore())
                 .ForMember(dest => dest.ArtifactType, act => act.Ignore())
                 .ForMember(dest => dest.Project, act => act.Ignore());
+            CreateMap<DataAccess.EntityModels.Artifact, Models.AwsArtifacts.AwsEc2>()
+                .ForMember(dest => dest.Id, act => act.Ignore())
+                .ForMember(dest => dest.ArtifactType, act => act.Ignore())
+                .ForMember(dest => dest.Project, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ArtifactType, Models.ArtifactType>()
                 .ReverseMap();
             CreateMap<DataAccess.EntityModels.UsersByProject, Models.UsersProfile>()

--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -40,10 +40,7 @@ namespace FRF.Core
                 .ForMember(dest => dest.Id, act => act.Ignore())
                 .ForMember(dest => dest.ArtifactType, act => act.Ignore())
                 .ForMember(dest => dest.Project, act => act.Ignore());
-            CreateMap<DataAccess.EntityModels.Artifact, Models.AwsArtifacts.AwsEc2>()
-                .ForMember(dest => dest.Id, act => act.Ignore())
-                .ForMember(dest => dest.ArtifactType, act => act.Ignore())
-                .ForMember(dest => dest.Project, act => act.Ignore());
+            CreateMap<DataAccess.EntityModels.Artifact, Models.AwsArtifacts.AwsEc2>();
             CreateMap<DataAccess.EntityModels.ArtifactType, Models.ArtifactType>()
                 .ReverseMap();
             CreateMap<DataAccess.EntityModels.UsersByProject, Models.UsersProfile>()

--- a/FiveRockingFingers/FRF.Core/AwsEc2Descriptions.cs
+++ b/FiveRockingFingers/FRF.Core/AwsEc2Descriptions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FRF.Core
+{
+    public class AwsEc2Descriptions
+    {
+        //Atributtes
+        public const string Location = "location";
+        public const string PreInstalledSw = "preInstalledSw";
+        public const string OperatingSystem = "operatingSystem";
+        public const string InstanceType = "instanceType";
+        public const string Vcpu = "vcpu";
+        public const string Memory = "memory";
+        public const string NetworkPerformance = "networkPerformance";
+        public const string Storage = "storage";
+        public const string VolumeApiName = "volumeApiName";
+        public const string TransferType = "transferType";
+        public const string FromLocation = "fromLocation";
+        public const string ToLocation = "toLocation";
+        public const string ServiceCode = "servicecode";
+        public const string LocationType = "locationType";
+        public const string ToLocationType = "toLocationType";
+        public const string FromLocationType = "fromLocationType";
+        public const string ProductFamily = "productFamily";
+
+        //General
+        public const string ServiceValue = "AmazonEC2";
+        public const string LocationTypeValue = "AWS Region";
+
+        //Compute instance
+        public const string ProductFamilyComputeInstanceValue = "Compute Instance";
+
+
+        //EBS storage
+        public const string ProductFamilyEbsStorageValue = "Storage";
+        public const string VolumenApiNameGp3Value = "gp3";
+        public const string VolumenApiNameIo1Value = "io1";
+        public const string VolumenApiNameIo2Value = "io2";
+
+
+        //EBS snapshots
+        public const string ProductFamilyEbsSnapshotsValue = "Storage Snapshot";
+
+
+        //EBS Iops
+        public const string ProductFamilyEbsIopsValue = "System Operation";
+
+
+        //Provisioned Throughput
+        public const string ProductFamilyEbsThroughputValue = "Provisioned Throughput";
+
+
+        //Data transfer
+        public const string ProductFamilyDataTransferValue = "Data Transfer";
+
+        //Free tier
+        public const decimal FreeTierGp3Iops = 3000m;
+        public const decimal FreeTierGp3Throughput = 125m;
+    }
+}

--- a/FiveRockingFingers/FRF.Core/AwsEc2Descriptions.cs
+++ b/FiveRockingFingers/FRF.Core/AwsEc2Descriptions.cs
@@ -54,6 +54,7 @@ namespace FRF.Core
 
         //Data transfer
         public const string ProductFamilyDataTransferValue = "Data Transfer";
+        public const string IntraRegionDataTransfer = "IntraRegion";
 
         //Free tier
         public const decimal FreeTierGp3Iops = 3000m;

--- a/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsEc2.cs
+++ b/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsEc2.cs
@@ -1,0 +1,325 @@
+﻿using FRF.Core.Response;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FRF.Core.Models.AwsArtifacts
+{
+    public class AwsEc2 : Artifact
+    {
+        public const decimal PartialStorageDiscount = 0.5m;
+
+        //Compute instance properties
+        public int HoursUsedPerMonth { get; set; }
+        public string PurchaseOption { get; set; }
+        public decimal InstancePricePerUnit0 { get; set; }
+        public decimal InstancePricePerUnit1 { get; set; }
+        public string LeaseContractLength { get; set; }
+
+        //EBS Storage properties
+        public string VolumenApiName { get; set; }
+
+        public int NumberOfGbStorageInEbs { get; set; }
+        public decimal EbsPricePerUnit { get; set; }
+
+        //EBS Snapshots properties
+        public int NumberOfGbChangedPerSnapshot {get; set; }
+        public decimal NumberOfSnapshotsPerMonth { get; set; }
+        public decimal SnapshotPricePerUnit { get; set; }
+
+        //EBS IOPS properties
+        public int NumberOfIops { get; set; }
+        public decimal IopsPricePerUnit { get; set; }
+
+        //EBS Throughput properties
+        public int NumberOfMbpsThroughput { get; set; }
+        public decimal ThroughputPricePerUnit { get; set; }
+
+        //Data Transfer properties
+        public int NumberOfGbTransferIntraRegion { get; set; }
+        public decimal IntraTegionDataTransferPricePerUnit { get; set; }
+
+        override public decimal GetPrice()
+        {
+            GetAllProperties();
+
+            var totalPrice = GetInstancePrice() + GetEbsPrice() + GetSnapshotsPrice()
+                + GetIntraRegionDataTransferPrice() + GetIopsPrice() + GetThroughputPrice();
+
+            return totalPrice;
+        }
+
+        private decimal GetIntraRegionDataTransferPrice()
+        {
+            var intraRegionDataTransferPrice = 2 * NumberOfGbTransferIntraRegion * IntraTegionDataTransferPricePerUnit;
+
+            return intraRegionDataTransferPrice;
+        }
+
+        private decimal GetIopsPrice()
+        {
+            var price = 0m;
+
+            if(VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameGp3Value))
+            {
+                var numberOfIopsBillable = NumberOfIops - AwsEc2Descriptions.FreeTierGp3Iops;
+
+                if(numberOfIopsBillable > 0)
+                {
+                    price = numberOfIopsBillable * IopsPricePerUnit;
+                }
+
+                return price;
+            }
+
+            if(VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameIo1Value) || VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameIo2Value))
+            {
+                price = NumberOfIops * IopsPricePerUnit;
+
+                return price;
+            }
+
+            return price;
+        }
+
+        private decimal GetThroughputPrice()
+        {
+            var price = 0m;
+
+            if (VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameGp3Value))
+            {
+                var numberOfMbpsThroughputBillable = NumberOfMbpsThroughput - AwsEc2Descriptions.FreeTierGp3Throughput;
+
+                var numberOfGbpsThroughputBillable = numberOfMbpsThroughputBillable / 1024;
+
+                if (numberOfMbpsThroughputBillable > 0)
+                {
+                    price = numberOfGbpsThroughputBillable * ThroughputPricePerUnit;
+                }
+
+                return price;
+            }
+
+            if (VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameIo1Value) || VolumenApiName.Equals(AwsEc2Descriptions.VolumenApiNameIo2Value))
+            {
+                price = NumberOfMbpsThroughput * ThroughputPricePerUnit;
+
+                return price;
+            }
+
+            return price;
+        }
+
+        private decimal GetSnapshotsPrice()
+        {
+            var initialSnapshotPrice = NumberOfGbStorageInEbs * SnapshotPricePerUnit;
+
+            var incrementaSnapshotsPrice = NumberOfSnapshotsPerMonth * SnapshotPricePerUnit * PartialStorageDiscount * NumberOfGbChangedPerSnapshot;
+
+            var totalShanpshotPrice = initialSnapshotPrice + incrementaSnapshotsPrice;
+
+            return totalShanpshotPrice;
+        }
+
+        private decimal GetEbsPrice()
+        {
+            return NumberOfGbStorageInEbs * EbsPricePerUnit;
+        }
+
+        private decimal GetInstancePrice()
+        {
+            var price = -1m;
+
+            if((PurchaseOption.Equals("All Upfront", StringComparison.InvariantCultureIgnoreCase) ||
+                PurchaseOption.Equals("AllUpfront", StringComparison.InvariantCultureIgnoreCase)) &&
+                (LeaseContractLength.Equals("1yr", StringComparison.InvariantCultureIgnoreCase) ||
+                LeaseContractLength.Equals("1 yr", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                price = GetPriceAllUpfront1Yr();
+            }
+
+            if ((PurchaseOption.Equals("All Upfront", StringComparison.InvariantCultureIgnoreCase) ||
+                PurchaseOption.Equals("AllUpfront", StringComparison.InvariantCultureIgnoreCase)) &&
+                (LeaseContractLength.Equals("3yr", StringComparison.InvariantCultureIgnoreCase) ||
+                LeaseContractLength.Equals("3 yr", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                price = GetPriceAllUpfront3Yr();
+            }
+
+            if ((PurchaseOption.Equals("Partial Upfront", StringComparison.InvariantCultureIgnoreCase) ||
+                PurchaseOption.Equals("PartialUpfront", StringComparison.InvariantCultureIgnoreCase)) &&
+                (LeaseContractLength.Equals("1yr", StringComparison.InvariantCultureIgnoreCase) ||
+                LeaseContractLength.Equals("1 yr", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                price = GetPricePartialUpfront1Yr();
+            }
+
+            if ((PurchaseOption.Equals("Partial Upfront", StringComparison.InvariantCultureIgnoreCase) ||
+                PurchaseOption.Equals("PartialUpfront", StringComparison.InvariantCultureIgnoreCase)) &&
+                (LeaseContractLength.Equals("3yr", StringComparison.InvariantCultureIgnoreCase) ||
+                LeaseContractLength.Equals("3 yr", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                price = GetPricePartialUpfront3Yr();
+            }
+
+            if (PurchaseOption.Equals("No Upfront", StringComparison.InvariantCultureIgnoreCase) ||
+                PurchaseOption.Equals("NoUpfront", StringComparison.InvariantCultureIgnoreCase))
+            {
+                price = GetPriceNoUpfront();
+            }
+
+            return price;
+        }
+
+        private decimal GetPriceAllUpfront1Yr()
+        {
+            return InstancePricePerUnit1 / 12;
+        }
+
+        private decimal GetPriceAllUpfront3Yr()
+        {
+            return InstancePricePerUnit1 / 36;
+        }
+
+        private decimal GetPricePartialUpfront1Yr()
+        {
+            return InstancePricePerUnit0 * HoursUsedPerMonth + InstancePricePerUnit1 / 12;
+        }
+
+        private decimal GetPricePartialUpfront3Yr()
+        {
+            return InstancePricePerUnit0 * HoursUsedPerMonth + InstancePricePerUnit1 / 36;
+        }
+
+        private decimal GetPriceNoUpfront()
+        {
+            return InstancePricePerUnit0 * HoursUsedPerMonth;
+        }
+
+        private void GetAllProperties()
+        {
+            GetComputeInstaceProperties();
+            GetEbsProperties();
+            GetEbsSnapshotsProperties();
+            GetEbsIopsProperties();
+            GetEbsThroughputProperties();
+            GetDataTransferProperties();
+        }
+
+        private void GetComputeInstaceProperties()
+        {
+            HoursUsedPerMonth = int.Parse(Settings.Element("product0").Element("hoursUsedPerMonth").Value);
+
+            InstancePricePerUnit0 = decimal.Parse(Settings.Element("product0")
+                .Element("pricingDimensions")
+                .Element("range0")
+                .Element("pricePerUnit")
+                .Value, CultureInfo.InvariantCulture);
+            
+            InstancePricePerUnit1 = decimal.Parse(Settings.Element("product0")
+                .Element("pricingDimensions").Element("range1")
+                .Element("pricePerUnit")
+                .Value, CultureInfo.InvariantCulture);
+            
+            PurchaseOption = Settings.Element("product0").Element("purchaseOption").Value;
+            
+            LeaseContractLength = Settings.Element("product0").Element("leaseContractLength").Value;
+        }
+
+        private void GetEbsProperties()
+        {
+            VolumenApiName = Settings.Element("product1").Element("volumeApiName").Value;
+
+            NumberOfGbStorageInEbs = int.Parse(Settings.Element("product1")
+                .Element("numberOfGbStorageInEbs").Value);
+
+            EbsPricePerUnit = decimal.Parse(Settings.Element("product1")
+                .Element("pricingDimensions").Element("range0")
+                .Element("pricePerUnit").Value, CultureInfo.InvariantCulture);
+        }
+
+        private void GetEbsSnapshotsProperties()
+        {
+            NumberOfSnapshotsPerMonth = decimal.Parse(Settings.Element("product2").
+                Element("numberOfSnapshotsPerMonth").Value, CultureInfo.InvariantCulture);
+
+            NumberOfGbChangedPerSnapshot = int.Parse(Settings.Element("product2").
+                Element("numberOfGbChangedPerSnapshot").Value);
+
+            SnapshotPricePerUnit = decimal.Parse(Settings.Element("product2").
+                Element("pricingDimensions").
+                Element("range0")
+                .Element("pricePerUnit").Value, CultureInfo.InvariantCulture);
+        }
+
+        private void GetEbsIopsProperties()
+        {
+            if(Settings.Element("product3") != null &&
+                Settings.Element("product3")
+                .Element("numberOfIopsPerMonth") != null)
+            {
+                if(int.TryParse(Settings.Element("product3")
+                    .Element("numberOfIopsPerMonth").Value, out int numberOfIopsParse))
+                {
+                    NumberOfIops = numberOfIopsParse;
+                }                
+            }
+
+            if(Settings.Element("product3") != null &&
+                Settings.Element("product3")
+                .Element("pricingDimensions")
+                .Element("range0")
+                .Element("pricePerUnit") != null)
+            {
+                if(decimal.TryParse(Settings.Element("product3")
+                    .Element("pricingDimensions")
+                    .Element("range0")
+                    .Element("pricePerUnit").Value, out decimal iopsPricePerUnitParse))
+                {
+                    IopsPricePerUnit = iopsPricePerUnitParse;
+                }                
+            }
+        }
+
+        private void GetEbsThroughputProperties()
+        {
+            if(Settings.Element("product4") != null &&
+                Settings.Element("product4")
+                .Element("numberOfMbpsThroughput") != null)
+            {
+                if(int.TryParse(Settings.Element("product4").Element("numberOfMbpsThroughput").Value, out int numberOfMbpsThroughputParse))
+                {
+                    NumberOfMbpsThroughput = numberOfMbpsThroughputParse;
+                }                
+            }
+
+            if(Settings.Element("product4") != null &&
+                Settings.Element("product4")
+                .Element("pricingDimensions")
+                .Element("range0")
+                .Element("pricePerUnit") != null)
+            {
+                if(decimal.TryParse(Settings.Element("product4")
+                    .Element("pricingDimensions")
+                    .Element("range0")
+                    .Element("pricePerUnit")
+                    .Value, out decimal throughputPricePerUnitParse))
+                {
+                    ThroughputPricePerUnit = throughputPricePerUnitParse;
+                }                
+            }
+        }
+
+        private void GetDataTransferProperties()
+        {
+            NumberOfGbTransferIntraRegion = int.Parse(Settings.Element("product5").Element("numberOfGbTransferIntraRegion").Value);
+            IntraTegionDataTransferPricePerUnit = decimal.Parse(Settings.Element("product5")
+                .Element("pricingDimensions")
+                .Element("range0")
+                .Element("pricePerUnit")
+                .Value, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/DataTransferEc2.cs
+++ b/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/DataTransferEc2.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FRF.Core.Models.AwsArtifacts
+{
+    public class DataTransferEc2
+    {
+        public string TransferType { get; set; }
+        public int NumberOfGbTransferIntraRegion { get; set; }
+        public decimal IntraTegionDataTransferPricePerUnit { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -48,7 +48,7 @@ namespace FRF.Core.Services
                         case AwsS3Descriptions.Service:
                             return _mapper.Map<AwsS3>(artifact);
                         case AwsEc2Descriptions.ServiceValue:
-                            return _mapper.Map<AwsS3>(artifact);
+                            return _mapper.Map<AwsEc2>(artifact);
                         default:
                             return _mapper.Map<Artifact>(artifact);
                     }

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -47,6 +47,8 @@ namespace FRF.Core.Services
                     {
                         case AwsS3Descriptions.Service:
                             return _mapper.Map<AwsS3>(artifact);
+                        case AwsEc2Descriptions.ServiceValue:
+                            return _mapper.Map<AwsS3>(artifact);
                         default:
                             return _mapper.Map<Artifact>(artifact);
                     }

--- a/FiveRockingFingers/FRF.Core/XmlValidation/AwsEc2.xsd
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/AwsEc2.xsd
@@ -1,0 +1,235 @@
+﻿<xs:schema
+  attributeFormDefault="unqualified"
+  elementFormDefault="qualified"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="settings">
+    <xs:complexType>
+      <xs:sequence>
+        <!--This part is related to the instance-->
+        <xs:element name="product0" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="hoursUsedPerMonth" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="operatingSystem" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="preInstalledSw" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="instanceType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="vcpu" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="memory" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="networkPerformance" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="storage" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="locationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="range1" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="0" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="0" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>          
+        </xs:element>
+        <!--This part is related to EBS storage-->
+        <xs:element name="product1" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="numberOfGbStorageInEbs" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="volumeApiName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="locationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <!--This part is related to EBS snapshots-->
+        <xs:element name="product2" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="numberOfSnapshotsPerMonth" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="numberOfGbChangedPerSnapshot" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="volumeApiName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="locationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>                    
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <!--This part is related to system operations (iops)-->
+        <xs:element name="product3" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="numberOfIopsPerMonth" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="volumeApiName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="locationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <!--This part is related to provisioned throughput-->
+        <xs:element name="product4" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="numberOfMbpsThroughput" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="volumeApiName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="locationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <!--This part is related to data transfer-->
+        <xs:element name="product5" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="numberOfGbTransferIntraRegion" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="transferType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="fromLocationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="fromLocation" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="toLocationType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="toLocation" type="xs:string" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="pricingDimensions">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="range0" minOccurs="1" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="unit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                          <xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/FiveRockingFingers/FRF.Core/XmlValidation/AwsEc2.xsd
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/AwsEc2.xsd
@@ -195,10 +195,10 @@
           </xs:complexType>
         </xs:element>
         <!--This part is related to data transfer-->
-        <xs:element name="product5" minOccurs="0" maxOccurs="1">
+        <xs:element name="product5" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="numberOfGbTransferIntraRegion" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="numberOfGbTransfer" type="xs:decimal" minOccurs="1" maxOccurs="1"/>
               <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1"/>
               <xs:element name="productFamily" type="xs:string" minOccurs="1" maxOccurs="1"/>
               <xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1"/>

--- a/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
@@ -25,7 +25,15 @@ namespace FRF.Core.XmlValidation
                     path = Path.Combine(rootPath, "CustomArtifact.xsd");
                     break;
                 case ArtifactTypes.Aws:
-                    path = Path.Combine(path, "AwsS3.xsd");
+                    switch (artifact.ArtifactType.Name)
+                    {
+                        case AwsS3Descriptions.Service:
+                            path = Path.Combine(path, "AwsS3.xsd");
+                            break;
+                        case AwsEc2Descriptions.ServiceValue:
+                            path = Path.Combine(path, "AwsEc2.xsd");
+                            break;
+                    }
                     break;
                 default:
                     return !areSettingsValid;

--- a/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
@@ -31,7 +31,7 @@ namespace FRF.Core.XmlValidation
                             path = Path.Combine(path, "AwsS3.xsd");
                             break;
                         case AwsEc2Descriptions.ServiceValue:
-                            path = Path.Combine(path, "AwsEc2.xsd");
+                            path = Path.Combine(rootPath, "AwsEc2.xsd");
                             break;
                     }
                     break;

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingTermDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/PricingTermDTO.cs
@@ -6,6 +6,7 @@ namespace FRF.Web.Dtos.Artifacts
 {
     public class PricingTermDTO
     {
+        public string Product { get; set; }
         public string Sku { get; set; }
         public string Term { get; set; }
         public List<PricingDimensionDTO> PricingDimensions { get; set; }

--- a/FiveRockingFingers/FRF.Web/FRF.Web.csproj
+++ b/FiveRockingFingers/FRF.Web/FRF.Web.csproj
@@ -64,6 +64,13 @@
 		</ContentWithTargetPath>
 	</ItemGroup>
 
+  <ItemGroup>
+    <ContentWithTargetPath Include="..\..\FiveRockingFingers\FRF.Core\XmlValidation\AwsEc2.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>AwsEc2.xsd</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
+
 	<Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">

--- a/test/FRF.Core.Tests/FRF.Core.Tests.csproj
+++ b/test/FRF.Core.Tests/FRF.Core.Tests.csproj
@@ -27,4 +27,11 @@
     </ContentWithTargetPath>
   </ItemGroup>
 
+  <ItemGroup>
+    <ContentWithTargetPath Include="..\..\FiveRockingFingers\FRF.Core\XmlValidation\AwsEc2.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>AwsEc2.xsd</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
+
 </Project>

--- a/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Test.cs
+++ b/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Test.cs
@@ -1,0 +1,237 @@
+﻿using FRF.Core.Models.AwsArtifacts;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace FRF.Core.Tests.Models.AwsArtifacts
+{
+    public class AwsEc2Test
+    {
+        private readonly AwsEc2 _classUnderTest;
+
+        public AwsEc2Test()
+        {
+            _classUnderTest = new AwsEc2();
+        }
+
+        [Fact]
+        public void GetPrice_Gp2()
+        {
+            // Arrange
+
+            const decimal FinalCost = 1231.5354194444444444444444444m;
+
+            _classUnderTest.Settings = CreateArtifactSettingsGp2();
+
+            // Act
+            var result = _classUnderTest.GetPrice();
+            // Assert
+            Assert.IsType<decimal>(result);
+            Assert.Equal(FinalCost, result);
+        }
+
+        [Fact]        
+        public void GetPrice_Gp3()
+        {
+            // Arrange
+
+            const decimal FinalCost = 1241.6154194444444444444444444m;
+
+            _classUnderTest.Settings = CreateArtifactSettingsGp3();
+
+            // Act
+            var result = _classUnderTest.GetPrice();
+            // Assert
+            Assert.IsType<decimal>(result);
+            Assert.Equal(FinalCost, result);
+        }
+
+        [Fact]
+        public void GetPrice_Io1()
+        {
+            // Arrange
+
+            const decimal FinalCost = 1520.0754194444444444444444444m;
+
+            _classUnderTest.Settings = CreateArtifactSettingsIo1();
+
+            // Act
+            var result = _classUnderTest.GetPrice();
+            // Assert
+            Assert.IsType<decimal>(result);
+            Assert.Equal(FinalCost, result);
+        }
+
+        #region CreateArtifactSettingsGp2
+        private XElement CreateArtifactSettingsGp2()
+        {
+            XElement settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),                        
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("pricingDimensions", 
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("volumeApiName", "gp2"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.1200000000)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                );
+
+            return settings;
+        }
+        #endregion
+        #region CreateArtifactSettingsGp3
+        private XElement CreateArtifactSettingsGp3()
+        {
+            XElement settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("volumeApiName", "gp3"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.096)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product3",
+                        new XElement("numberOfIopsPerMonth", 4000),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.006)
+                            )
+                        )
+                    ),
+                    new XElement("product4",
+                        new XElement("numberOfMbpsThroughput", 225),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 49.1520000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                );
+
+            return settings;
+        }
+        #endregion
+        #region CreateArtifactSettingsIo1
+        private XElement CreateArtifactSettingsIo1()
+        {
+            XElement settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("volumeApiName", "io1"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.138)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product3",
+                        new XElement("numberOfIopsPerMonth", 4000),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0720000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                );
+
+            return settings;
+        }
+        #endregion        
+    }
+}

--- a/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Test.cs
+++ b/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Test.cs
@@ -22,7 +22,7 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
         {
             // Arrange
 
-            const decimal FinalCost = 1231.5354194444444444444444444m;
+            const decimal FinalCost = 1241.7754194444444444444444444m;
 
             _classUnderTest.Settings = CreateArtifactSettingsGp2();
 
@@ -38,7 +38,7 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
         {
             // Arrange
 
-            const decimal FinalCost = 1241.6154194444444444444444444m;
+            const decimal FinalCost = 1251.8554194444444444444444444m;
 
             _classUnderTest.Settings = CreateArtifactSettingsGp3();
 
@@ -54,7 +54,7 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
         {
             // Arrange
 
-            const decimal FinalCost = 1520.0754194444444444444444444m;
+            const decimal FinalCost = 1530.3154194444444444444444444m;
 
             _classUnderTest.Settings = CreateArtifactSettingsIo1();
 
@@ -101,7 +101,17 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", AwsEc2Descriptions.IntraRegionDataTransfer),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", "Data Transfer Type"),
                         new XElement("pricingDimensions",
                             new XElement("range0",
                                 new XElement("pricePerUnit", 0.0100000000)
@@ -165,7 +175,17 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", AwsEc2Descriptions.IntraRegionDataTransfer),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", "Data Transfer Type"),
                         new XElement("pricingDimensions",
                             new XElement("range0",
                                 new XElement("pricePerUnit", 0.0100000000)
@@ -221,7 +241,17 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", AwsEc2Descriptions.IntraRegionDataTransfer),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransfer", 1024),
+                        new XElement("transferType", "Data Transfer Type"),
                         new XElement("pricingDimensions",
                             new XElement("range0",
                                 new XElement("pricePerUnit", 0.0100000000)

--- a/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Tests.cs
+++ b/test/FRF.Core.Tests/Models/AwsArtifacts/AwsEc2Tests.cs
@@ -1,4 +1,5 @@
-﻿using FRF.Core.Models.AwsArtifacts;
+﻿using FRF.Core.Models;
+using FRF.Core.Models.AwsArtifacts;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -8,26 +9,19 @@ using Xunit;
 
 namespace FRF.Core.Tests.Models.AwsArtifacts
 {
-    public class AwsEc2Test
+    public class AwsEc2Tests
     {
-        private readonly AwsEc2 _classUnderTest;
-
-        public AwsEc2Test()
-        {
-            _classUnderTest = new AwsEc2();
-        }
-
         [Fact]
         public void GetPrice_Gp2()
         {
             // Arrange
-
             const decimal FinalCost = 1241.7754194444444444444444444m;
-
-            _classUnderTest.Settings = CreateArtifactSettingsGp2();
+            var settings = CreateArtifactSettingsGp2();
+            var _classUnderTest = new AwsEc2(settings);
 
             // Act
             var result = _classUnderTest.GetPrice();
+
             // Assert
             Assert.IsType<decimal>(result);
             Assert.Equal(FinalCost, result);
@@ -39,11 +33,12 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
             // Arrange
 
             const decimal FinalCost = 1251.8554194444444444444444444m;
-
-            _classUnderTest.Settings = CreateArtifactSettingsGp3();
+            var settings = CreateArtifactSettingsGp3();
+            var _classUnderTest = new AwsEc2(settings);
 
             // Act
             var result = _classUnderTest.GetPrice();
+
             // Assert
             Assert.IsType<decimal>(result);
             Assert.Equal(FinalCost, result);
@@ -53,13 +48,13 @@ namespace FRF.Core.Tests.Models.AwsArtifacts
         public void GetPrice_Io1()
         {
             // Arrange
-
             const decimal FinalCost = 1530.3154194444444444444444444m;
-
-            _classUnderTest.Settings = CreateArtifactSettingsIo1();
+            var settings = CreateArtifactSettingsIo1();
+            var _classUnderTest = new AwsEc2(settings);
 
             // Act
             var result = _classUnderTest.GetPrice();
+
             // Assert
             Assert.IsType<decimal>(result);
             Assert.Equal(FinalCost, result);

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -439,6 +439,108 @@ namespace FRF.Core.Tests.Services
             }
         }
 
+        [Fact]
+        public async Task GetEc2ProductsAsync_ReturnProductsList()
+        {
+            // Arange
+            var serviceCode = "[Mock] Service Code";
+            var sku = "[Mock] Sku";
+            var term = "[Mock] Term";
+            var unit = "[Mock] Unit";
+            var endRange = "Inf";
+            var description = "[Mock] Description";
+            var rateCode = "[Mock] Rate Code";
+            var beginRange = "10";
+            var currency = "[Mock] Currency";
+            var pricePerUnit = "99.99";
+            var offerTermCode = "[Mock] Offer term code";
+            var leaseContractLength = "[Mock] Lease contract length";
+            var offeringClass = "[Mock] Offering class";
+            var purchaseOption = "[Mock] Purchase option";
+            var attributeName = "[Mock] Attribute name";
+            var attributeValue = "[Mock] Attribute value";
+
+            var response = GetProductsResponse(attributeName, attributeValue, sku, serviceCode, term, rateCode, unit,
+                endRange, description, beginRange, currency, pricePerUnit, offerTermCode, leaseContractLength,
+                offeringClass, purchaseOption);
+
+            var settings = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("location", "US West (N. California)"),
+                new KeyValuePair<string,string>("operatingSystem","Windows"),
+                new KeyValuePair<string,string>("preInstalledSw","SQL Ent"),
+                new KeyValuePair<string,string>("instanceType","t3a.xlarge"),
+                new KeyValuePair<string, string>("vcpu", "4"),
+                new KeyValuePair<string, string>("memory", "16 GiB"),
+                new KeyValuePair<string, string>("networkPerformance", "Up to 5 Gigabit"),
+                new KeyValuePair<string, string>("storage", "EBS only"),
+                new KeyValuePair<string, string>("volumeApiName", "gp2"),
+                new KeyValuePair<string, string>("transferType", "IntraRegion"),
+                new KeyValuePair<string, string>("fromLocation", "US West (N. California)"),
+                new KeyValuePair<string, string>("toLocation", "US West (N. California)")
+            };
+
+            _client
+                .Setup(mock => mock.GetProductsAsync(It.IsAny<GetProductsRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            // Act
+            var result = await _classUnderTest.GetProductsAsync(settings, "AmazonEC2");
+
+            // Assert
+            float.TryParse(beginRange, out float beginRangeFloat);
+            var endRangeFloat = -1f;
+
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            var resultValue = result.Value;
+            _client.Verify(mock => mock.GetProductsAsync(It.IsAny<GetProductsRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(6));
+            foreach (var pricingTerm in resultValue)
+            {
+                Assert.Equal(sku, pricingTerm.Sku);
+                Assert.Equal(term, pricingTerm.Term);
+                Assert.Equal(purchaseOption, pricingTerm.PurchaseOption);
+                Assert.Equal(offeringClass, pricingTerm.OfferingClass);
+                Assert.Equal(leaseContractLength, pricingTerm.LeaseContractLength);
+                Assert.Equal(beginRangeFloat, pricingTerm.PricingDimensions[0].BeginRange);
+                Assert.Equal(currency, pricingTerm.PricingDimensions[0].Currency);
+                Assert.Equal(description, pricingTerm.PricingDimensions[0].Description);
+                Assert.Equal(endRangeFloat, pricingTerm.PricingDimensions[0].EndRange);
+                Assert.Equal((decimal)float.Parse(pricePerUnit, CultureInfo.InvariantCulture), pricingTerm.PricingDimensions[0].PricePerUnit);
+                Assert.Equal(rateCode, pricingTerm.PricingDimensions[0].RateCode);
+                Assert.Equal(unit, pricingTerm.PricingDimensions[0].Unit);
+            }
+        }
+
+        [Fact]
+        public async Task GetEc2ProductsAsync_ReturnEmptyList()
+        {
+            // Arange
+
+            var settings = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("location", "US West (N. California)"),
+                new KeyValuePair<string,string>("operatingSystem","Windows"),
+                new KeyValuePair<string,string>("preInstalledSw","SQL Ent"),
+                new KeyValuePair<string,string>("instanceType","t3a.xlarge"),
+                new KeyValuePair<string, string>("vcpu", "4"),
+                new KeyValuePair<string, string>("memory", "16 GiB"),
+                new KeyValuePair<string, string>("networkPerformance", "Up to 5 Gigabit"),
+                new KeyValuePair<string, string>("storage", "EBS only"),
+                new KeyValuePair<string, string>("volumeApiName", "gp2"),
+                new KeyValuePair<string, string>("transferType", "IntraRegion"),
+                new KeyValuePair<string, string>("fromLocation", "US West (N. California)"),
+                new KeyValuePair<string, string>("toLocation", "US West (N. California)")
+            };
+
+            // Act
+            var result = await _classUnderTest.GetProductsAsync(settings, "AmazonEC2");
+
+            // Assert
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            Assert.True(result.Success);
+            Assert.Empty(result.Value);
+        }
+
         private GetProductsResponse GetProductsResponse(string attributeName, string attributeValue, string sku,
             string serviceCode, string term, string rateCode, string unit, string endRange, string description,
             string beginRange, string currency, string pricePerUnit, string offerTermCode, string leaseContractLength,

--- a/test/FRF.Core.Tests/XmlValidation/SettingsValidatorTest.cs
+++ b/test/FRF.Core.Tests/XmlValidation/SettingsValidatorTest.cs
@@ -29,10 +29,11 @@ namespace FRF.Core.Tests.XmlValidation
             return project;
         }
 
-        private ArtifactType CreateArtifactType()
+        private ArtifactType CreateArtifactType(string name)
         {
             var artifactType = new ArtifactType();
             artifactType.Id = 1;
+            artifactType.Name = name;
             artifactType.Description = "[Mock] Artifact type description";
 
             return artifactType;
@@ -53,7 +54,7 @@ namespace FRF.Core.Tests.XmlValidation
         public void ValidateSettings_CustomArtifactRetunsTrue()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var artifactType = CreateArtifactType(ArtifactTypes.Custom);
             artifactType.Provider = CreateProvider(ArtifactTypes.Custom);
             var project = CreateProject();
 
@@ -80,8 +81,482 @@ namespace FRF.Core.Tests.XmlValidation
         public void ValidateSettings_CustomArtifactRetunsFalse()
         {
             // Arange
-            var artifactType = CreateArtifactType();
+            var artifactType = CreateArtifactType(ArtifactTypes.Custom);
             artifactType.Provider = CreateProvider(ArtifactTypes.Custom);
+            var project = CreateProject();
+
+            var artifact = new Artifact()
+            {
+                Id = 1,
+                Name = "[Mock] Updated name",
+                CreatedDate = DateTime.Now,
+                ProjectId = project.Id,
+                Project = project,
+                ArtifactTypeId = artifactType.Id,
+                ArtifactType = artifactType,
+                Settings = new XElement("settings")
+            };
+
+            // Act
+            var result = _classUnderTest.ValidateSettings(artifact);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ValidateSettings_AwsEc2Gp2_RetunsTrue()
+        {
+            // Arange
+            var artifactType = CreateArtifactType(AwsEc2Descriptions.ServiceValue);
+            artifactType.Provider = CreateProvider(ArtifactTypes.Aws);
+            var project = CreateProject();
+
+            var artifact = new Artifact()
+            {
+                Id = 1,
+                Name = "[Mock] Updated name",
+                CreatedDate = DateTime.Now,
+                ProjectId = project.Id,
+                Project = project,
+                ArtifactTypeId = artifactType.Id,
+                ArtifactType = artifactType,
+                Settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Compute Instance"),
+                        new XElement("term", "Reserved"),
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("offeringClass", "Convertible"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("operatingSystem", "Windows"),
+                        new XElement("preInstalledSw", "SQL Ent"),
+                        new XElement("instanceType", "t3a.xlarge"),
+                        new XElement("vcpu", "4"),
+                        new XElement("memory", "16 GiB"),
+                        new XElement("networkPerformance", "Up to 5 Gigabit"),
+                        new XElement("storage", "EBS only"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Hrs"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Windows with SQL Server Enterprise (Amazon VPC), t3a.xlarge reserved instance applied"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("unit", "Quantity"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Upfront Fee"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.2TG2D8R56U"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Storage"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp2"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Gb-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.12 per GB-month of General Purpose SSD (gp2) provisioned storage - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.1200000000)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Storage Snapshot"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp2"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.055 per GB-Month of snapshot data stored - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Data Transfer"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("transferType", "IntraRegion"),
+                        new XElement("fromLocationType", "AWS Region"),
+                        new XElement("fromLocation", "US West (N. California)"),
+                        new XElement("toLocationType", "AWS Region"),
+                        new XElement("toLocation", "US West (N. California)"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.010 per GB Regional Data Transfer - in/out/between AZs or using public IP or Elastic IP addresses"),
+                                new XElement("rateCode", "FDJZG2WS6XZNB2B3.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                )
+            };
+
+            // Act
+            var result = _classUnderTest.ValidateSettings(artifact);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidateSettings_AwsEc2Gp3_RetunsTrue()
+        {
+            // Arange
+            var artifactType = CreateArtifactType(AwsEc2Descriptions.ServiceValue);
+            artifactType.Provider = CreateProvider(ArtifactTypes.Aws);
+            var project = CreateProject();
+
+            var artifact = new Artifact()
+            {
+                Id = 1,
+                Name = "[Mock] Updated name",
+                CreatedDate = DateTime.Now,
+                ProjectId = project.Id,
+                Project = project,
+                ArtifactTypeId = artifactType.Id,
+                ArtifactType = artifactType,
+                Settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Compute Instance"),
+                        new XElement("term", "Reserved"),
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("offeringClass", "Convertible"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("operatingSystem", "Windows"),
+                        new XElement("preInstalledSw", "SQL Ent"),
+                        new XElement("instanceType", "t3a.xlarge"),
+                        new XElement("vcpu", "4"),
+                        new XElement("memory", "16 GiB"),
+                        new XElement("networkPerformance", "Up to 5 Gigabit"),
+                        new XElement("storage", "EBS only"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Hrs"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Windows with SQL Server Enterprise (Amazon VPC), t3a.xlarge reserved instance applied"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("unit", "Quantity"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Upfront Fee"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.2TG2D8R56U"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Storage"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp3"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Gb-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.12 per GB-month of General Purpose SSD (gp2) provisioned storage - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.096)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Storage Snapshot"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp3"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.055 per GB-Month of snapshot data stored - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product3",
+                        new XElement("numberOfIopsPerMonth", 4000),
+                        new XElement("sku", "AW6X9CDG3FS9XTDS"),
+                        new XElement("productFamily", "System Operation"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp3"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "IOPS-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.072 per IOPS-month provisioned (io2) - US West (Northern California)"),
+                                new XElement("rateCode", "AW6X9CDG3FS9XTDS.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.006)
+                            )
+                        )
+                    ),
+                    new XElement("product4",
+                        new XElement("numberOfMbpsThroughput", 225),
+                        new XElement("sku", "AW6X9CDG3FS9XTDS"),
+                        new XElement("productFamily", "Provisioned Throughput"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "gp3"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GiBps-mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.048 per provisioned MiBps-month of gp3 - US West (N. California)"),
+                                new XElement("rateCode", "ZDC2V7MBY9Z73F7V.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 49.1520000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Data Transfer"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("transferType", "IntraRegion"),
+                        new XElement("fromLocationType", "AWS Region"),
+                        new XElement("fromLocation", "US West (N. California)"),
+                        new XElement("toLocationType", "AWS Region"),
+                        new XElement("toLocation", "US West (N. California)"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.010 per GB Regional Data Transfer - in/out/between AZs or using public IP or Elastic IP addresses"),
+                                new XElement("rateCode", "FDJZG2WS6XZNB2B3.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                )
+            };
+
+            // Act
+            var result = _classUnderTest.ValidateSettings(artifact);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidateSettings_AwsEc2Io1_RetunsTrue()
+        {
+            // Arange
+            var artifactType = CreateArtifactType(AwsEc2Descriptions.ServiceValue);
+            artifactType.Provider = CreateProvider(ArtifactTypes.Aws);
+            var project = CreateProject();
+
+            var artifact = new Artifact()
+            {
+                Id = 1,
+                Name = "[Mock] Updated name",
+                CreatedDate = DateTime.Now,
+                ProjectId = project.Id,
+                Project = project,
+                ArtifactTypeId = artifactType.Id,
+                ArtifactType = artifactType,
+                Settings = new XElement("settings",
+                    new XElement("product0",
+                        new XElement("hoursUsedPerMonth", 730),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Compute Instance"),
+                        new XElement("term", "Reserved"),
+                        new XElement("leaseContractLength", "3 yr"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("offeringClass", "Convertible"),
+                        new XElement("purchaseOption", "Partial Upfront"),
+                        new XElement("operatingSystem", "Windows"),
+                        new XElement("preInstalledSw", "SQL Ent"),
+                        new XElement("instanceType", "t3a.xlarge"),
+                        new XElement("vcpu", "4"),
+                        new XElement("memory", "16 GiB"),
+                        new XElement("networkPerformance", "Up to 5 Gigabit"),
+                        new XElement("storage", "EBS only"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Hrs"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Windows with SQL Server Enterprise (Amazon VPC), t3a.xlarge reserved instance applied"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.8225000000)
+                            ),
+                            new XElement("range1",
+                                new XElement("unit", "Quantity"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "Upfront Fee"),
+                                new XElement("rateCode", "WY6M7B237ABTJB8K.38NPMPTW36.2TG2D8R56U"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 21616)
+                            )
+                        )
+                    ),
+                    new XElement("product1",
+                        new XElement("numberOfGbStorageInEbs", 30),
+                        new XElement("sku", "WY6M7B237ABTJB8K"),
+                        new XElement("productFamily", "Storage"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "io1"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "Gb-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.12 per GB-month of General Purpose SSD (gp2) provisioned storage - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.138)
+                            )
+                        )
+                    ),
+                    new XElement("product2",
+                        new XElement("numberOfSnapshotsPerMonth", 59.83),
+                        new XElement("numberOfGbChangedPerSnapshot", 3),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Storage Snapshot"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "io1"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.055 per GB-Month of snapshot data stored - US West (Northern California)"),
+                                new XElement("rateCode", "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0550000000)
+                            )
+                        )
+                    ),
+                    new XElement("product3",
+                        new XElement("numberOfIopsPerMonth", 4000),
+                        new XElement("sku", "AW6X9CDG3FS9XTDS"),
+                        new XElement("productFamily", "System Operation"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("volumeApiName", "io1"),
+                        new XElement("location", "US West (N. California)"),
+                        new XElement("locationType", "AWS Region"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "IOPS-Mo"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.072 per IOPS-month provisioned (io2) - US West (Northern California)"),
+                                new XElement("rateCode", "AW6X9CDG3FS9XTDS.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0720000000)
+                            )
+                        )
+                    ),
+                    new XElement("product5",
+                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("sku", "3F2BXQPS4TRZ6SR6"),
+                        new XElement("productFamily", "Data Transfer"),
+                        new XElement("term", "OnDemand"),
+                        new XElement("transferType", "IntraRegion"),
+                        new XElement("fromLocationType", "AWS Region"),
+                        new XElement("fromLocation", "US West (N. California)"),
+                        new XElement("toLocationType", "AWS Region"),
+                        new XElement("toLocation", "US West (N. California)"),
+                        new XElement("pricingDimensions",
+                            new XElement("range0",
+                                new XElement("unit", "GB"),
+                                new XElement("endRange", -1),
+                                new XElement("description", "$0.010 per GB Regional Data Transfer - in/out/between AZs or using public IP or Elastic IP addresses"),
+                                new XElement("rateCode", "FDJZG2WS6XZNB2B3.JRTCKXETXF.6YS6EN2CT7"),
+                                new XElement("beginRange", 0),
+                                new XElement("currency", "USD"),
+                                new XElement("pricePerUnit", 0.0100000000)
+                            )
+                        )
+                    )
+                )
+            };
+
+            // Act
+            var result = _classUnderTest.ValidateSettings(artifact);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidateSettings_AwsEc2RetunsFalse()
+        {
+            // Arange
+            var artifactType = CreateArtifactType(AwsEc2Descriptions.ServiceValue);
+            artifactType.Provider = CreateProvider(ArtifactTypes.Aws);
             var project = CreateProject();
 
             var artifact = new Artifact()

--- a/test/FRF.Core.Tests/XmlValidation/SettingsValidatorTest.cs
+++ b/test/FRF.Core.Tests/XmlValidation/SettingsValidatorTest.cs
@@ -202,7 +202,7 @@ namespace FRF.Core.Tests.XmlValidation
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
                         new XElement("sku", "3F2BXQPS4TRZ6SR6"),
                         new XElement("productFamily", "Data Transfer"),
                         new XElement("term", "OnDemand"),
@@ -371,7 +371,7 @@ namespace FRF.Core.Tests.XmlValidation
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
                         new XElement("sku", "3F2BXQPS4TRZ6SR6"),
                         new XElement("productFamily", "Data Transfer"),
                         new XElement("term", "OnDemand"),
@@ -520,7 +520,7 @@ namespace FRF.Core.Tests.XmlValidation
                         )
                     ),
                     new XElement("product5",
-                        new XElement("numberOfGbTransferIntraRegion", 1024),
+                        new XElement("numberOfGbTransfer", 1024),
                         new XElement("sku", "3F2BXQPS4TRZ6SR6"),
                         new XElement("productFamily", "Data Transfer"),
                         new XElement("term", "OnDemand"),


### PR DESCRIPTION
Se debe crear una clase que represente el servicio AmazonEC2 (la clase se llama AwsEc2) y que contenga un método capaz de calcular el precio final de un artefacto de este tipo. Esta clase hereda de la clase Artifact y todas las variables necesarias para realizar el cálculo de precio son tomadas de la propiedad Settings.

Además se debe crear un archivo xsd para que se validen las settings de un artefacto AmazonEC2 al momento de ser guardado o de ser actualizado y de esta forma evitar problemas en el futuro al querer usar el método GetPrice y no encontrar los nodos necesarios en el XML correspondiente a las settings.