### PR TITLE
[Five-302] (DAL) Crear implementacion de precios para Artifact AWS EC2

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -47,6 +47,8 @@ namespace FRF.Core.Services
                     {
                         case AwsS3Descriptions.Service:
                             return _mapper.Map<AwsS3>(artifact);
+                        case AwsEc2Descriptions.ServiceValue:
+                            return _mapper.Map<AwsS3>(artifact);
                         default:
                             return _mapper.Map<Artifact>(artifact);
                     }

--- a/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/AwsArtifactsProviderService.cs
@@ -295,30 +295,30 @@ namespace FRF.Core.Services
         private async Task<ServiceResponse<List<PricingTerm>>> GetEc2ProductsAsync(List<KeyValuePair<string, string>> settings)
         {
             //Filters get from settings
-            Filter locationFilter = new Filter { Field = AwsEc2Descriptions.Location, Type = "TERM_MATCH", Value = "" };
-            Filter operatingSystemFilter = new Filter { Field = AwsEc2Descriptions.OperatingSystem, Type = "TERM_MATCH", Value = "" };
-            Filter preInstalledSwFilter = new Filter { Field = AwsEc2Descriptions.PreInstalledSw, Type = "TERM_MATCH", Value = "" };
-            Filter instanceTypeFilter = new Filter { Field = AwsEc2Descriptions.InstanceType, Type = "TERM_MATCH", Value = "" };
-            Filter vcpuFilter = new Filter { Field = AwsEc2Descriptions.Vcpu, Type = "TERM_MATCH", Value = "" };
-            Filter memoryFilter = new Filter { Field = AwsEc2Descriptions.Memory, Type = "TERM_MATCH", Value = "" };
-            Filter networkPerformanceFilter = new Filter { Field = AwsEc2Descriptions.NetworkPerformance, Type = "TERM_MATCH", Value = "" };
-            Filter storageFilter = new Filter { Field = AwsEc2Descriptions.Storage, Type = "TERM_MATCH", Value = "" };
-            Filter volumeApiNameFilter = new Filter { Field = AwsEc2Descriptions.VolumeApiName, Type = "TERM_MATCH", Value = "" };
-            Filter transferTypeFilter = new Filter { Field = AwsEc2Descriptions.TransferType, Type = "TERM_MATCH", Value = "" };
-            Filter fromLocationFilter = new Filter { Field = AwsEc2Descriptions.FromLocation, Type = "TERM_MATCH", Value = "" };
-            Filter toLocationFilter = new Filter { Field = AwsEc2Descriptions.ToLocation, Type = "TERM_MATCH", Value = "" };
+            var locationFilter = new Filter { Field = AwsEc2Descriptions.Location, Type = "TERM_MATCH", Value = "" };
+            var operatingSystemFilter = new Filter { Field = AwsEc2Descriptions.OperatingSystem, Type = "TERM_MATCH", Value = "" };
+            var preInstalledSwFilter = new Filter { Field = AwsEc2Descriptions.PreInstalledSw, Type = "TERM_MATCH", Value = "" };
+            var instanceTypeFilter = new Filter { Field = AwsEc2Descriptions.InstanceType, Type = "TERM_MATCH", Value = "" };
+            var vcpuFilter = new Filter { Field = AwsEc2Descriptions.Vcpu, Type = "TERM_MATCH", Value = "" };
+            var memoryFilter = new Filter { Field = AwsEc2Descriptions.Memory, Type = "TERM_MATCH", Value = "" };
+            var networkPerformanceFilter = new Filter { Field = AwsEc2Descriptions.NetworkPerformance, Type = "TERM_MATCH", Value = "" };
+            var storageFilter = new Filter { Field = AwsEc2Descriptions.Storage, Type = "TERM_MATCH", Value = "" };
+            var volumeApiNameFilter = new Filter { Field = AwsEc2Descriptions.VolumeApiName, Type = "TERM_MATCH", Value = "" };
+            var transferTypeFilter = new Filter { Field = AwsEc2Descriptions.TransferType, Type = "TERM_MATCH", Value = "" };
+            var fromLocationFilter = new Filter { Field = AwsEc2Descriptions.FromLocation, Type = "TERM_MATCH", Value = "" };
+            var toLocationFilter = new Filter { Field = AwsEc2Descriptions.ToLocation, Type = "TERM_MATCH", Value = "" };
 
             //Filters that don't came in the settings
-            Filter locationTypeFilter = new Filter { Field = AwsEc2Descriptions.LocationType, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
-            Filter toLocationTypeFilter = new Filter { Field = AwsEc2Descriptions.ToLocationType, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
-            Filter fromLocationTypeFilter = new Filter { Field = AwsEc2Descriptions.FromLocation, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
-            Filter serviceCodeFilter = new Filter { Field = AwsEc2Descriptions.ServiceCode, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ServiceValue };
-            Filter productFamilyComputeInstanceFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyComputeInstanceValue };
-            Filter productFamilyEbsStorageFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsStorageValue };
-            Filter productFamilyEbsSnapshotFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsSnapshotsValue };
-            Filter productFamilyIopsFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsIopsValue };
-            Filter productFamilyThroughputFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsThroughputValue };
-            Filter productFamilyDataTransferFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyDataTransferValue };
+            var locationTypeFilter = new Filter { Field = AwsEc2Descriptions.LocationType, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
+            var toLocationTypeFilter = new Filter { Field = AwsEc2Descriptions.ToLocationType, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
+            var fromLocationTypeFilter = new Filter { Field = AwsEc2Descriptions.FromLocationType, Type = "TERM_MATCH", Value = AwsEc2Descriptions.LocationTypeValue };
+            var serviceCodeFilter = new Filter { Field = AwsEc2Descriptions.ServiceCode, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ServiceValue };
+            var productFamilyComputeInstanceFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyComputeInstanceValue };
+            var productFamilyEbsStorageFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsStorageValue };
+            var productFamilyEbsSnapshotFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsSnapshotsValue };
+            var productFamilyIopsFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsIopsValue };
+            var productFamilyThroughputFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyEbsThroughputValue };
+            var productFamilyDataTransferFilter = new Filter { Field = AwsEc2Descriptions.ProductFamily, Type = "TERM_MATCH", Value = AwsEc2Descriptions.ProductFamilyDataTransferValue };
             
             var pricingDetailsList = new List<PricingTerm>();
 

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -439,6 +439,108 @@ namespace FRF.Core.Tests.Services
             }
         }
 
+        [Fact]
+        public async Task GetEc2ProductsAsync_ReturnProductsList()
+        {
+            // Arange
+            var serviceCode = "[Mock] Service Code";
+            var sku = "[Mock] Sku";
+            var term = "[Mock] Term";
+            var unit = "[Mock] Unit";
+            var endRange = "Inf";
+            var description = "[Mock] Description";
+            var rateCode = "[Mock] Rate Code";
+            var beginRange = "10";
+            var currency = "[Mock] Currency";
+            var pricePerUnit = "99.99";
+            var offerTermCode = "[Mock] Offer term code";
+            var leaseContractLength = "[Mock] Lease contract length";
+            var offeringClass = "[Mock] Offering class";
+            var purchaseOption = "[Mock] Purchase option";
+            var attributeName = "[Mock] Attribute name";
+            var attributeValue = "[Mock] Attribute value";
+
+            var response = GetProductsResponse(attributeName, attributeValue, sku, serviceCode, term, rateCode, unit,
+                endRange, description, beginRange, currency, pricePerUnit, offerTermCode, leaseContractLength,
+                offeringClass, purchaseOption);
+
+            var settings = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("location", "US West (N. California)"),
+                new KeyValuePair<string,string>("operatingSystem","Windows"),
+                new KeyValuePair<string,string>("preInstalledSw","SQL Ent"),
+                new KeyValuePair<string,string>("instanceType","t3a.xlarge"),
+                new KeyValuePair<string, string>("vcpu", "4"),
+                new KeyValuePair<string, string>("memory", "16 GiB"),
+                new KeyValuePair<string, string>("networkPerformance", "Up to 5 Gigabit"),
+                new KeyValuePair<string, string>("storage", "EBS only"),
+                new KeyValuePair<string, string>("volumeApiName", "gp2"),
+                new KeyValuePair<string, string>("transferType", "IntraRegion"),
+                new KeyValuePair<string, string>("fromLocation", "US West (N. California)"),
+                new KeyValuePair<string, string>("toLocation", "US West (N. California)")
+            };
+
+            _client
+                .Setup(mock => mock.GetProductsAsync(It.IsAny<GetProductsRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            // Act
+            var result = await _classUnderTest.GetProductsAsync(settings, "AmazonEC2");
+
+            // Assert
+            float.TryParse(beginRange, out float beginRangeFloat);
+            var endRangeFloat = -1f;
+
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            var resultValue = result.Value;
+            _client.Verify(mock => mock.GetProductsAsync(It.IsAny<GetProductsRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(6));
+            foreach (var pricingTerm in resultValue)
+            {
+                Assert.Equal(sku, pricingTerm.Sku);
+                Assert.Equal(term, pricingTerm.Term);
+                Assert.Equal(purchaseOption, pricingTerm.PurchaseOption);
+                Assert.Equal(offeringClass, pricingTerm.OfferingClass);
+                Assert.Equal(leaseContractLength, pricingTerm.LeaseContractLength);
+                Assert.Equal(beginRangeFloat, pricingTerm.PricingDimensions[0].BeginRange);
+                Assert.Equal(currency, pricingTerm.PricingDimensions[0].Currency);
+                Assert.Equal(description, pricingTerm.PricingDimensions[0].Description);
+                Assert.Equal(endRangeFloat, pricingTerm.PricingDimensions[0].EndRange);
+                Assert.Equal((decimal)float.Parse(pricePerUnit, CultureInfo.InvariantCulture), pricingTerm.PricingDimensions[0].PricePerUnit);
+                Assert.Equal(rateCode, pricingTerm.PricingDimensions[0].RateCode);
+                Assert.Equal(unit, pricingTerm.PricingDimensions[0].Unit);
+            }
+        }
+
+        [Fact]
+        public async Task GetEc2ProductsAsync_ReturnEmptyList()
+        {
+            // Arange
+
+            var settings = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("location", "US West (N. California)"),
+                new KeyValuePair<string,string>("operatingSystem","Windows"),
+                new KeyValuePair<string,string>("preInstalledSw","SQL Ent"),
+                new KeyValuePair<string,string>("instanceType","t3a.xlarge"),
+                new KeyValuePair<string, string>("vcpu", "4"),
+                new KeyValuePair<string, string>("memory", "16 GiB"),
+                new KeyValuePair<string, string>("networkPerformance", "Up to 5 Gigabit"),
+                new KeyValuePair<string, string>("storage", "EBS only"),
+                new KeyValuePair<string, string>("volumeApiName", "gp2"),
+                new KeyValuePair<string, string>("transferType", "IntraRegion"),
+                new KeyValuePair<string, string>("fromLocation", "US West (N. California)"),
+                new KeyValuePair<string, string>("toLocation", "US West (N. California)")
+            };
+
+            // Act
+            var result = await _classUnderTest.GetProductsAsync(settings, "AmazonEC2");
+
+            // Assert
+            Assert.IsType<ServiceResponse<List<PricingTerm>>>(result);
+            Assert.True(result.Success);
+            Assert.Empty(result.Value);
+        }
+
         private GetProductsResponse GetProductsResponse(string attributeName, string attributeValue, string sku,
             string serviceCode, string term, string rateCode, string unit, string endRange, string description,
             string beginRange, string currency, string pricePerUnit, string offerTermCode, string leaseContractLength,


### PR DESCRIPTION
En el PR #97 se incorporó un método al cual se le envían todos las settings de un artefacto AmazonS3 y el método devuelve todos los precios que hacen al precio total del S3. En este PR se busca lo mismo para el AmazonEC2. Por ejemplo si le envío al método GetProductsAsync del Controller AwsArtifactsProviderController las siguientes settings de un servicio AmazonEC2:
```
[
  {"key": "location", "value": "US West (N. California)"},
  {"key": "operatingSystem", "value": "Windows"},
  {"key": "preInstalledSw", "value": "SQL Ent"},
  {"key": "instanceType", "value": "t3a.xlarge"},
  {"key": "vcpu", "value": "4"},
  {"key": "memory", "value": "16 GiB"},
  {"key": "networkPerformance", "value": "Up to 5 Gigabit"},
  {"key": "storage", "value": "EBS only"},
  {"key": "volumeApiName", "value": "gp2"},
  {"key": "transferType", "value": "IntraRegion"},
  {"key": "fromLocation", "value": "US West (N. California)"},
  {"key": "toLocation", "value": "US West (N. California)"},
]
```
Espero tener la siguiente respuesta:
```
[
  {
    "product": "Compute Instance",
    "sku": "WY6M7B237ABTJB8K",
    "term": "Reserved",
    "pricingDimensions": [
      {
        "unit": "Hrs",
        "endRange": -1,
        "description": "USD 0.0 per Windows with SQL Server Enterprise (Amazon VPC), t3a.xlarge reserved instance applied",
        "rateCode": "WY6M7B237ABTJB8K.MZU6U2429S.6YS6EN2CT7",
        "beginRange": 0,
        "currency": "USD",
        "pricePerUnit": 0
      },
      {
        "unit": "Quantity",
        "endRange": 0,
        "description": "Upfront Fee",
        "rateCode": "WY6M7B237ABTJB8K.MZU6U2429S.2TG2D8R56U",
        "beginRange": 0,
        "currency": "USD",
        "pricePerUnit": 43797
      }
    ],
    "leaseContractLength": "3yr",
    "offeringClass": "convertible",
    "purchaseOption": "All Upfront"
  },
  {
    "product": "Storage",
    "sku": "UZ6TZ5NDAH7AGJPJ",
    "term": "OnDemand",
    "pricingDimensions": [
      {
        "unit": "GB-Mo",
        "endRange": -1,
        "description": "$0.12 per GB-month of General Purpose SSD (gp2) provisioned storage - US West (Northern California)",
        "rateCode": "UZ6TZ5NDAH7AGJPJ.JRTCKXETXF.6YS6EN2CT7",
        "beginRange": 0,
        "currency": "USD",
        "pricePerUnit": 0.12
      }
    ],
    "leaseContractLength": null,
    "offeringClass": null,
    "purchaseOption": null
  },
  {
    "product": "Storage Snapshot",
    "sku": "3F2BXQPS4TRZ6SR6",
    "term": "OnDemand",
    "pricingDimensions": [
      {
        "unit": "GB-Mo",
        "endRange": -1,
        "description": "$0.055 per GB-Month of snapshot data stored - US West (Northern California)",
        "rateCode": "3F2BXQPS4TRZ6SR6.JRTCKXETXF.6YS6EN2CT7",
        "beginRange": 0,
        "currency": "USD",
        "pricePerUnit": 0.055
      }
    ],
    "leaseContractLength": null,
    "offeringClass": null,
    "purchaseOption": null
  },
  {
    "product": "Data Transfer",
    "sku": "FDJZG2WS6XZNB2B3",
    "term": "OnDemand",
    "pricingDimensions": [
      {
        "unit": "GB",
        "endRange": -1,
        "description": "$0.010 per GB Regional Data Transfer - in/out/between AZs or using public IP or Elastic IP addresses",
        "rateCode": "FDJZG2WS6XZNB2B3.JRTCKXETXF.6YS6EN2CT7",
        "beginRange": 0,
        "currency": "USD",
        "pricePerUnit": 0.01
      }
    ],
    "leaseContractLength": null,
    "offeringClass": null,
    "purchaseOption": null
  }
]
```
Siendo Compute Instance, Storage, Storage Snapshot, Data Transfer 4 de los 6 posibles componentes que tendrá el precio final del servicio