### PR TITLE
[Five-324] Corregir métodos Save, Update y GetAllRelationsOfAnArtifactAsync en el servicio de Artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -43,15 +43,20 @@ namespace FRF.Core.Services
                 case ArtifactTypes.Custom:
                     return _mapper.Map<CustomArtifact>(artifact);
                 case ArtifactTypes.Aws:
-                    switch (artifact.ArtifactType.Name)
-                    {
-                        case AwsS3Descriptions.Service:
-                            return _mapper.Map<AwsS3>(artifact);
-                        case AwsEc2Descriptions.ServiceValue:
-                            return _mapper.Map<AwsEc2>(artifact);
-                        default:
-                            return _mapper.Map<Artifact>(artifact);
-                    }
+                    return MapAwsArtifact(artifact);
+                default:
+                    return _mapper.Map<Artifact>(artifact);
+            }
+        }
+
+        private Artifact MapAwsArtifact(EntityModels.Artifact artifact)
+        {
+            switch (artifact.ArtifactType.Name)
+            {
+                case AwsS3Descriptions.Service:
+                    return _mapper.Map<AwsS3>(artifact);
+                case AwsEc2Descriptions.ServiceValue:
+                    return _mapper.Map<AwsEc2>(artifact);
                 default:
                     return _mapper.Map<Artifact>(artifact);
             }

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -221,11 +221,15 @@ namespace FRF.Core.Services
                 return new ServiceResponse<Artifact>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {artifact.ProjectId}"));
             }
 
-            if (!await _dataContext.ArtifactType.AnyAsync(at => at.Id == artifact.ArtifactTypeId))
+            var artifactType = await _dataContext.ArtifactType.Include(at => at.Provider).SingleOrDefaultAsync(at => at.Id == artifact.ArtifactTypeId);
+
+            if (artifactType == null)
             {
                 return new ServiceResponse<Artifact>(new Error(ErrorCodes.ArtifactTypeNotExists, $"There is no artifact type with Id = {artifact.ArtifactTypeId}"));
             }
-            
+
+            artifact.ArtifactType = _mapper.Map<ArtifactType>(artifactType);
+
             if (!_settingsValidator.ValidateSettings(artifact))
             {
                 return new ServiceResponse<Artifact>(new Error(ErrorCodes.InvalidArtifactSettings, $"Settings are invalid"));

--- a/FiveRockingFingers/FRF.Core/XmlValidation/AwsS3.xsd
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/AwsS3.xsd
@@ -10,16 +10,16 @@
 				<xs:element name="writeRequestsUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 				<xs:element name="retrieveRequestsUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 				<xs:element name="storageUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
-				<!--<xs:element name="infrequentAccessMultiplier" type="xs:decimal" minOccurs="0" maxOccurs="1"  nillable="true"/>-->
+				<xs:element name="infrequentAccessMultiplier" type="xs:decimal" minOccurs="0" maxOccurs="1"  nillable="true"/>
 				<!--This part is related to the price per storage used-->
 				<xs:element name="product0" minOccurs="1" maxOccurs="1">
 					<xs:complexType>
 						<xs:sequence>
               <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
-							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="pricingDimension">
 								<xs:complexType>
 									<xs:sequence>
@@ -74,9 +74,9 @@
 						<xs:sequence>
               <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
-							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="pricingDimension">
 								<xs:complexType>
 									<xs:sequence>
@@ -105,9 +105,9 @@
 						<xs:sequence>
               <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
-							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
-							<xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
+              <xs:element name="purchaseOption" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="pricingDimension">
 								<xs:complexType>
 									<xs:sequence>
@@ -131,7 +131,6 @@
 					</xs:complexType>
 				</xs:element>
 				<!--This part is related to the price of storage used in Intelligent-Tiering, Infrequent Access Tier -->
-        <!--
 				<xs:element name="product3" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence>
@@ -162,7 +161,6 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-        -->
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>

--- a/FiveRockingFingers/FRF.Core/XmlValidation/AwsS3.xsd
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/AwsS3.xsd
@@ -6,14 +6,16 @@
 	<xs:element name="settings">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="writeRequestsUsed" type="xs:int" minOccurs="1" maxOccurs="1" />
-				<xs:element name="retrieveRequestsUsed" type="xs:int" minOccurs="1" maxOccurs="1" />
-				<xs:element name="storageUsed" type="xs:int" minOccurs="1" maxOccurs="1" />
-				<xs:element name="infrequentAccessMultiplier" type="xs:int" minOccurs="0" maxOccurs="1"  nillable="true"/>
+        <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1" />
+				<xs:element name="writeRequestsUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
+				<xs:element name="retrieveRequestsUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
+				<xs:element name="storageUsed" type="xs:decimal" minOccurs="1" maxOccurs="1" />
+				<!--<xs:element name="infrequentAccessMultiplier" type="xs:decimal" minOccurs="0" maxOccurs="1"  nillable="true"/>-->
 				<!--This part is related to the price per storage used-->
-				<xs:element name="product0">
+				<xs:element name="product0" minOccurs="1" maxOccurs="1">
 					<xs:complexType>
 						<xs:sequence>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
@@ -28,9 +30,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -41,9 +43,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -54,9 +56,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -67,9 +69,10 @@
 					</xs:complexType>
 				</xs:element>
 				<!--This part is related to PUT, COPY, POST, or LIST requests-->
-				<xs:element name="product1">
+				<xs:element name="product1" minOccurs="1" maxOccurs="1">
 					<xs:complexType>
 						<xs:sequence>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
@@ -84,9 +87,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -97,9 +100,10 @@
 					</xs:complexType>
 				</xs:element>
 				<!--This part is related to GET and all other requests-->
-				<xs:element name="product2">
+				<xs:element name="product2" minOccurs="1" maxOccurs="1">
 					<xs:complexType>
 						<xs:sequence>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
@@ -114,9 +118,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -127,9 +131,11 @@
 					</xs:complexType>
 				</xs:element>
 				<!--This part is related to the price of storage used in Intelligent-Tiering, Infrequent Access Tier -->
+        <!--
 				<xs:element name="product3" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence>
+              <xs:element name="sku" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="term" type="xs:string" minOccurs="1" maxOccurs="1" />
 							<xs:element name="leaseContractLength" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
 							<xs:element name="offeringClass" type="xs:string" minOccurs="1" maxOccurs="1" nillable="true" />
@@ -144,9 +150,9 @@
 													<xs:element name="endRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
 													<xs:element name="rateCode" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="beginRange" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="beginRange" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 													<xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="1" />
-													<xs:element name="pricePerUnit" type="xs:string" minOccurs="1" maxOccurs="1" />
+													<xs:element name="pricePerUnit" type="xs:decimal" minOccurs="1" maxOccurs="1" />
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -156,6 +162,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
+        -->
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>

--- a/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
@@ -25,7 +25,7 @@ namespace FRF.Core.XmlValidation
                     path = Path.Combine(rootPath, "CustomArtifact.xsd");
                     break;
                 case ArtifactTypes.Aws:
-                    path = Path.Combine(path, "AwsS3.xsd");
+                    path = Path.Combine(rootPath, "AwsS3.xsd");
                     break;
                 default:
                     return !areSettingsValid;

--- a/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
+++ b/FiveRockingFingers/FRF.Core/XmlValidation/SettingsValidator.cs
@@ -25,15 +25,12 @@ namespace FRF.Core.XmlValidation
                     path = Path.Combine(rootPath, "CustomArtifact.xsd");
                     break;
                 case ArtifactTypes.Aws:
-                    switch (artifact.ArtifactType.Name)
+                    var fileName = GetFileNameAwsArtifact(artifact.ArtifactType.Name);
+                    if(fileName.Equals(""))
                     {
-                        case AwsS3Descriptions.Service:
-                            path = Path.Combine(rootPath, "AwsS3.xsd");
-                            break;
-                        case AwsEc2Descriptions.ServiceValue:
-                            path = Path.Combine(rootPath, "AwsEc2.xsd");
-                            break;
+                        return !areSettingsValid;
                     }
+                    path = Path.Combine(rootPath, fileName);
                     break;
                 default:
                     return !areSettingsValid;
@@ -60,6 +57,23 @@ namespace FRF.Core.XmlValidation
             while (xr.Read()) { }
 
             return areSettingsValid;
+        }
+
+        private string GetFileNameAwsArtifact(string artifactType)
+        {
+            var fileName = "";
+
+            switch (artifactType)
+            {
+                case AwsS3Descriptions.Service:
+                    fileName = "AwsS3.xsd";
+                    break;
+                case AwsEc2Descriptions.ServiceValue:
+                    fileName = "AwsEc2.xsd";
+                    break;
+            }
+
+            return fileName;
         }
     }
 }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -433,9 +433,7 @@ namespace FRF.Core.Tests.Services
                 ArtifactTypeId = newArtifactType.Id,
                 ArtifactType = _mapper.Map<CoreModels.ArtifactType>(newArtifactType),
                 Settings = new XElement("Settings")
-            };
-
-            
+            };            
 
             _settingsValidator.Setup(mock => mock.ValidateSettings(It.IsAny<CoreModels.Artifact>()))
                 .Returns(true);
@@ -470,7 +468,7 @@ namespace FRF.Core.Tests.Services
         [Fact]
         public async Task UpdateAsync_ReturnsExceptionInvalidArtifactSettings()
         {
-            // Arange
+            /// Arange
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
@@ -488,7 +486,8 @@ namespace FRF.Core.Tests.Services
             var newArtifactType = new ArtifactType()
             {
                 Name = "[Mock] Artifact type name",
-                Description = "[Mock] Artifact type description"
+                Description = "[Mock] Artifact type description",
+                Provider = provider
             };
             _dataAccess.ArtifactType.Add(newArtifactType);
             _dataAccess.SaveChanges();
@@ -506,7 +505,7 @@ namespace FRF.Core.Tests.Services
             };
 
             // Act
-            var result = await _classUnderTest.Save(artifactToUpdate);
+            var result = await _classUnderTest.Update(artifactToUpdate);
 
             // Assert
             Assert.IsType<ServiceResponse<CoreModels.Artifact>>(result);

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -940,7 +940,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task GetAllRelationsOfAnArtifactAsync_ReturnsRelationNotExists()
+        public async Task GetAllRelationsOfAnArtifactAsync_ReturnsArtifactNotExists()
         {
             // Arange
             var artifactId = 0;
@@ -952,7 +952,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
+            Assert.Equal(ErrorCodes.ArtifactNotExists, response.Error.Code);
         }
 
         [Fact]

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -468,7 +468,7 @@ namespace FRF.Core.Tests.Services
         [Fact]
         public async Task UpdateAsync_ReturnsExceptionInvalidArtifactSettings()
         {
-            /// Arange
+            // Arange
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();


### PR DESCRIPTION
Se deben modificar los métodos Save y Update del servicio de artefactos para descomentar la sección que se encarga de la validación del xml correspondientes a las settings del artefacto que se quiere guardar o modificar. Para eso se debe buscar el tipo al cual corresponde el artefacto, al momento de realizar el Save o el Update, ya que la validación se realizara según el tipo de artefacto que sea.

El método GetAllRelationsOfAnArtifactAsync del servicio de artefactos se debe modificar para que devuelva un error en caso de que el artefacto, del cual se quieren obtener las relaciones, no exista.