### PR TITLE
[Five-330] (DAL) Añadir edición de artefactos custom

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -360,10 +360,10 @@ namespace FRF.Core.Services
                 {
                     return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotExists, $"There is no relation with Id={artifactRelationId}"));
                 }
-                artifactsRelations.Add(artifactsRelation);
-                _dataContext.ArtifactsRelation.Remove(artifactsRelation);
+                artifactsRelations.Add(artifactsRelation);                
             }
-            
+
+            _dataContext.ArtifactsRelation.RemoveRange(artifactsRelations);
             await _dataContext.SaveChangesAsync();
 
             return new ServiceResponse<IList<ArtifactsRelation>>(_mapper.Map<IList<ArtifactsRelation>>(artifactsRelations));

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using EntityModels = FRF.DataAccess.EntityModels;
 
 namespace FRF.Core.Services
@@ -240,6 +241,8 @@ namespace FRF.Core.Services
                 return new ServiceResponse<Artifact>(new Error(ErrorCodes.InvalidArtifactSettings, $"Settings are invalid"));
             }
 
+            await DeleteRelationsOfUpdatedArtifact(artifact.Id, artifact.Settings, result.Settings);
+
             //Updates the artifact
             result.Name = artifact.Name;
             result.Settings = artifact.Settings;
@@ -407,6 +410,46 @@ namespace FRF.Core.Services
             await _dataContext.SaveChangesAsync();
 
             return new ServiceResponse<IList<ArtifactsRelation>>(artifactsRelationsNew);
-        }        
+        }
+
+        private async Task DeleteRelationsOfUpdatedArtifact(int artifactId, XElement updatedSettings, XElement originalSettings)
+        {
+            var changedSettingsName = FindSettingsNamesChanged(updatedSettings, originalSettings);
+            var artifactsRelationsIdsToDelete = await GetRelationsToDeleteOfUpdatedArtifact(artifactId, changedSettingsName);
+            await DeleteRelationsAsync(artifactsRelationsIdsToDelete);
+        }
+
+        private List<string> FindSettingsNamesChanged(XElement updatedSettings, XElement originalSettings)
+        {
+            var changedSettingsName = new List<string>();
+
+            foreach(var setting in updatedSettings.Elements())
+            {
+                if(!setting.HasElements && originalSettings.Elements(setting.Name).Any())
+                {
+                    changedSettingsName.Add(setting.Name.ToString());
+                }
+            }
+
+            return changedSettingsName;
+        }
+
+        private async Task<List<Guid>> GetRelationsToDeleteOfUpdatedArtifact(int artifactId, List<string> changedSettingsName)
+        {
+            var relationsResponse = await GetAllRelationsOfAnArtifactAsync(artifactId);
+            var relations = relationsResponse.Value;
+
+            var artifactsRelationsIdsToDelete = new List<Guid>();
+
+            foreach (var relation in relations)
+            {
+                if(changedSettingsName.Contains(relation.Artifact1Property) || changedSettingsName.Contains(relation.Artifact2Property))
+                {
+                    artifactsRelationsIdsToDelete.Add(relation.Id);
+                }
+            }
+
+            return artifactsRelationsIdsToDelete;
+        }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -357,6 +357,14 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<IList<ArtifactsRelation>>> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
         {
+            var relationsIdFromDb = await _dataContext.ArtifactsRelation.Select(ar => ar.Id).ToListAsync();
+            var relationsThatDoNotExist = artifactRelationIds.Except(relationsIdFromDb).ToList();
+            if (relationsThatDoNotExist.Any())
+            {
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotExists,
+                    $"There is no relation with Id={string.Join(", Id=", relationsThatDoNotExist)}"));
+            }
+
             var artifactsRelations = await _dataContext.ArtifactsRelation.Where(ar => artifactRelationIds.Contains(ar.Id)).ToListAsync();
 
             _dataContext.ArtifactsRelation.RemoveRange(artifactsRelations);

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -350,20 +350,10 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<IList<ArtifactsRelation>>> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
         {
-            var artifactsRelations = new List<EntityModels.ArtifactsRelation>();
-
-            foreach (var artifactRelationId in artifactRelationIds)
-            {
-                var artifactsRelation = await _dataContext.ArtifactsRelation
-                .FirstOrDefaultAsync(ar => ar.Id.Equals(artifactRelationId));
-                if (artifactsRelation == null)
-                {
-                    return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotExists, $"There is no relation with Id={artifactRelationId}"));
-                }
-                artifactsRelations.Add(artifactsRelation);                
-            }
+            var artifactsRelations = await _dataContext.ArtifactsRelation.Where(ar => artifactRelationIds.Contains(ar.Id)).ToListAsync();
 
             _dataContext.ArtifactsRelation.RemoveRange(artifactsRelations);
+
             await _dataContext.SaveChangesAsync();
 
             return new ServiceResponse<IList<ArtifactsRelation>>(_mapper.Map<IList<ArtifactsRelation>>(artifactsRelations));

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -348,6 +348,27 @@ namespace FRF.Core.Services
             return new ServiceResponse<ArtifactsRelation>(_mapper.Map<ArtifactsRelation>(artifactsRelation));
         }
 
+        public async Task<ServiceResponse<IList<ArtifactsRelation>>> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
+        {
+            var artifactsRelations = new List<EntityModels.ArtifactsRelation>();
+
+            foreach (var artifactRelationId in artifactRelationIds)
+            {
+                var artifactsRelation = await _dataContext.ArtifactsRelation
+                .FirstOrDefaultAsync(ar => ar.Id.Equals(artifactRelationId));
+                if (artifactsRelation == null)
+                {
+                    return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotExists, $"There is no relation with Id={artifactRelationId}"));
+                }
+                artifactsRelations.Add(artifactsRelation);
+                _dataContext.ArtifactsRelation.Remove(artifactsRelation);
+            }
+            
+            await _dataContext.SaveChangesAsync();
+
+            return new ServiceResponse<IList<ArtifactsRelation>>(_mapper.Map<IList<ArtifactsRelation>>(artifactsRelations));
+        }
+
         public async Task<ServiceResponse<IList<ArtifactsRelation>>> UpdateRelationAsync(int artifactId,
             IList<ArtifactsRelation> artifactsRelationsNew)
         {

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
@@ -18,6 +18,7 @@ namespace FRF.Core.Services
         Task<ServiceResponse<IList<ArtifactsRelation>>> GetAllRelationsOfAnArtifactAsync(int artifactId);
         Task<ServiceResponse<IList<ArtifactsRelation>>> GetAllRelationsByProjectIdAsync(int projectId);
         Task<ServiceResponse<ArtifactsRelation>> DeleteRelationAsync(Guid artifactRelationId);
+        Task<ServiceResponse<IList<ArtifactsRelation>>> DeleteRelationsAsync(IList<Guid> artifactRelationIds);
         Task<ServiceResponse<IList<ArtifactsRelation>>> UpdateRelationAsync(int artifact1Id,
             IList<ArtifactsRelation> artifactsRelationsNew);
     }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -1,6 +1,6 @@
 ﻿import * as React from 'react';
 import { Table, Button } from 'reactstrap';
-import Artifact from '../../interfaces/Artifact'
+import Artifact from '../../interfaces/Artifact';
 import ArtifactsTableRow from './ArtifactsTableRow';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
@@ -10,6 +10,8 @@ import NewArtifactsRelation from '../NewArtifactsRelation';
 import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
+import ArtifactType from '../../interfaces/ArtifactType';
+import EditArtifactDialog from './EditArtifactDialog';
 
 const ArtifactsTable = (props: { projectId: number}) => {
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
@@ -17,6 +19,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
     const [showNewArtifactDialog, setShowNewArtifactDialog] = React.useState(false);
     const [showNewArtifactsRelation, setShowNewArtifactsRelation] = React.useState(false);
+    const [showEditArtifactDialog, setEditArtifactDialog] = React.useState(false);
+    const [artifactToEdit, setArtifactToEdit] = React.useState<Artifact | null>(null);
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
@@ -77,6 +81,15 @@ const ArtifactsTable = (props: { projectId: number}) => {
         }
     }
 
+    const openEditArtifactDialog = () => {
+        setEditArtifactDialog(true);
+    }
+
+    const closeEditArtifactDialog = () => {
+        setArtifactToEdit(null);
+        setEditArtifactDialog(false);
+    }
+
     const closeNewArtifactDialog = () => {
         setShowNewArtifactDialog(false);
     }
@@ -127,6 +140,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
                                 artifact={artifact}
                                 openSnackbar={manageOpenSnackbar}
                                 updateList={getArtifacts}
+                                setArtifactToEdit={setArtifactToEdit}
+                                openEditArtifactDialog={openEditArtifactDialog}
                             />
                             ) : null}
                         <ArtifactsTotalPrice totalPrice={price} projectBudget={projectBudget} /></>
@@ -157,6 +172,18 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 artifactsRelations={artifactsRelations}
                 updateList = {{update: false}}
             />
+            { artifactToEdit ?
+                <EditArtifactDialog
+                    showEditArtifactDialog={showEditArtifactDialog}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    setOpenSnackbar={setOpenSnackbar}
+                    setSnackbarSettings={setSnackbarSettings}
+                    artifactToEdit={artifactToEdit}
+                    updateArtifacts={getArtifacts}
+                    updateRelations={getRelations}
+                /> :
+                null
+            }
         </React.Fragment>
     );
 };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
@@ -3,12 +3,18 @@ import Artifact from '../../interfaces/Artifact';
 import { Button } from 'reactstrap';
 import ConfirmationDialog from './ConfirmationDialog';
 import { Link } from 'react-router-dom';
+import { PROVIDERS } from '../../Constants';
 
-const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, updateList: Function }) => {
+const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, updateList: Function, setArtifactToEdit: Function, openEditArtifactDialog: Function }) => {
     const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
 
     const deleteButtonClick = () => {
         setOpenConfirmDialog(true);
+    }
+
+    const handleModifyArtifactClick = () => {
+        props.setArtifactToEdit(props.artifact);
+        props.openEditArtifactDialog();
     }
 
     return (
@@ -18,25 +24,37 @@ const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, 
             <td>{props.artifact.provider}</td>
             <td>{props.artifact.artifactType.name}</td>
             <td>{props.artifact.price}</td>
-          <td >
-            <Button
-                className="mx-3" 
-                style={{ minHeight: "32px", width: "20%" }}
-              color="danger"
-              onClick={deleteButtonClick}
-            >
-              Borrar
-            </Button>
+            <td>                
+                <Button
+                    className="mx-3" 
+                    style={{ minHeight: "32px", width: "20%" }}
+                  color="danger"
+                  onClick={deleteButtonClick}
+                >
+                  Borrar
+                </Button>
 
-            <Button
-                style={{ minHeight: "32px", width: "20%" }}
-              color="info"
-              tag={Link}
-              to={`/projects/${props.artifact.projectId}/artifacts/${props.artifact.id}`}
-            >
-              Relaciones
-            </Button>
-          </td>
+                <Button
+                    style={{ minHeight: "32px", width: "20%" }}
+                  color="info"
+                  tag={Link}
+                  to={`/projects/${props.artifact.projectId}/artifacts/${props.artifact.id}`}
+                >
+                        Relaciones
+                </Button>
+
+                {props.artifact.artifactType.name === PROVIDERS[1] ?
+                    <Button
+                        className="mx-3"
+                        style={{ minHeight: "32px", width: "20%" }}
+                        color="warning"
+                        onClick={handleModifyArtifactClick}
+                    >
+                        Modificar
+                    </Button> :
+                    null
+                }
+            </td>
         </tr>
         <ConfirmationDialog
           open={openConfirmDialog}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -1,0 +1,379 @@
+﻿import { Button, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import * as React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import Typography from '@material-ui/core/Typography';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Setting from '../../interfaces/Setting';
+import Artifact from '../../interfaces/Artifact';
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        container: {
+            display: 'flex',
+            flexWrap: 'wrap',
+        },
+        formControl: {
+            margin: theme.spacing(1),
+            width: '100%'
+        },
+        inputF: {
+            padding: 2,
+            marginTop: 10
+        }
+    }),
+);
+
+const EditArtifact = (props: {
+    artifactToEdit: Artifact,
+    closeEditArtifactDialog: Function,
+    setIsArtifactEdited: Function,
+    setArtifactEdited: Function,
+    setNamesOfSettingsChanged: Function }) => {
+
+    const classes = useStyles();
+    const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
+    const { closeEditArtifactDialog } = props;
+
+
+
+    const createSettingsListFromArtifact = () => {
+        let settingsListFromArtifact: Setting[] = [];
+        if (props.artifactToEdit.id === 0) {
+            return settingsListFromArtifact;
+        }
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
+            settingsListFromArtifact.push(settingFromArtifact);
+        });
+        return settingsListFromArtifact;
+    }
+
+    //Hook for save the user's settings input
+    const [settingsList, setSettingsList] = React.useState<Setting[]>(createSettingsListFromArtifact());
+    const [price, setPrice] = React.useState(() => {
+        let index = settingsList.findIndex(s => s.name === 'price');
+        if (index != -1) {
+            let price = settingsList[index];
+            settingsList.splice(index, 1);
+            setSettingsList(settingsList);
+            return price.value;
+        }
+        return 0;
+    });
+    const [artifactName, setArtifactName] = React.useState(props.artifactToEdit.name);
+
+    const createSettingsMapFromArtifact = () => {
+        let settingsMapFromArtifact: { [key: string]: number[] } = {};
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            if (key !== 'price') {
+                settingsMapFromArtifact[key] = [index];
+            }            
+        });
+        return settingsMapFromArtifact;
+    }
+
+    //Hook for saving the numbers of times a setting's name input is repeated
+    const [settingsMap, setSettingsMap] = React.useState<{ [key: string]: number[] }>(createSettingsMapFromArtifact());
+
+    React.useEffect(() => {
+        setNameSettingsErrors();
+    }, [settingsMap, props.artifactToEdit]);
+
+    //Create the artifact after submit
+    const handleConfirm = async () => {
+        if (!settingsList.find(s => s.name === 'price')) {
+            settingsList.unshift({ name: 'price', value: price.toString() });
+        }
+        let artifactEdited = Object.create(props.artifactToEdit);
+        artifactEdited.name = artifactName;
+        artifactEdited.settings = createSettingsObject();
+        props.setArtifactEdited(artifactEdited);
+        props.setNamesOfSettingsChanged(getNamesOfSettingsChanged());
+        props.setIsArtifactEdited(true);
+    }
+
+    const getNamesOfSettingsChanged = () => {
+        let namesOfSettingsChanged : string[] = [];
+        let originalSettingsList = createSettingsListFromArtifact();
+        let index = originalSettingsList.findIndex(s => s.name === 'price');
+        if (index != -1) {
+            originalSettingsList.splice(index, 1);
+        }
+        originalSettingsList.forEach((setting, index) => {
+            if (!settingsList.find(s => s.name === setting.name)) {
+                namesOfSettingsChanged.push(setting.name);
+            }
+        });
+        return namesOfSettingsChanged;
+    }
+
+    const handleChangeName = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        setArtifactName(event.target.value);
+    }
+
+    const handleChangePrice = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        setPrice(parseInt(event.target.value, 10));
+    }
+
+    const isPriceValid = () => {
+        if (price >= 0) return true
+        return false
+    }
+
+    //Handle changes in the inputs fields
+    const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>, index: number) => {
+        let { name, value } = event.target;
+        name = name.split(".")[1];
+        if (name === 'name') {
+            checkSettingName(value, index);
+        }
+        const list = [...settingsList];
+        list[index][name] = value;
+        setSettingsList(list);
+    }
+
+    //Check if the setting's name the user enters has already have been used
+    const checkSettingName = (settingName: string, index: number) => {
+        let mapList = { ...settingsMap };
+        let key = searchIndexInObject(mapList, index);
+        if (key != null) {
+            deleteIndexFromObject(mapList, index, key);
+        }
+        if (!settingsMap.hasOwnProperty(settingName)) {
+            mapList[settingName] = [index];
+            setSettingsMap(mapList);
+        }
+        else {
+            mapList[settingName].push(index);
+            setSettingsMap(mapList);
+        }
+    }
+
+    //Search the key of the input index in settingsMap
+    const searchIndexInObject = (object: { [key: string]: number[] }, index: number) => {
+        for (let [key, array] of Object.entries(object)) {
+            for (let i = 0; i < array.length; i++) {
+                if (index === array[i]) {
+                    return key;
+                }
+            }
+        }
+        return null;
+    }
+
+    //Delete the input index in settingsMap
+    const deleteIndexFromObject = (object: { [key: string]: number[] }, index: number, key: string) => {
+        if (key !== null) {
+            object[key] = object[key].filter(number => number !== index);
+            if (object[key].length === 0) {
+                delete object[key];
+            }
+        }
+    }
+
+    //Set errors if the setting's name the user enters are repeat
+    const setNameSettingsErrors = () => {
+        for (let [key, array] of Object.entries(settingsMap)) {
+            if (array.length > 1) {
+                for (let i = 0; i < array.length; i++) {
+                    setError(`settings[${array[i]}].name`, {
+                        type: "repeat",
+                        message: "Los nombres no pueden repetirse"
+                    });
+                }
+            }
+            else if (array.length === 1) {
+                clearErrors(`settings[${array[0]}].name`);
+            }
+        }
+    }
+
+    //Check if there are names repeated in settingsMap
+    const areNamesRepeated = (index: number) => {
+        let key = searchIndexInObject(settingsMap, index);
+        if (key != null && (settingsMap[key].length > 1 || key === 'price')) {
+            return true;
+        }
+        return false;
+    }
+
+    const isFieldEmpty = (index: number, field: string) => {
+        if (settingsList[index][field].trim() === "") {
+            return true;
+        }
+        return false;
+    }
+
+    const handleCancel = () => {
+        closeEditArtifactDialog();
+    }
+
+    const handleAddSetting = () => {
+        setSettingsList([...settingsList, { name: "", value: "" }]);
+    }
+
+    const handleDeleteSetting = (index: number) => {
+        const list = [...settingsList];
+        list.splice(index, 1);
+        setSettingsList(list);
+        let mapList = { ...settingsMap };
+        let key = searchIndexInObject(mapList, index);
+        if (key != null) {
+            deleteIndexFromObject(mapList, index, key);
+            updateSettingsMap(mapList, index);
+        }
+        setSettingsMap(mapList);
+    }
+
+    const updateSettingsMap = (object: { [key: string]: number[] }, index: number) => {
+        for (let [key, array] of Object.entries(object)) {
+            for (let i = 0; i < array.length; i++) {
+                if (array[i] > index) {
+                    array[i] = array[i] - 1;
+                }
+            }
+        }
+    }
+
+    //Create and return the settings object for the create the artifact
+    const createSettingsObject = () => {
+        let settingsObject: { [key: string]: string } = {};
+
+        for (let i = 0; i < settingsList.length; i++) {
+            settingsObject[settingsList[i].name] = settingsList[i].value;
+        }
+
+        return settingsObject;
+    }
+
+    return (
+        <>
+            <DialogTitle id="alert-dialog-title">Formulario de actualización de artefactos custom</DialogTitle>
+            <DialogContent>
+                <Controller
+                    control={control}
+                    name={'price.value'}
+                    rules={{ validate: { isValid: () => isPriceValid() } }}
+                    render={({ onChange }) => (
+                        <TextField
+                            inputRef={register({ required: true, validate: { isValid: value => value.trim() != "" } })}
+                            error={errors.name ? true : false}
+                            id="name"
+                            name="name"
+                            label="Nombre del artefacto"
+                            helperText="Requerido*"
+                            variant="outlined"
+                            className={classes.inputF}
+                            onChange={event => { handleChangeName(event); onChange(event); }}
+                            fullWidth
+                            defaultValue={props.artifactToEdit.name}
+                        />
+                    )}
+                />
+                <Typography gutterBottom>
+                    Propiedades del artefacto
+                </Typography>
+                <form className={classes.container}>
+                    <TextField
+                        disabled
+                        label="Nombre de la setting"
+                        helperText={"Requerido*"}
+                        variant="outlined"
+                        defaultValue='Precio'
+                        value='Precio'
+                        className={classes.inputF}
+                    />
+                    <Controller
+                        control={control}
+                        name={'price.value'}
+                        rules={{ validate: { isValid: () => isPriceValid() } }}
+                        render={({ onChange }) => (
+                            <TextField
+                                error={!isPriceValid()}
+                                label="Valor de la setting"
+                                helperText="Requerido*"
+                                variant="outlined"
+                                defaultValue={price}
+                                value={price}
+                                className={classes.inputF}
+                                onChange={event => { handleChangePrice(event); onChange(event); }}
+                                autoComplete='off'
+                                type="number"
+                            />
+                        )}
+                    />
+                    {settingsList.map((setting: Setting, index: number) => {
+                        return (
+                            <React.Fragment key={index}>
+                                <Controller
+                                    control={control}
+                                    name={`settings[${index}].name`}
+                                    rules={{ validate: { isValid: () => !isFieldEmpty(index, "name"), isRepeate: () => !areNamesRepeated(index) } }}
+                                    render={({ onChange }) => (
+                                        <TextField
+                                            error={errors.settings && errors.settings[index] && typeof errors.settings[index]?.name !== 'undefined' || setting.name === 'price'}
+                                            id={`name[${index}]`}
+                                            name={`settings[${index}].name`}
+                                            label="Nombre de la setting"
+                                            helperText={areNamesRepeated(index) ? "Los nombres no pueden repetirse" : "Requerido*"}
+                                            variant="outlined"
+                                            defaultValue={setting.name}
+                                            value={setting.name}
+                                            className={classes.inputF}
+                                            onChange={event => { handleInputChange(event, index); onChange(event); }}
+                                            autoComplete='off'
+                                        />
+                                    )}
+                                />
+
+                                <Controller
+                                    control={control}
+                                    name={`settings[${index}].value`}
+                                    rules={{ validate: { isValid: () => !isFieldEmpty(index, "value") } }}
+                                    render={({ onChange }) => (
+                                        <TextField
+                                            error={errors.settings && errors.settings[index] && typeof errors.settings[index]?.value !== 'undefined'}
+                                            id={`value[${index}]`}
+                                            name={`settings[${index}].value`}
+                                            label="Valor de la setting"
+                                            helperText="Requerido*"
+                                            variant="outlined"
+                                            defaultValue={setting.value}
+                                            value={setting.value}
+                                            className={classes.inputF}
+                                            onChange={event => { handleInputChange(event, index); onChange(event); }}
+                                            autoComplete='off'
+                                        />
+                                    )}
+                                />
+
+                                <ButtonGroup>
+                                    {settingsList.length - 1 === index &&
+                                        <IconButton onClick={handleAddSetting} aria-label="add" color="primary">
+                                            <AddCircleIcon />
+                                        </IconButton>
+                                    }
+
+                                    {settingsList.length !== 1 &&
+                                        <IconButton onClick={event => handleDeleteSetting(index)} aria-label="delete" color="secondary">
+                                            <DeleteIcon />
+                                        </IconButton>
+                                    }
+                                </ButtonGroup>
+                            </React.Fragment>
+                        );
+                    })}
+
+                </form>
+            </DialogContent>
+            <DialogActions>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Listo</Button>
+                <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
+            </DialogActions>
+        </>
+    );
+}
+
+export default EditArtifact;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -1,0 +1,123 @@
+﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import Typography from '@material-ui/core/Typography';
+import Artifact from '../../interfaces/Artifact';
+import ArtifactService from '../../services/ArtifactService';
+
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        title: {
+            fontWeight: 'bold'
+        },
+        settingName: {
+            fontStyle: 'italic'
+        },
+        listStyleNone: {
+            listStyle: 'none'
+        }
+    }),
+);
+
+
+const EditArtifactConfirmation = (props: {
+    artifactToEdit: Artifact,
+    namesOfSettingsChanged: string[],
+    closeEditArtifactDialog: Function,
+    setOpenSnackbar: Function,
+    setSnackbarSettings: Function,
+    updateArtifacts: Function,
+    updateRelations: Function }) => {
+
+    const classes = useStyles();
+    const { handleSubmit } = useForm();
+
+    //Create the artifact after submit
+    const handleConfirm = async () => {
+
+        const artifactEdited = {
+            name: props.artifactToEdit.name,
+            provider: props.artifactToEdit.provider,
+            artifactTypeId: props.artifactToEdit.artifactType.id,
+            projectId: props.artifactToEdit.projectId,
+            settings: {
+                settings: props.artifactToEdit.settings
+            }
+        };
+
+        try {
+            const response = await ArtifactService.update(props.artifactToEdit.id, artifactEdited);
+            if (response.status === 200) {
+                props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
+                props.setOpenSnackbar(true);
+            } else {
+                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
+                props.setOpenSnackbar(true);
+            }
+        }
+        catch (error) {
+            props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
+            props.setOpenSnackbar(true);
+        }
+        props.updateArtifacts();
+        props.updateRelations();
+        props.closeEditArtifactDialog();
+    }
+
+    const handleCancel = () => {
+        props.closeEditArtifactDialog();
+    }
+
+    return (
+        <>
+            <DialogTitle id="alert-dialog-title">Confirmación</DialogTitle>
+            <DialogContent>
+                {props.namesOfSettingsChanged.length > 0 ?
+                    <Typography gutterBottom color="secondary" className={classes.title}>
+                        Tenga en cuenta que al modificar el nombre de alguna de las settings se borrará
+                        las relaciones asociadas.
+                        Las settings cuyos nombres serán modificados son:
+                        <br />
+                        <br />
+                        <li className={classes.listStyleNone}>
+                            {props.namesOfSettingsChanged.map(name => {
+                                return (<ul>{name}</ul>);
+                            })}
+                        </li>
+                    </Typography> :
+                    null
+                }
+                <hr/>
+                <Typography gutterBottom>
+                    Revise las características con las que quedará su artefacto modificado
+                    y si está de acuerdo haga click en confirmar
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Nombre:</span> {props.artifactToEdit.name}
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Provedor:</span> {props.artifactToEdit.artifactType.name}
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Propiedades:</span>
+                </Typography>
+                {
+                    Object.entries(props.artifactToEdit.settings).map(([key, value], index) =>  (
+                            <Typography gutterBottom>
+                                <span className={classes.settingName}>{key}</span>: {value}
+                            </Typography>
+                        )
+                    )
+                }
+            </DialogContent>
+            <DialogActions>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Finalizar</Button>
+                <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
+            </DialogActions>
+        </>
+    );
+}
+
+export default EditArtifactConfirmation;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -1,0 +1,49 @@
+﻿import { Dialog } from '@material-ui/core';
+import * as React from 'react';
+import Artifact from '../../interfaces/Artifact';
+import ArtifactService from '../../services/ArtifactService';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
+import EditArtifact from './EditArtifact';
+import EditArtifactConfirmation from './EditArtifactConfirmation';
+
+
+const EditArtifactDialog = (props: {
+    artifactToEdit: Artifact,
+    showEditArtifactDialog: boolean,
+    closeEditArtifactDialog: Function,
+    setOpenSnackbar: Function,
+    setSnackbarSettings: Function,
+    updateArtifacts: Function,
+    updateRelations: Function }) => {
+
+    const { showEditArtifactDialog, closeEditArtifactDialog } = props;
+
+    const [isArtifactEdited, setIsArtifactEdited] = React.useState<boolean>(false);
+    const [artifactEdited, setArtifactEdited] = React.useState<Artifact>(props.artifactToEdit);
+    const [namesOfSettingsChanged, setNamesOfSettingsChanged] = React.useState<string[]>([]);
+
+    return (
+        <Dialog open={showEditArtifactDialog}>
+            {!isArtifactEdited ?
+                <EditArtifact
+                    artifactToEdit={props.artifactToEdit}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    setIsArtifactEdited={setIsArtifactEdited}
+                    setArtifactEdited={setArtifactEdited}
+                    setNamesOfSettingsChanged={setNamesOfSettingsChanged}
+                /> :
+                <EditArtifactConfirmation
+                    artifactToEdit={artifactEdited}
+                    namesOfSettingsChanged={namesOfSettingsChanged}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    setOpenSnackbar={props.setOpenSnackbar}
+                    setSnackbarSettings={props.setSnackbarSettings}
+                    updateArtifacts={props.updateArtifacts}
+                    updateRelations={props.updateRelations}
+                />
+            }
+        </Dialog>
+    );
+}
+
+export default EditArtifactDialog;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -68,6 +68,14 @@ class ArtifactService {
             return error.response ? error.response : error.message;
         }
     };
+
+    static deleteRelations = async (artifactRelationIds: any) => {
+        try {
+            return await axios.delete(`${BASE_URL}relations`, { data: artifactRelationIds });
+        } catch (error) {
+            return error.response ? error.response : error.message;
+        }
+    };
     
     static setRelations = async (artifactRelationsList: any) => {
         try {

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -144,6 +144,15 @@ namespace FRF.Web.Controllers
             return NoContent();
         }
 
+        [HttpDelete("~/api/relations")]
+        public async Task<IActionResult> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
+        {
+            var result = await _artifactsService.DeleteRelationsAsync(artifactRelationIds);
+            if (!result.Success) return NotFound();
+
+            return NoContent();
+        }
+
         [HttpPut("{artifactId}/relations")]
         public async Task<IActionResult> UpdateRelationsAsync(int artifactId,
             IList<ArtifactsRelationUpdateDTO> artifactRelationUpdatedList)

--- a/FiveRockingFingers/FRF.Web/FRF.Web.csproj
+++ b/FiveRockingFingers/FRF.Web/FRF.Web.csproj
@@ -38,6 +38,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifact.tsx" />
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifactConfirmation.tsx" />
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifactDialog.tsx" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FRF.Core\FRF.Core.csproj" />
     <ProjectReference Include="..\FRF.Web.Dtos\FRF.Web.Dtos.csproj" />
   </ItemGroup>

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -999,5 +999,59 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifactRelation.Artifact1Property, resultValue.Artifact1Property);
             Assert.Equal(artifactRelation.Artifact2Property, resultValue.Artifact2Property);
         }
+
+        [Fact]
+        public async Task DeleteRelationsAsync_ReturnsNull_RelationNotExist()
+        {
+            // Arange
+            var artifactRelationIds = new List<Guid>
+            {
+                new Guid()
+            };
+
+            // Act
+            var response = await _classUnderTest.DeleteRelationsAsync(artifactRelationIds);
+
+            // Assert
+            Assert.False(response.Success);
+            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.NotNull(response.Error);
+            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
+        }
+
+        [Fact]
+        public async Task DeleteRelationsAsync_ReturnsRelations()
+        {
+            // Arange
+            var project = CreateProject();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var artifact1 = CreateArtifact(project, artifactType);
+            var artifact2 = CreateArtifact(project, artifactType);
+            var artifactRelation = CreateArtifactsRelationModel(artifact1.Id, artifact2.Id);
+            var artifactRelationMapped = _mapper.Map<FRF.DataAccess.EntityModels.ArtifactsRelation>(artifactRelation);
+
+            await _dataAccess.ArtifactsRelation.AddAsync(artifactRelationMapped);
+            await _dataAccess.SaveChangesAsync();
+
+            var artifactRelationsIds = new List<Guid>
+            {
+                artifactRelationMapped.Id
+            };
+
+            // Act
+            var response = await _classUnderTest.DeleteRelationsAsync(artifactRelationsIds);
+
+            // Assert
+            Assert.True(response.Success);
+            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            var resultValue = Assert.IsAssignableFrom<IList<ArtifactsRelation>>(response.Value);
+            Assert.Equal(artifactRelationMapped.Id, resultValue[0].Id);
+            Assert.Equal(artifactRelation.Artifact1Id, resultValue[0].Artifact1Id);
+            Assert.Equal(artifactRelation.Artifact2Id, resultValue[0].Artifact2Id);
+            Assert.Equal(artifactRelation.RelationTypeId, resultValue[0].RelationTypeId);
+            Assert.Equal(artifactRelation.Artifact1Property, resultValue[0].Artifact1Property);
+            Assert.Equal(artifactRelation.Artifact2Property, resultValue[0].Artifact2Property);
+        }
     }
 }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -1001,7 +1001,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteRelationsAsync_ReturnsNull_RelationNotExist()
+        public async Task DeleteRelationsAsync_ReturnsEmptyList()
         {
             // Arange
             var artifactRelationIds = new List<Guid>
@@ -1013,10 +1013,9 @@ namespace FRF.Core.Tests.Services
             var response = await _classUnderTest.DeleteRelationsAsync(artifactRelationIds);
 
             // Assert
-            Assert.False(response.Success);
+            Assert.True(response.Success);
             Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
-            Assert.NotNull(response.Error);
-            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
+            Assert.Empty(response.Value);
         }
 
         [Fact]

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -1024,7 +1024,7 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteRelationsAsync_ReturnsEmptyList()
+        public async Task DeleteRelationsAsync_ExceptionRelationNotExists()
         {
             // Arange
             var artifactRelationIds = new List<Guid>
@@ -1036,9 +1036,10 @@ namespace FRF.Core.Tests.Services
             var response = await _classUnderTest.DeleteRelationsAsync(artifactRelationIds);
 
             // Assert
-            Assert.True(response.Success);
             Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
-            Assert.Empty(response.Value);
+            Assert.False(response.Success);
+            Assert.NotNull(response.Error);
+            Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -830,6 +830,59 @@ namespace FRF.Web.Tests.Controllers
         }
 
         [Fact]
+        public async Task DeleteRelationsAsync_ReturnNoContent()
+        {
+            // Arrange
+            var projectId = 1;
+            var project = CreateProject(projectId);
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var artifact1 = CreateArtifact(1, project, artifactType);
+            var artifact2 = CreateArtifact(2, project, artifactType);
+            var artifactRelation = CreateArtifactsRelation(artifact1, artifact2);
+            var artifactRelationList = new List<ArtifactsRelation>
+            {
+                artifactRelation
+            };
+            var artifactRelationIdsList = new List<Guid>
+            {
+                artifactRelation.Id
+            };
+
+            _artifactsService
+                .Setup(mock => mock.DeleteRelationsAsync(It.IsAny<IList<Guid>>()))
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(artifactRelationList));
+
+            // Act
+            var result = await _classUnderTest.DeleteRelationsAsync(artifactRelationIdsList);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _artifactsService.Verify(mock => mock.DeleteRelationsAsync(It.IsAny<IList<Guid>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteRelationsAsync_ReturnNotFound()
+        {
+            // Arrange
+            var artifactRelationIdsList = new List<Guid>
+            {
+                Guid.NewGuid()
+            };
+
+            _artifactsService
+                .Setup(mock => mock.DeleteRelationsAsync(It.IsAny<IList<Guid>>()))
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.ArtifactNotExists, "[Mock] message")));
+
+            // Act
+            var result = await _classUnderTest.DeleteRelationsAsync(artifactRelationIdsList);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+            _artifactsService.Verify(mock => mock.DeleteRelationsAsync(It.IsAny<IList<Guid>>()), Times.Once);
+        }
+
+        [Fact]
         public async Task UpdateArtifactsRelationsAsync_ReturnOk()
         {
             // Arrange


### PR DESCRIPTION
Se debe añadir la posibilidad de editar artefactos Custom. Para ello se deben borrar las relaciones de las settings de las cuales se haya cambiado el nombre. Es por esto que en este PR se incorpora un método al servicio de artefactos que me permita eliminar varias relaciones a la vez