### PR TITLE
[FIVE-327] Agregar filtros de proyectos por categoria

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
@@ -1,42 +1,133 @@
 import * as React from 'react';
-import { Menu, ProSidebar, SidebarContent, SidebarFooter } from 'react-pro-sidebar';
+import { Menu, ProSidebar, SidebarContent, SidebarFooter, SubMenu } from 'react-pro-sidebar';
 import 'react-pro-sidebar/dist/css/styles.css';
 import { Link } from 'react-router-dom';
 import Project from '../interfaces/Project';
+import Category from "../interfaces/Category";
 import '../styles/NavMenu.css';
 import NavMenuItem from './NavMenuItem';
+import NavMenuFilter from "./NavMenuFilter";
 import ProjectService from '../services/ProjectService';
+import CategoryService from "../services/CategoryService";
+import TuneTwoToneIcon from "@material-ui/icons/TuneTwoTone";
+import { Theme, withStyles, createStyles } from "@material-ui/core/styles";
+import Badge from "@material-ui/core/Badge";
+import {green} from "@material-ui/core/colors";
+import { Typography } from '@material-ui/core';
+
+const StyledBadge = withStyles((theme: Theme) =>
+  createStyles({
+    badge: {
+      right: -3,
+      top: 0,
+      fontSize: 13,
+      border: `2px solid ${theme.palette.background.paper}`,
+      padding: "0 4px",
+      color: green[500],
+    },
+  })
+)(Badge);
 
 const NavMenu = () => {
+  const [projects, setProjects] = React.useState<Project[]>([]);
+  const [projectsFiltered, setProjectsFiltered] = React.useState<Project[]>([]);
+  const [categories, setCategories] = React.useState<Category[]>([]);
+  const [categoriesFilter, setCategoriesFilter] = React.useState<Category[]>([]);
 
-    const [projects, setProjects] = React.useState<Project[]>([]);
-    React.useEffect(() => {
-        getProjects();
-    },
-        []);
-
-    const getProjects = async () => {
-
-        const response = await ProjectService.getAll();
-
+  const getProjects = async () => {
+    try {
+      const response = await ProjectService.getAll();
+      if (response.status === 200) {
         setProjects(response.data);
+      }
+    } catch {
+      setProjects([]);
     }
-    return (
-        <ProSidebar>
-            <SidebarContent>
-                <Menu>
-                    {Array.isArray(projects)
-                        ? projects.map((project) => (
-                            <NavMenuItem key={project.id} project={project} />
-                        ))
-                        : "No hay projectos"}
-                </Menu>
-            </SidebarContent>
-            <SidebarFooter>
-                <Link to="/administrarProyectos">Administrar proyectos</Link>
-            </SidebarFooter>
-        </ProSidebar>
-    );
+  };
+
+  const getCategories = async () => {
+    try {
+      const response = await CategoryService.getAll();
+      if (response.status === 200) setCategories(response.data);
+    } catch {
+      setCategories([]);
+    }
+  };
+
+  React.useEffect(() => {
+    getProjects();
+    getCategories();
+  }, []);
+
+  const filterProjects = () => {
+    const filterProjects = projects.filter((p) => {
+      return p.projectCategories.some((pc) => {
+        return categoriesFilter.some((cf) => {
+          return cf.id === pc.category.id;
+        });
+      });
+    });
+    setProjectsFiltered(filterProjects);
+  };
+
+  React.useEffect(() => {
+    filterProjects();
+  }, [categoriesFilter]);
+
+  const handleFilterCleaner = () => {
+    setCategoriesFilter([]);
+    setProjectsFiltered([]);
+  }
+
+  const handleNavMenuItem = () => {
+    return projectsFiltered.length === 0 && categoriesFilter.length === 0
+      ? projects.map((project) => (
+          <NavMenuItem key={project.id} project={project} />
+        ))
+      :  
+      projectsFiltered.length === 0 ? 
+      <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
+      : 
+      projectsFiltered.map((project) => (
+          <NavMenuItem key={project.id} project={project} />
+        ));
+  };
+
+  return (
+    <ProSidebar>
+      <SidebarContent>
+        <Menu iconShape="circle">
+          <SubMenu
+            title={"Filtros"}
+            icon={
+              <StyledBadge badgeContent={categoriesFilter.length}>
+                <TuneTwoToneIcon />
+              </StyledBadge>
+            }
+          >
+            <NavMenuFilter
+              categories={categories}
+              setCategoriesFilter={setCategoriesFilter}
+              cleaner={handleFilterCleaner}
+            />
+          </SubMenu>
+        </Menu>
+        <div
+          style={{
+            paddingTop: 0,
+            marginTop: "-2vh",
+          }}
+        >
+          <Menu iconShape="circle">
+            {Array.isArray(projects) ? handleNavMenuItem() : "No hay projectos"}
+          </Menu>
+        </div>
+      </SidebarContent>
+      <SidebarFooter>
+        <Link to="/administrarProyectos">Administrar proyectos</Link>
+      </SidebarFooter>
+    </ProSidebar>
+  );
 };
 
 export default NavMenu;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
@@ -80,15 +80,18 @@ const NavMenu = () => {
   }
 
   const handleNavMenuItem = () => {
-    return projectsFiltered.length === 0 && categoriesFilter.length === 0
-      ? projects.map((project) => (
-          <NavMenuItem key={project.id} project={project} />
-        ))
-      :  
-      projectsFiltered.length === 0 ? 
-      <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
-      : 
-      projectsFiltered.map((project) => (
+    const hasFilteredProjects = projectsFiltered.length === 0;
+    const hasCategoryFilters = categoriesFilter.length === 0;
+
+    return hasFilteredProjects && hasCategoryFilters ?
+      projects.map((project) => (
+        <NavMenuItem key={project.id} project={project} />
+      ))
+      :
+      hasFilteredProjects ?
+        <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
+        :
+        projectsFiltered.map((project) => (
           <NavMenuItem key={project.id} project={project} />
         ));
   };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenu.tsx
@@ -80,15 +80,15 @@ const NavMenu = () => {
   }
 
   const handleNavMenuItem = () => {
-    const hasFilteredProjects = projectsFiltered.length === 0;
-    const hasCategoryFilters = categoriesFilter.length === 0;
+    const hasFilteredProjects = projectsFiltered.length !== 0;
+    const hasCategoryFilters = categoriesFilter.length !== 0;
 
-    return hasFilteredProjects && hasCategoryFilters ?
+    return !hasFilteredProjects && !hasCategoryFilters ?
       projects.map((project) => (
         <NavMenuItem key={project.id} project={project} />
       ))
       :
-      hasFilteredProjects ?
+      !hasFilteredProjects ?
         <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
         :
         projectsFiltered.map((project) => (

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { createMuiTheme, makeStyles, TextField, Theme, ThemeProvider } from "@material-ui/core";
+import { lime } from "@material-ui/core/colors";
+import { Autocomplete } from "@material-ui/lab";
+import Category from "../interfaces/Category";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  inputRoot: {
+    width: "90%",
+    marginTop: 0,
+    color: "#eceff1",
+    fontWeight: "bold",
+    background: "#546e7a",
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: lime[100],
+      border: `2px solid`
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+      borderColor: lime[100],
+      border: `2px solid`
+    },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: lime[100],
+      border: `2px solid`
+    },
+  },
+}));
+
+const theme = createMuiTheme({
+  overrides: {
+    MuiFormLabel: {
+      root: {
+        color: lime[100],
+        "&$focused": {
+          color: lime[100],
+        },
+      },
+    },
+  },
+});
+
+const NavMenuFilter = (props: {categories: Category[], setCategoriesFilter: Function ,cleaner: Function}) => {
+  const classes = useStyles();
+  const { categories, setCategoriesFilter, cleaner } = props;
+
+  const handleChange = (_event: React.ChangeEvent<{}>, value: Category[], reason: string) => {
+    if (reason === "clear") {
+      cleaner();
+      return;
+    }
+    if (value.length === 0) {
+      setCategoriesFilter([]);
+      return;
+    }
+    setCategoriesFilter(value);
+  };
+
+  return (
+    <Autocomplete
+      multiple
+      limitTags={1}
+      size="small"
+      classes={classes}
+      options={categories}
+      onChange={handleChange}
+      getOptionLabel={(option) => option.name}
+      renderInput={(params) => (
+        <ThemeProvider theme={theme}>
+          <TextField
+            {...params}
+            variant="outlined"
+            margin="normal"
+            label="Filtro por categorias:"
+          />
+        </ThemeProvider>
+      )}
+    />
+  );
+};
+
+export default NavMenuFilter;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
-import { createMuiTheme, makeStyles, TextField, Theme, ThemeProvider } from "@material-ui/core";
-import { lime } from "@material-ui/core/colors";
+import { createMuiTheme, makeStyles, TextField, ThemeProvider } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import Category from "../interfaces/Category";
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   inputRoot: {
     width: "90%",
     marginTop: 0,

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/NavMenuFilter.tsx
@@ -8,19 +8,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   inputRoot: {
     width: "90%",
     marginTop: 0,
-    color: "#eceff1",
+    color: "#fafafa",
     fontWeight: "bold",
-    background: "#546e7a",
+    background: "#545454",
     "& .MuiOutlinedInput-notchedOutline": {
-      borderColor: lime[100],
+      borderColor: "#b0bec6",
       border: `2px solid`
     },
     "&:hover .MuiOutlinedInput-notchedOutline": {
-      borderColor: lime[100],
+      borderColor: "#b0bec6",
       border: `2px solid`
     },
     "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-      borderColor: lime[100],
+      borderColor: "#b0bec6",
       border: `2px solid`
     },
   },
@@ -30,9 +30,10 @@ const theme = createMuiTheme({
   overrides: {
     MuiFormLabel: {
       root: {
-        color: lime[100],
+        color: "#fafafa",
         "&$focused": {
-          color: lime[100],
+          fontSize: 18,
+          color: "#fafafa",
         },
       },
     },
@@ -62,6 +63,7 @@ const NavMenuFilter = (props: {categories: Category[], setCategoriesFilter: Func
       size="small"
       classes={classes}
       options={categories}
+      getOptionSelected={(option, value) => option.id === value.id}
       onChange={handleChange}
       getOptionLabel={(option) => option.name}
       renderInput={(params) => (

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
@@ -5,7 +5,6 @@ import Navbar from './ManageProjectsComponents/Navbar';
 import ProjectService from '../services/ProjectService';
 import CategoryService from '../services/CategoryService';
 import ProjectsList from './ManageProjectsComponents/ProjectsList';
-import NavMenuFilter from '../commons/NavMenuFilter';
 
 export default function ManageProjects() {
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjects.tsx
@@ -5,19 +5,33 @@ import Navbar from './ManageProjectsComponents/Navbar';
 import ProjectService from '../services/ProjectService';
 import CategoryService from '../services/CategoryService';
 import ProjectsList from './ManageProjectsComponents/ProjectsList';
+import NavMenuFilter from '../commons/NavMenuFilter';
 
 export default function ManageProjects() {
 
     const [projects, setProjects] = React.useState([] as Project[]);
     const [categories, setCategories] = React.useState([] as Category[]);
+    const [projectsFiltered, setProjectsFiltered] = React.useState<Project[]>([]);
+    const [categoriesFilter, setCategoriesFilter] = React.useState<Category[]>([]);
+
     const getProjectList = async () => {
-        const response = await ProjectService.getAll();
-        setProjects(response.data);
+        try {
+          const response = await ProjectService.getAll();
+          if (response.status === 200) {
+            setProjects(response.data);
+          }
+        } catch {
+          setProjects([]);
+        }
     }
 
     const getCategoryList = async () => {
-        const response = await CategoryService.getAll();
-        setCategories(response.data);
+        try {
+          const response = await CategoryService.getAll();
+          if (response.status === 200) setCategories(response.data);
+        } catch {
+          setCategories([]);
+        }
     }
 
     React.useEffect(() => {
@@ -25,10 +39,35 @@ export default function ManageProjects() {
         getCategoryList();
     }, [])
 
+    const filterProjects = () => {
+        const filterProjects = projects.filter((p) => {
+          return p.projectCategories.some((pc) => {
+            return categoriesFilter.some((cf) => {
+              return cf.id === pc.category.id;
+            });
+          });
+        });
+        setProjectsFiltered(filterProjects);
+      };
+
+      const handleUpdateProjectList = () => {
+        getProjectList();
+        filterProjects();
+      };
+
+    React.useEffect(() => {
+        filterProjects();
+    }, [categoriesFilter,projects,categories]);
+
+    const handleFilterCleaner = () => {
+        setCategoriesFilter([]);
+        setProjectsFiltered([]);
+    };
+
     return (
         <div className="App">
             <Navbar />
-            <ProjectsList projects={projects} categories={categories} updateProjects={getProjectList} updateCategories={getCategoryList}/>
+            <ProjectsList projects={projects} categories={categories} updateProjects={handleUpdateProjectList} updateCategories={getCategoryList} projectsFiltered={projectsFiltered} categoriesFilter={categoriesFilter} handleFilterCleaner={handleFilterCleaner} setCategoriesFilter={setCategoriesFilter}/>
         </div>
     )
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -1,6 +1,6 @@
-﻿import { Badge, Button, CssBaseline, Divider, Drawer, List, Toolbar, Typography } from '@material-ui/core';
+﻿import { Badge, Button, CssBaseline, Drawer, List, Toolbar, Typography } from '@material-ui/core';
 import TuneTwoToneIcon from "@material-ui/icons/TuneTwoTone";
-import { makeStyles,Theme, withStyles, createStyles } from "@material-ui/core/styles";
+import { makeStyles,withStyles, createStyles } from "@material-ui/core/styles";
 import AddIcon from '@material-ui/icons/Add';
 import * as React from 'react';
 import { SubMenu } from 'react-pro-sidebar';
@@ -58,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-const StyledBadge = withStyles((theme: Theme) =>
+const StyledBadge = withStyles(() =>
   createStyles({
     badge: {
       right: -3,
@@ -156,15 +156,15 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
     }
 
     const handleListElement = () => {
-        const hasFilteredProjects = projectsFiltered.length === 0;
-        const hasCategoryFilters = categoriesFilter.length === 0;
+        const hasFilteredProjects = projectsFiltered.length !== 0;
+        const hasCategoryFilters = categoriesFilter.length !== 0;
 
-        return hasFilteredProjects && hasCategoryFilters ?
+        return !hasFilteredProjects && !hasCategoryFilters ?
             projects.map((project) => (
                 <ListElement selected={selectedIndex === project.id} key={project.id} id={project.id} selectProject={selectProject} deleteProject={deleteProject} name={project.name} />
             ))
             :
-            hasFilteredProjects ?
+            !hasFilteredProjects ?
                 <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
                 :
                 projectsFiltered.map((project) => (

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ProjectsList.tsx
@@ -1,7 +1,10 @@
-﻿import { Button, CssBaseline, Divider, Drawer, List, Toolbar } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+﻿import { Badge, Button, CssBaseline, Divider, Drawer, List, Toolbar, Typography } from '@material-ui/core';
+import TuneTwoToneIcon from "@material-ui/icons/TuneTwoTone";
+import { makeStyles,Theme, withStyles, createStyles } from "@material-ui/core/styles";
 import AddIcon from '@material-ui/icons/Add';
 import * as React from 'react';
+import { SubMenu } from 'react-pro-sidebar';
+import NavMenuFilter from '../../commons/NavMenuFilter';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import Category from '../../interfaces/Category';
 import Project from '../../interfaces/Project';
@@ -38,17 +41,41 @@ const useStyles = makeStyles((theme) => ({
         background: "#212121",
         color: 'white',
         borderRadius: 0,
+        alignContent: 'center',
         '&:hover': {
             backgroundColor: "#323232",
             color: '#FFF'
         }
+    },
+    subMenu: {
+        listStyleType: "none",
+        paddingLeft: "7vh",
+        paddingTop: "1vh",
+        paddingBottom: "1vh",
+        color: "#fafafa",
+        backgroundColor: "#212121",
+        "& .pro-inner-list-item":{marginLeft: '-9vh'},
     }
 }));
 
-const ProjectsList = (props: { projects: Project[], categories: Category[], updateProjects: Function, updateCategories: Function }) => {
+const StyledBadge = withStyles((theme: Theme) =>
+  createStyles({
+    badge: {
+      right: -3,
+      top: 0,
+      fontSize: 13,
+      border: `2px solid #f44336`,
+      padding: "0 4px",
+      color: "#ffebee",
+      backgroundColor: "#f44336"
+    },
+  })
+)(Badge);
+
+const ProjectsList = (props: { projects: Project[], categories: Category[], updateProjects: Function, updateCategories: Function, projectsFiltered: Project[],categoriesFilter: Category[],setCategoriesFilter: Function, handleFilterCleaner: Function }) => {
 
     const classes = useStyles();
-
+    const {projects, categories, updateProjects, updateCategories,projectsFiltered ,categoriesFilter, setCategoriesFilter, handleFilterCleaner} = props;
     const [edit, setEdit] = React.useState(false);
     const [create, setCreate] = React.useState(false);
     const [openDelete, setOpenDelete] = React.useState(false);
@@ -78,7 +105,7 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
     }
 
     const deleteProject = (id: number) => {
-        const aux = props.projects.filter(p => p.id === id);
+        const aux = projects.filter(p => p.id === id);
         if (aux.length === 0) {
             setProjectToDelete(null);
         } else {
@@ -90,7 +117,7 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
     const fillProjectCategories = async (selectedCategories: Category[]) => {
         let projectCategories = [] as ProjectCategory[];
         for (const category of selectedCategories) {
-            let categoryToAdd = props.categories.find(c => c.name === category.name);
+            let categoryToAdd = categories.find(c => c.name === category.name);
             if (categoryToAdd === undefined) {
                 const response = await CategoryService.save(category);
                 if (response.status === 200) {
@@ -128,6 +155,23 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
         setOpenSnackbar(true);
     }
 
+    const handleListElement = () => {
+        const hasFilteredProjects = projectsFiltered.length === 0;
+        const hasCategoryFilters = categoriesFilter.length === 0;
+
+        return hasFilteredProjects && hasCategoryFilters ?
+            projects.map((project) => (
+                <ListElement selected={selectedIndex === project.id} key={project.id} id={project.id} selectProject={selectProject} deleteProject={deleteProject} name={project.name} />
+            ))
+            :
+            hasFilteredProjects ?
+                <Typography align="center" variant="h6" gutterBottom>Categoría sin proyectos</Typography>
+                :
+                projectsFiltered.map((project) => (
+                    <ListElement selected={selectedIndex === project.id} key={project.id} id={project.id} selectProject={selectProject} deleteProject={deleteProject} name={project.name} />
+                ));
+      };
+
     return (
         <div className={classes.root}>
             <CssBaseline />
@@ -140,17 +184,29 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                     <NewProjectDialog
                         create={create}
                         finishCreation={finishCreation}
-                        categories={props.categories}
+                        categories={categories}
                         openSnackbar={manageOpenSnackbar}
-                        updateProjects={props.updateProjects}
-                        updateCategories={props.updateCategories}
+                        updateProjects={updateProjects}
+                        updateCategories={updateCategories}
                         fillProjectCategories={fillProjectCategories} />
-                    <Divider />
+                    <SubMenu
+                        className={classes.subMenu}
+                        title={"Filtros"}
+                        icon={
+                            <StyledBadge badgeContent={categoriesFilter.length}>
+                                <TuneTwoToneIcon />
+                            </StyledBadge>
+                        }
+                    >
+                        <NavMenuFilter
+                            categories={categories}
+                            setCategoriesFilter={setCategoriesFilter}
+                            cleaner={handleFilterCleaner}
+                        />
+                    </SubMenu>
                     <List>
-                        {props.projects.map((project: Project) =>
-                            <ListElement selected={selectedIndex === project.id} key={project.id} id={project.id} selectProject={selectProject} deleteProject={deleteProject} name={project.name} />
-                        )}
-                        <ConfirmationDialog keepMounted open={openDelete} onClose={handleClose} project={projectToDelete} resetView={resetView} openSnackbar={manageOpenSnackbar} updateProjects={props.updateProjects} />
+                        {Array.isArray(projects) ? handleListElement() : "No hay projectos"}
+                        <ConfirmationDialog keepMounted open={openDelete} onClose={handleClose} project={projectToDelete} resetView={resetView} openSnackbar={manageOpenSnackbar} updateProjects={updateProjects} />
                     </List>
                 </div>
             </Drawer>
@@ -158,17 +214,17 @@ const ProjectsList = (props: { projects: Project[], categories: Category[], upda
                 {
                     selectedIndex === -1 ?
                         (<h1>Seleccione un proyecto para ver sus detalles</h1>)
-                        : props.projects.filter(p => p.id === selectedIndex)[0] ?
+                        : projects.filter(p => p.id === selectedIndex)[0] ?
                             (edit ?
                                 (<EditProject
-                                    project={props.projects.filter(p => p.id === selectedIndex)[0]}
+                                    project={projects.filter(p => p.id === selectedIndex)[0]}
                                     cancelEdit={cancelEdit}
-                                    categories={props.categories}
+                                    categories={categories}
                                     openSnackbar={manageOpenSnackbar}
-                                    updateProjects={props.updateProjects}
-                                    updateCategories={props.updateCategories}
+                                    updateProjects={updateProjects}
+                                    updateCategories={updateCategories}
                                     fillProjectCategories={fillProjectCategories} />)
-                                : (<ViewProject project={props.projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
+                                : (<ViewProject project={projects.filter(p => p.id === selectedIndex)[0]} changeEdit={changeEdit} />))
                             : setSelectedIndex(-1)
                 }
                 <SnackbarMessage

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/custom.css
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/custom.css
@@ -14,7 +14,7 @@ code {
 }
 
 .content {
-  height: 100%;
+  height: 95.6vh;
   display: flex;
 }
 


### PR DESCRIPTION
### Cambios realizados:
![FIVE-327(3)](https://user-images.githubusercontent.com/71275081/109191546-0c873a80-7775-11eb-81f0-24bac777ef34.gif)



- Se creó componente NavMenuFilter el cual filtra los proyectos por categoría.
- Se agregó hooks dentro NavMenu para gestionar los estados de los proyectos filtrados y los filtros seleccionados.