### PR TITLE
[Five-330] (Frontend) Añadir edición de artefactos custom

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -181,6 +181,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
                     setSnackbarSettings={setSnackbarSettings}
                     artifactToEdit={artifactToEdit}
                     artifactsRelations={artifactsRelations}
+                    updateArtifacts={getArtifacts}
+                    updateRelations={getRelations}
                 /> :
                 null
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -176,11 +176,9 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 <EditArtifactDialog
                     showEditArtifactDialog={showEditArtifactDialog}
                     closeEditArtifactDialog={closeEditArtifactDialog}
-                    projectId={projectId}
                     setOpenSnackbar={setOpenSnackbar}
                     setSnackbarSettings={setSnackbarSettings}
                     artifactToEdit={artifactToEdit}
-                    artifactsRelations={artifactsRelations}
                     updateArtifacts={getArtifacts}
                     updateRelations={getRelations}
                 /> :

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -1,6 +1,6 @@
 ﻿import * as React from 'react';
 import { Table, Button } from 'reactstrap';
-import Artifact from '../../interfaces/Artifact'
+import Artifact from '../../interfaces/Artifact';
 import ArtifactsTableRow from './ArtifactsTableRow';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
@@ -10,6 +10,8 @@ import NewArtifactsRelation from '../NewArtifactsRelation';
 import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
+import ArtifactType from '../../interfaces/ArtifactType';
+import EditArtifactDialog from './EditArtifactDialog';
 
 const ArtifactsTable = (props: { projectId: number}) => {
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
@@ -17,6 +19,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
     const [showNewArtifactDialog, setShowNewArtifactDialog] = React.useState(false);
     const [showNewArtifactsRelation, setShowNewArtifactsRelation] = React.useState(false);
+    const [showEditArtifactDialog, setEditArtifactDialog] = React.useState(false);
+    const [artifactToEdit, setArtifactToEdit] = React.useState<Artifact | null>(null);
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
@@ -77,6 +81,15 @@ const ArtifactsTable = (props: { projectId: number}) => {
         }
     }
 
+    const openEditArtifactDialog = () => {
+        setEditArtifactDialog(true);
+    }
+
+    const closeEditArtifactDialog = () => {
+        setArtifactToEdit(null);
+        setEditArtifactDialog(false);
+    }
+
     const closeNewArtifactDialog = () => {
         setShowNewArtifactDialog(false);
     }
@@ -127,6 +140,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
                                 artifact={artifact}
                                 openSnackbar={manageOpenSnackbar}
                                 updateList={getArtifacts}
+                                setArtifactToEdit={setArtifactToEdit}
+                                openEditArtifactDialog={openEditArtifactDialog}
                             />
                             ) : null}
                         <ArtifactsTotalPrice totalPrice={price} projectBudget={projectBudget} /></>
@@ -157,6 +172,18 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 artifactsRelations={artifactsRelations}
                 updateList = {{update: false}}
             />
+            { artifactToEdit ?
+                <EditArtifactDialog
+                    showEditArtifactDialog={showEditArtifactDialog}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    projectId={projectId}
+                    setOpenSnackbar={setOpenSnackbar}
+                    setSnackbarSettings={setSnackbarSettings}
+                    artifactToEdit={artifactToEdit}
+                    artifactsRelations={artifactsRelations}
+                /> :
+                null
+            }
         </React.Fragment>
     );
 };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTableRow.tsx
@@ -3,12 +3,18 @@ import Artifact from '../../interfaces/Artifact';
 import { Button } from 'reactstrap';
 import ConfirmationDialog from './ConfirmationDialog';
 import { Link } from 'react-router-dom';
+import { PROVIDERS } from '../../Constants';
 
-const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, updateList: Function }) => {
+const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, updateList: Function, setArtifactToEdit: Function, openEditArtifactDialog: Function }) => {
     const [openConfirmDialog, setOpenConfirmDialog] = React.useState(false);
 
     const deleteButtonClick = () => {
         setOpenConfirmDialog(true);
+    }
+
+    const handleModifyArtifactClick = () => {
+        props.setArtifactToEdit(props.artifact);
+        props.openEditArtifactDialog();
     }
 
     return (
@@ -18,25 +24,37 @@ const ArtifactsTableRow = (props: { artifact: Artifact, openSnackbar: Function, 
             <td>{props.artifact.provider}</td>
             <td>{props.artifact.artifactType.name}</td>
             <td>{props.artifact.price}</td>
-          <td >
-            <Button
-                className="mx-3" 
-                style={{ minHeight: "32px", width: "20%" }}
-              color="danger"
-              onClick={deleteButtonClick}
-            >
-              Borrar
-            </Button>
+            <td>                
+                <Button
+                    className="mx-3" 
+                    style={{ minHeight: "32px", width: "20%" }}
+                  color="danger"
+                  onClick={deleteButtonClick}
+                >
+                  Borrar
+                </Button>
 
-            <Button
-                style={{ minHeight: "32px", width: "20%" }}
-              color="info"
-              tag={Link}
-              to={`/projects/${props.artifact.projectId}/artifacts/${props.artifact.id}`}
-            >
-              Relaciones
-            </Button>
-          </td>
+                <Button
+                    style={{ minHeight: "32px", width: "20%" }}
+                  color="info"
+                  tag={Link}
+                  to={`/projects/${props.artifact.projectId}/artifacts/${props.artifact.id}`}
+                >
+                        Relaciones
+                </Button>
+
+                {props.artifact.artifactType.name === PROVIDERS[1] ?
+                    <Button
+                        className="mx-3"
+                        style={{ minHeight: "32px", width: "20%" }}
+                        color="warning"
+                        onClick={handleModifyArtifactClick}
+                    >
+                        Modificar
+                    </Button> :
+                    null
+                }
+            </td>
         </tr>
         <ConfirmationDialog
           open={openConfirmDialog}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
+﻿import { Button, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import * as React from 'react';
 import { useForm, Controller } from 'react-hook-form';

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -194,7 +194,6 @@ const EditArtifact = (props: {
     const areNamesRepeated = (index: number) => {
         let key = searchIndexInObject(settingsMap, index);
         if (key != null && (settingsMap[key].length > 1 || key === 'price')) {
-            console.log("Hola");
             return true;
         }
         return false;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -25,7 +25,13 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog: Function, setIsArtifactEdited: Function, setArtifactEdited: Function, setNamesOfSettingsChanged: Function }) => {
+const EditArtifact = (props: {
+    artifactToEdit: Artifact,
+    closeEditArtifactDialog: Function,
+    setIsArtifactEdited: Function,
+    setArtifactEdited: Function,
+    setNamesOfSettingsChanged: Function }) => {
+
     const classes = useStyles();
     const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
     const { closeEditArtifactDialog } = props;
@@ -61,7 +67,9 @@ const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog
     const createSettingsMapFromArtifact = () => {
         let settingsMapFromArtifact: { [key: string]: number[] } = {};
         Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
-            settingsMapFromArtifact[key] = [index];
+            if (key !== 'price') {
+                settingsMapFromArtifact[key] = [index];
+            }            
         });
         return settingsMapFromArtifact;
     }
@@ -186,6 +194,7 @@ const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog
     const areNamesRepeated = (index: number) => {
         let key = searchIndexInObject(settingsMap, index);
         if (key != null && (settingsMap[key].length > 1 || key === 'price')) {
+            console.log("Hola");
             return true;
         }
         return false;
@@ -242,7 +251,7 @@ const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog
 
     return (
         <>
-            <DialogTitle id="alert-dialog-title">Formulario de artefactos custom</DialogTitle>
+            <DialogTitle id="alert-dialog-title">Formulario de actualización de artefactos custom</DialogTitle>
             <DialogContent>
                 <Controller
                     control={control}
@@ -265,7 +274,7 @@ const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog
                     )}
                 />
                 <Typography gutterBottom>
-                    A continuación ingrese las propiedades de su nuevo artefacto custom y el valor que tomarán esas propiedades
+                    Propiedades del artefacto
                 </Typography>
                 <form className={classes.container}>
                     <TextField

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -1,0 +1,367 @@
+﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import * as React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import Typography from '@material-ui/core/Typography';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Setting from '../../interfaces/Setting';
+import Artifact from '../../interfaces/Artifact';
+import ArtifactService from '../../services/ArtifactService';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
+
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        container: {
+            display: 'flex',
+            flexWrap: 'wrap',
+        },
+        formControl: {
+            margin: theme.spacing(1),
+            width: '100%'
+        },
+        inputF: {
+            padding: 2,
+            marginTop: 10
+        }
+    }),
+);
+
+
+const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[], settingMap: { [key: string]: number[] }, closeEditArtifactDialog: Function, artifactsRelations: ArtifactRelation[], setIsArtifactEdited: Function, setArtifactEdited: Function, setNamesOfSettingsChanged: Function }) => {
+    const classes = useStyles();
+    const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
+    const { closeEditArtifactDialog } = props;
+    //Hook for save the user's settings input
+    const [settingsList, setSettingsList] = React.useState<Setting[]>(props.settingsList);
+    const [price, setPrice] = React.useState(() => {
+        let index = settingsList.findIndex(s => s.name === 'price');
+        if (index != -1) {
+            let price = settingsList[index];
+            settingsList.splice(index, 1);
+            setSettingsList(settingsList);
+            return price.value;
+        }
+        return 0;
+    });
+    const [artifactName, setArtifactName] = React.useState(props.artifactToEdit.name);    
+    //Hook for saving the numbers of times a setting's name input is repeated
+    const [settingsMap, setSettingsMap] = React.useState<{ [key: string]: number[] }>(props.settingMap);
+
+    React.useEffect(() => {
+        setNameSettingsErrors();
+    }, [settingsMap, props.artifactToEdit]);
+
+    //Create the artifact after submit
+    const handleConfirm = async () => {
+        if (!settingsList.find(s => s.name === 'price')) {
+            settingsList.unshift({ name: 'price', value: price.toString() });
+        }
+        let artifactEdited = Object.create(props.artifactToEdit);
+        artifactEdited.name = artifactName;
+        artifactEdited.settings = createSettingsObject();
+        props.setArtifactEdited(artifactEdited);
+        console.log(props.artifactToEdit);
+        props.setNamesOfSettingsChanged(getNamesOfSettingsChanged());
+        props.setIsArtifactEdited(true);
+    }
+
+    const createSettingsListFromArtifact = () => {
+        let settingsListFromArtifact: Setting[] = [];
+        if (props.artifactToEdit.id === 0) {
+            return settingsListFromArtifact;
+        }
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
+            settingsListFromArtifact.push(settingFromArtifact);
+        });
+        return settingsListFromArtifact;
+    }
+
+    const getNamesOfSettingsChanged = () => {
+        let namesOfSettingsChanged : string[] = [];
+        let originalSettingsList = createSettingsListFromArtifact();
+        let index = originalSettingsList.findIndex(s => s.name === 'price');
+        if (index != -1) {
+            originalSettingsList.splice(index, 1);
+        }
+        console.log(originalSettingsList);
+        originalSettingsList.forEach((setting, index) => {
+            console.log(setting);
+            console.log(settingsList.find(s => s.name === setting.name));
+            if (!settingsList.find(s => s.name === setting.name)) {
+                namesOfSettingsChanged.push(setting.name);
+            }
+        });
+        return namesOfSettingsChanged;
+    }
+
+    const handleChangeName = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        setArtifactName(event.target.value);
+    }
+
+    const handleChangePrice = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        setPrice(parseInt(event.target.value, 10));
+    }
+
+    const isPriceValid = () => {
+        if (price >= 0) return true
+        return false
+    }
+
+    //Handle changes in the inputs fields
+    const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>, index: number) => {
+        let { name, value } = event.target;
+        name = name.split(".")[1];
+        if (name === 'name') {
+            checkSettingName(value, index);
+        }
+        const list = [...settingsList];
+        list[index][name] = value;
+        setSettingsList(list);
+    }
+
+    //Check if the setting's name the user enters has already have been used
+    const checkSettingName = (settingName: string, index: number) => {
+        let mapList = { ...settingsMap };
+        let key = searchIndexInObject(mapList, index);
+        if (key != null) {
+            deleteIndexFromObject(mapList, index, key);
+        }
+        if (!settingsMap.hasOwnProperty(settingName)) {
+            mapList[settingName] = [index];
+            setSettingsMap(mapList);
+        }
+        else {
+            mapList[settingName].push(index);
+            setSettingsMap(mapList);
+        }
+    }
+
+    //Search the key of the input index in settingsMap
+    const searchIndexInObject = (object: { [key: string]: number[] }, index: number) => {
+        for (let [key, array] of Object.entries(object)) {
+            for (let i = 0; i < array.length; i++) {
+                if (index === array[i]) {
+                    return key;
+                }
+            }
+        }
+        return null;
+    }
+
+    //Delete the input index in settingsMap
+    const deleteIndexFromObject = (object: { [key: string]: number[] }, index: number, key: string) => {
+        if (key !== null) {
+            object[key] = object[key].filter(number => number !== index);
+            if (object[key].length === 0) {
+                delete object[key];
+            }
+        }
+    }
+
+    //Set errors if the setting's name the user enters are repeat
+    const setNameSettingsErrors = () => {
+        for (let [key, array] of Object.entries(settingsMap)) {
+            if (array.length > 1) {
+                for (let i = 0; i < array.length; i++) {
+                    setError(`settings[${array[i]}].name`, {
+                        type: "repeat",
+                        message: "Los nombres no pueden repetirse"
+                    });
+                }
+            }
+            else if (array.length === 1) {
+                clearErrors(`settings[${array[0]}].name`);
+            }
+        }
+    }
+
+    //Check if there are names repeated in settingsMap
+    const areNamesRepeated = (index: number) => {
+        let key = searchIndexInObject(settingsMap, index);
+        if (key != null && (settingsMap[key].length > 1 || key === 'price')) {
+            return true;
+        }
+        return false;
+    }
+
+    const isFieldEmpty = (index: number, field: string) => {
+        if (settingsList[index][field].trim() === "") {
+            return true;
+        }
+        return false;
+    }
+
+    const handleCancel = () => {
+        closeEditArtifactDialog();
+    }
+
+    const handleAddSetting = () => {
+        setSettingsList([...settingsList, { name: "", value: "" }]);
+    }
+
+    const handleDeleteSetting = (index: number) => {
+        const list = [...settingsList];
+        list.splice(index, 1);
+        setSettingsList(list);
+        let mapList = { ...settingsMap };
+        let key = searchIndexInObject(mapList, index);
+        if (key != null) {
+            deleteIndexFromObject(mapList, index, key);
+            updateSettingsMap(mapList, index);
+        }
+        setSettingsMap(mapList);
+    }
+
+    const updateSettingsMap = (object: { [key: string]: number[] }, index: number) => {
+        for (let [key, array] of Object.entries(object)) {
+            for (let i = 0; i < array.length; i++) {
+                if (array[i] > index) {
+                    array[i] = array[i] - 1;
+                }
+            }
+        }
+    }
+
+    //Create and return the settings object for the create the artifact
+    const createSettingsObject = () => {
+        let settingsObject: { [key: string]: string } = {};
+
+        for (let i = 0; i < settingsList.length; i++) {
+            settingsObject[settingsList[i].name] = settingsList[i].value;
+        }
+
+        return settingsObject;
+    }
+
+    return (
+        <>
+            <DialogTitle id="alert-dialog-title">Formulario de artefactos custom</DialogTitle>
+            <DialogContent>
+                <Controller
+                    control={control}
+                    name={'price.value'}
+                    rules={{ validate: { isValid: () => isPriceValid() } }}
+                    render={({ onChange }) => (
+                        <TextField
+                            inputRef={register({ required: true, validate: { isValid: value => value.trim() != "" } })}
+                            error={errors.name ? true : false}
+                            id="name"
+                            name="name"
+                            label="Nombre del artefacto"
+                            helperText="Requerido*"
+                            variant="outlined"
+                            className={classes.inputF}
+                            onChange={event => { handleChangeName(event); onChange(event); }}
+                            fullWidth
+                            defaultValue={props.artifactToEdit.name}
+                        />
+                    )}
+                />
+                <Typography gutterBottom>
+                    A continuación ingrese las propiedades de su nuevo artefacto custom y el valor que tomarán esas propiedades
+                </Typography>
+                <form className={classes.container}>
+                    <TextField
+                        disabled
+                        label="Nombre de la setting"
+                        helperText={"Requerido*"}
+                        variant="outlined"
+                        defaultValue='Precio'
+                        value='Precio'
+                        className={classes.inputF}
+                    />
+                    <Controller
+                        control={control}
+                        name={'price.value'}
+                        rules={{ validate: { isValid: () => isPriceValid() } }}
+                        render={({ onChange }) => (
+                            <TextField
+                                error={!isPriceValid()}
+                                label="Valor de la setting"
+                                helperText="Requerido*"
+                                variant="outlined"
+                                defaultValue={price}
+                                value={price}
+                                className={classes.inputF}
+                                onChange={event => { handleChangePrice(event); onChange(event); }}
+                                autoComplete='off'
+                                type="number"
+                            />
+                        )}
+                    />
+                    {settingsList.map((setting: Setting, index: number) => {
+                        return (
+                            <React.Fragment key={index}>
+                                <Controller
+                                    control={control}
+                                    name={`settings[${index}].name`}
+                                    rules={{ validate: { isValid: () => !isFieldEmpty(index, "name"), isRepeate: () => !areNamesRepeated(index) } }}
+                                    render={({ onChange }) => (
+                                        <TextField
+                                            error={errors.settings && errors.settings[index] && typeof errors.settings[index]?.name !== 'undefined' || setting.name === 'price'}
+                                            id={`name[${index}]`}
+                                            name={`settings[${index}].name`}
+                                            label="Nombre de la setting"
+                                            helperText={areNamesRepeated(index) ? "Los nombres no pueden repetirse" : "Requerido*"}
+                                            variant="outlined"
+                                            defaultValue={setting.name}
+                                            value={setting.name}
+                                            className={classes.inputF}
+                                            onChange={event => { handleInputChange(event, index); onChange(event); }}
+                                            autoComplete='off'
+                                        />
+                                    )}
+                                />
+
+                                <Controller
+                                    control={control}
+                                    name={`settings[${index}].value`}
+                                    rules={{ validate: { isValid: () => !isFieldEmpty(index, "value") } }}
+                                    render={({ onChange }) => (
+                                        <TextField
+                                            error={errors.settings && errors.settings[index] && typeof errors.settings[index]?.value !== 'undefined'}
+                                            id={`value[${index}]`}
+                                            name={`settings[${index}].value`}
+                                            label="Valor de la setting"
+                                            helperText="Requerido*"
+                                            variant="outlined"
+                                            defaultValue={setting.value}
+                                            value={setting.value}
+                                            className={classes.inputF}
+                                            onChange={event => { handleInputChange(event, index); onChange(event); }}
+                                            autoComplete='off'
+                                        />
+                                    )}
+                                />
+
+                                <ButtonGroup>
+                                    {settingsList.length - 1 === index &&
+                                        <IconButton onClick={handleAddSetting} aria-label="add" color="primary">
+                                            <AddCircleIcon />
+                                        </IconButton>
+                                    }
+
+                                    {settingsList.length !== 1 &&
+                                        <IconButton onClick={event => handleDeleteSetting(index)} aria-label="delete" color="secondary">
+                                            <DeleteIcon />
+                                        </IconButton>
+                                    }
+                                </ButtonGroup>
+                            </React.Fragment>
+                        );
+                    })}
+
+                </form>
+            </DialogContent>
+            <DialogActions>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Finalizar</Button>
+                <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
+            </DialogActions>
+        </>
+    );
+}
+
+export default EditArtifact;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -7,9 +7,6 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Setting from '../../interfaces/Setting';
 import Artifact from '../../interfaces/Artifact';
-import ArtifactService from '../../services/ArtifactService';
-import ArtifactRelation from '../../interfaces/ArtifactRelation';
-
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -28,13 +25,27 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-
-const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[], settingMap: { [key: string]: number[] }, closeEditArtifactDialog: Function, artifactsRelations: ArtifactRelation[], setIsArtifactEdited: Function, setArtifactEdited: Function, setNamesOfSettingsChanged: Function }) => {
+const EditArtifact = (props: { artifactToEdit: Artifact, closeEditArtifactDialog: Function, setIsArtifactEdited: Function, setArtifactEdited: Function, setNamesOfSettingsChanged: Function }) => {
     const classes = useStyles();
     const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
     const { closeEditArtifactDialog } = props;
+
+
+
+    const createSettingsListFromArtifact = () => {
+        let settingsListFromArtifact: Setting[] = [];
+        if (props.artifactToEdit.id === 0) {
+            return settingsListFromArtifact;
+        }
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
+            settingsListFromArtifact.push(settingFromArtifact);
+        });
+        return settingsListFromArtifact;
+    }
+
     //Hook for save the user's settings input
-    const [settingsList, setSettingsList] = React.useState<Setting[]>(props.settingsList);
+    const [settingsList, setSettingsList] = React.useState<Setting[]>(createSettingsListFromArtifact());
     const [price, setPrice] = React.useState(() => {
         let index = settingsList.findIndex(s => s.name === 'price');
         if (index != -1) {
@@ -45,9 +56,18 @@ const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[]
         }
         return 0;
     });
-    const [artifactName, setArtifactName] = React.useState(props.artifactToEdit.name);    
+    const [artifactName, setArtifactName] = React.useState(props.artifactToEdit.name);
+
+    const createSettingsMapFromArtifact = () => {
+        let settingsMapFromArtifact: { [key: string]: number[] } = {};
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            settingsMapFromArtifact[key] = [index];
+        });
+        return settingsMapFromArtifact;
+    }
+
     //Hook for saving the numbers of times a setting's name input is repeated
-    const [settingsMap, setSettingsMap] = React.useState<{ [key: string]: number[] }>(props.settingMap);
+    const [settingsMap, setSettingsMap] = React.useState<{ [key: string]: number[] }>(createSettingsMapFromArtifact());
 
     React.useEffect(() => {
         setNameSettingsErrors();
@@ -62,21 +82,8 @@ const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[]
         artifactEdited.name = artifactName;
         artifactEdited.settings = createSettingsObject();
         props.setArtifactEdited(artifactEdited);
-        console.log(props.artifactToEdit);
         props.setNamesOfSettingsChanged(getNamesOfSettingsChanged());
         props.setIsArtifactEdited(true);
-    }
-
-    const createSettingsListFromArtifact = () => {
-        let settingsListFromArtifact: Setting[] = [];
-        if (props.artifactToEdit.id === 0) {
-            return settingsListFromArtifact;
-        }
-        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
-            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
-            settingsListFromArtifact.push(settingFromArtifact);
-        });
-        return settingsListFromArtifact;
     }
 
     const getNamesOfSettingsChanged = () => {
@@ -86,10 +93,7 @@ const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[]
         if (index != -1) {
             originalSettingsList.splice(index, 1);
         }
-        console.log(originalSettingsList);
         originalSettingsList.forEach((setting, index) => {
-            console.log(setting);
-            console.log(settingsList.find(s => s.name === setting.name));
             if (!settingsList.find(s => s.name === setting.name)) {
                 namesOfSettingsChanged.push(setting.name);
             }
@@ -357,7 +361,7 @@ const EditArtifact = (props: { artifactToEdit: Artifact, settingsList: Setting[]
                 </form>
             </DialogContent>
             <DialogActions>
-                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Finalizar</Button>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Listo</Button>
                 <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
             </DialogActions>
         </>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -1,11 +1,8 @@
-﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
+﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import * as React from 'react';
-import { useForm, Controller } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import Typography from '@material-ui/core/Typography';
-import AddCircleIcon from '@material-ui/icons/AddCircle';
-import DeleteIcon from '@material-ui/icons/Delete';
-import Setting from '../../interfaces/Setting';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -92,7 +92,7 @@ const EditArtifactConfirmation = (props: {
                 <hr/>
                 <Typography gutterBottom>
                     Revise las características con las que quedará su artefacto modificado
-                    y se está de acuerdo haga click en confirmar
+                    y si está de acuerdo haga click en confirmar
                 </Typography>
                 <Typography gutterBottom>
                     <span className={classes.title}>Nombre:</span> {props.artifactToEdit.name}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -26,7 +26,16 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 
-const EditArtifactConfirmation = (props: { artifactToEdit: Artifact, namesOfSettingsChanged: string[], closeEditArtifactDialog: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, artifactsRelations: ArtifactRelation[] }) => {
+const EditArtifactConfirmation = (props: {
+    artifactToEdit: Artifact,
+    namesOfSettingsChanged: string[],
+    closeEditArtifactDialog: Function,
+    setOpenSnackbar: Function,
+    setSnackbarSettings: Function,
+    artifactsRelations: ArtifactRelation[]
+    updateArtifacts: Function,
+    updateRelations: Function }) => {
+
     const classes = useStyles();
     const { handleSubmit } = useForm();
 
@@ -81,6 +90,8 @@ const EditArtifactConfirmation = (props: { artifactToEdit: Artifact, namesOfSett
             props.setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
             props.setOpenSnackbar(true);
         }
+        props.updateArtifacts();
+        props.updateRelations();
         props.closeEditArtifactDialog();
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -5,7 +5,6 @@ import { useForm } from 'react-hook-form';
 import Typography from '@material-ui/core/Typography';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
-import ArtifactRelation from '../../interfaces/ArtifactRelation';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -29,7 +28,6 @@ const EditArtifactConfirmation = (props: {
     closeEditArtifactDialog: Function,
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
-    artifactsRelations: ArtifactRelation[]
     updateArtifacts: Function,
     updateRelations: Function }) => {
 
@@ -49,30 +47,6 @@ const EditArtifactConfirmation = (props: {
             }
         };
 
-        let artifactsRelationsIdsToDelete: string[] = [];
-
-        props.artifactsRelations.forEach(async relation => {
-            if (props.namesOfSettingsChanged.includes(relation.artifact1Property) || props.namesOfSettingsChanged.includes(relation.artifact2Property)) {
-                artifactsRelationsIdsToDelete.push(relation.id!);
-            }            
-        });
-
-        try {
-            const response = await ArtifactService.deleteRelations(artifactsRelationsIdsToDelete);
-            if (response.status === 204) {
-                props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
-                props.setOpenSnackbar(true);
-            } else {
-                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
-                props.setOpenSnackbar(true);
-                return;
-            }
-        }
-        catch (error) {
-            props.setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-            props.setOpenSnackbar(true);
-        }
-
         try {
             const response = await ArtifactService.update(props.artifactToEdit.id, artifactEdited);
             if (response.status === 200) {
@@ -84,7 +58,7 @@ const EditArtifactConfirmation = (props: {
             }
         }
         catch (error) {
-            props.setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+            props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
             props.setOpenSnackbar(true);
         }
         props.updateArtifacts();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -18,6 +18,9 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         settingName: {
             fontStyle: 'italic'
+        },
+        listStyleNone: {
+            listStyle: 'none'
         }
     }),
 );
@@ -89,15 +92,25 @@ const EditArtifactConfirmation = (props: { artifactToEdit: Artifact, namesOfSett
         <>
             <DialogTitle id="alert-dialog-title">Confirmación</DialogTitle>
             <DialogContent>
-                {props.namesOfSettingsChanged.length > 0 ? 
-                    <Typography gutterBottom color="secondary">
-                        Tenga en cuenta que al modificar el nombre de alguna de las settings se borrará las relaciones asociadas
+                {props.namesOfSettingsChanged.length > 0 ?
+                    <Typography gutterBottom color="secondary" className={classes.title}>
+                        Tenga en cuenta que al modificar el nombre de alguna de las settings se borrará
+                        las relaciones asociadas.
+                        Las settings cuyos nombres serán modificados son:
+                        <br />
+                        <br />
+                        <li className={classes.listStyleNone}>
+                            {props.namesOfSettingsChanged.map(name => {
+                                return (<ul>{name}</ul>);
+                            })}
+                        </li>
                     </Typography> :
                     null
                 }
-                
+                <hr/>
                 <Typography gutterBottom>
-                    Revise las características de su nuevo artefacto y se está de acuerdo haga click en confirmar
+                    Revise las características con las que quedará su artefacto modificado
+                    y se está de acuerdo haga click en confirmar
                 </Typography>
                 <Typography gutterBottom>
                     <span className={classes.title}>Nombre:</span> {props.artifactToEdit.name}
@@ -109,13 +122,12 @@ const EditArtifactConfirmation = (props: { artifactToEdit: Artifact, namesOfSett
                     <span className={classes.title}>Propiedades:</span>
                 </Typography>
                 {
-                    Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
-                        return (
+                    Object.entries(props.artifactToEdit.settings).map(([key, value], index) =>  (
                             <Typography gutterBottom>
-                                <span className={classes.settingName}>{"Hola"}</span>: {"Hola2"}
+                                <span className={classes.settingName}>{key}</span>: {value}
                             </Typography>
-                        );
-                    })
+                        )
+                    )
                 }
             </DialogContent>
             <DialogActions>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -1,0 +1,129 @@
+﻿import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, IconButton, ButtonGroup } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import * as React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import Typography from '@material-ui/core/Typography';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
+import DeleteIcon from '@material-ui/icons/Delete';
+import Setting from '../../interfaces/Setting';
+import Artifact from '../../interfaces/Artifact';
+import ArtifactService from '../../services/ArtifactService';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
+
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        title: {
+            fontWeight: 'bold'
+        },
+        settingName: {
+            fontStyle: 'italic'
+        }
+    }),
+);
+
+
+const EditArtifactConfirmation = (props: { artifactToEdit: Artifact, namesOfSettingsChanged: string[], closeEditArtifactDialog: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, artifactsRelations: ArtifactRelation[] }) => {
+    const classes = useStyles();
+    const { handleSubmit } = useForm();
+
+    //Create the artifact after submit
+    const handleConfirm = async () => {
+
+        const artifactEdited = {
+            name: props.artifactToEdit.name,
+            provider: props.artifactToEdit.provider,
+            artifactTypeId: props.artifactToEdit.artifactType.id,
+            projectId: props.artifactToEdit.projectId,
+            settings: {
+                settings: props.artifactToEdit.settings
+            }
+        };
+
+        let artifactsRelationsIdsToDelete: string[] = [];
+
+        props.artifactsRelations.forEach(async relation => {
+            if (props.namesOfSettingsChanged.includes(relation.artifact1Property) || props.namesOfSettingsChanged.includes(relation.artifact2Property)) {
+                artifactsRelationsIdsToDelete.push(relation.id!);
+            }            
+        });
+
+        try {
+            const response = await ArtifactService.deleteRelations(artifactsRelationsIdsToDelete);
+            if (response.status === 204) {
+                props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
+                props.setOpenSnackbar(true);
+            } else {
+                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
+                props.setOpenSnackbar(true);
+                return;
+            }
+        }
+        catch (error) {
+            props.setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+            props.setOpenSnackbar(true);
+        }
+
+        try {
+            const response = await ArtifactService.update(props.artifactToEdit.id, artifactEdited);
+            if (response.status === 200) {
+                props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
+                props.setOpenSnackbar(true);
+            } else {
+                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
+                props.setOpenSnackbar(true);
+            }
+        }
+        catch (error) {
+            props.setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+            props.setOpenSnackbar(true);
+        }
+        props.closeEditArtifactDialog();
+    }
+
+    const handleCancel = () => {
+        props.closeEditArtifactDialog();
+    }
+
+    return (
+        <>
+            <DialogTitle id="alert-dialog-title">Confirmación</DialogTitle>
+            <DialogContent>
+                {props.namesOfSettingsChanged.length > 0 ? 
+                    <Typography gutterBottom color="secondary">
+                        Tenga en cuenta que al modificar el nombre de alguna de las settings se borrará las relaciones asociadas
+                    </Typography> :
+                    null
+                }
+                
+                <Typography gutterBottom>
+                    Revise las características de su nuevo artefacto y se está de acuerdo haga click en confirmar
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Nombre:</span> {props.artifactToEdit.name}
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Provedor:</span> {props.artifactToEdit.artifactType.name}
+                </Typography>
+                <Typography gutterBottom>
+                    <span className={classes.title}>Propiedades:</span>
+                </Typography>
+                {
+                    Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+                        return (
+                            <Typography gutterBottom>
+                                <span className={classes.settingName}>{"Hola"}</span>: {"Hola2"}
+                            </Typography>
+                        );
+                    })
+                }
+            </DialogContent>
+            <DialogActions>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Finalizar</Button>
+                <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
+            </DialogActions>
+        </>
+    );
+}
+
+export default EditArtifactConfirmation;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -8,7 +8,17 @@ import EditArtifactConfirmation from './EditArtifactConfirmation';
 import Setting from '../../interfaces/Setting';
 
 
-const EditArtifactDialog = (props: { artifactToEdit: Artifact, showEditArtifactDialog: boolean, closeEditArtifactDialog: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, projectId: number, artifactsRelations: ArtifactRelation[] }) => {
+const EditArtifactDialog = (props: {
+    artifactToEdit: Artifact,
+    showEditArtifactDialog: boolean,
+    closeEditArtifactDialog: Function,
+    setOpenSnackbar: Function,
+    setSnackbarSettings: Function,
+    projectId: number,
+    artifactsRelations: ArtifactRelation[],
+    updateArtifacts: Function,
+    updateRelations: Function }) => {
+
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
     //Hook for save the user's settings input
@@ -56,6 +66,8 @@ const EditArtifactDialog = (props: { artifactToEdit: Artifact, showEditArtifactD
                     setOpenSnackbar={props.setOpenSnackbar}
                     setSnackbarSettings={props.setSnackbarSettings}
                     artifactsRelations={artifactsRelations}
+                    updateArtifacts={props.updateArtifacts}
+                    updateRelations={props.updateRelations}
                 />
             }
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -5,7 +5,6 @@ import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import EditArtifact from './EditArtifact';
 import EditArtifactConfirmation from './EditArtifactConfirmation';
-import Setting from '../../interfaces/Setting';
 
 
 const EditArtifactDialog = (props: {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -13,40 +13,14 @@ const EditArtifactDialog = (props: {
     closeEditArtifactDialog: Function,
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
-    projectId: number,
-    artifactsRelations: ArtifactRelation[],
     updateArtifacts: Function,
     updateRelations: Function }) => {
 
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
-    //Hook for save the user's settings input
     const [isArtifactEdited, setIsArtifactEdited] = React.useState<boolean>(false);
     const [artifactEdited, setArtifactEdited] = React.useState<Artifact>(props.artifactToEdit);
-    const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [namesOfSettingsChanged, setNamesOfSettingsChanged] = React.useState<string[]>([]);
-
-    const getArtifactsRelations = async () => {
-        try {
-            const response = await ArtifactService.getRelations(props.artifactToEdit.id);
-
-            if (response.status == 200) {
-                setArtifactsRelations(response.data);
-            }
-            else {
-                props.setSnackbarSettings({ message: "Hubo un error al cargar las relaciones", severity: "error" });
-                props.setOpenSnackbar(true);
-            }
-        }
-        catch {
-            props.setSnackbarSettings({ message: "Hubo un error al cargar las relaciones", severity: "error" });
-            props.setOpenSnackbar(true);
-        }
-    }
-
-    React.useEffect(() => {
-        getArtifactsRelations();
-    }, [props.artifactToEdit]);
 
     return (
         <Dialog open={showEditArtifactDialog}>
@@ -64,7 +38,6 @@ const EditArtifactDialog = (props: {
                     closeEditArtifactDialog={closeEditArtifactDialog}
                     setOpenSnackbar={props.setOpenSnackbar}
                     setSnackbarSettings={props.setSnackbarSettings}
-                    artifactsRelations={artifactsRelations}
                     updateArtifacts={props.updateArtifacts}
                     updateRelations={props.updateRelations}
                 />

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -1,0 +1,88 @@
+﻿import { Dialog } from '@material-ui/core';
+import * as React from 'react';
+import Artifact from '../../interfaces/Artifact';
+import ArtifactService from '../../services/ArtifactService';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
+import EditArtifact from './EditArtifact';
+import EditArtifactConfirmation from './EditArtifactConfirmation';
+import Setting from '../../interfaces/Setting';
+
+
+const EditArtifactDialog = (props: { artifactToEdit: Artifact, showEditArtifactDialog: boolean, closeEditArtifactDialog: Function, setOpenSnackbar: Function, setSnackbarSettings: Function, projectId: number, artifactsRelations: ArtifactRelation[] }) => {
+    const { showEditArtifactDialog, closeEditArtifactDialog } = props;
+
+    //Hook for save the user's settings input
+    const [isArtifactEdited, setIsArtifactEdited] = React.useState<boolean>(false);
+    const [artifactEdited, setArtifactEdited] = React.useState<Artifact>(props.artifactToEdit);
+    const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
+    const [namesOfSettingsChanged, setNamesOfSettingsChanged] = React.useState<string[]>([]);
+
+    const getArtifactsRelations = async () => {
+        try {
+            const response = await ArtifactService.getRelations(props.artifactToEdit.id);
+
+            if (response.status == 200) {
+                setArtifactsRelations(response.data);
+            }
+            else {
+                props.setSnackbarSettings({ message: "Hubo un error al cargar las relaciones", severity: "error" });
+                props.setOpenSnackbar(true);
+            }
+        }
+        catch {
+            props.setSnackbarSettings({ message: "Hubo un error al cargar las relaciones", severity: "error" });
+            props.setOpenSnackbar(true);
+        }
+    }
+
+    const createSettingsListFromArtifact = () => {
+        let settingsListFromArtifact: Setting[] = [];
+        if (props.artifactToEdit.id === 0) {
+            return settingsListFromArtifact;
+        }
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
+            settingsListFromArtifact.push(settingFromArtifact);
+        });
+        return settingsListFromArtifact;
+    }
+
+    const createSettingsMapFromArtifact = () => {
+        let settingsMapFromArtifact: { [key: string]: number[] } = {};
+        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
+            settingsMapFromArtifact[key] = [index];
+        });
+        return settingsMapFromArtifact;
+    }
+
+    React.useEffect(() => {
+        getArtifactsRelations();
+    }, [props.artifactToEdit]);
+
+    return (
+        <Dialog open={showEditArtifactDialog}>
+            {!isArtifactEdited ?
+                <EditArtifact
+                    artifactToEdit={props.artifactToEdit}
+                    settingsList={createSettingsListFromArtifact()}
+                    settingMap={createSettingsMapFromArtifact()}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    artifactsRelations={artifactsRelations}
+                    setIsArtifactEdited={setIsArtifactEdited}
+                    setArtifactEdited={setArtifactEdited}
+                    setNamesOfSettingsChanged={setNamesOfSettingsChanged}
+                /> :
+                <EditArtifactConfirmation
+                    artifactToEdit={artifactEdited}
+                    namesOfSettingsChanged={namesOfSettingsChanged}
+                    closeEditArtifactDialog={closeEditArtifactDialog}
+                    setOpenSnackbar={props.setOpenSnackbar}
+                    setSnackbarSettings={props.setSnackbarSettings}
+                    artifactsRelations={artifactsRelations}
+                />
+            }
+        </Dialog>
+    );
+}
+
+export default EditArtifactDialog;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -35,26 +35,6 @@ const EditArtifactDialog = (props: { artifactToEdit: Artifact, showEditArtifactD
         }
     }
 
-    const createSettingsListFromArtifact = () => {
-        let settingsListFromArtifact: Setting[] = [];
-        if (props.artifactToEdit.id === 0) {
-            return settingsListFromArtifact;
-        }
-        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
-            let settingFromArtifact: Setting = Object.assign({ name: key, value: value });
-            settingsListFromArtifact.push(settingFromArtifact);
-        });
-        return settingsListFromArtifact;
-    }
-
-    const createSettingsMapFromArtifact = () => {
-        let settingsMapFromArtifact: { [key: string]: number[] } = {};
-        Object.entries(props.artifactToEdit.settings).forEach(([key, value], index) => {
-            settingsMapFromArtifact[key] = [index];
-        });
-        return settingsMapFromArtifact;
-    }
-
     React.useEffect(() => {
         getArtifactsRelations();
     }, [props.artifactToEdit]);
@@ -64,10 +44,7 @@ const EditArtifactDialog = (props: { artifactToEdit: Artifact, showEditArtifactD
             {!isArtifactEdited ?
                 <EditArtifact
                     artifactToEdit={props.artifactToEdit}
-                    settingsList={createSettingsListFromArtifact()}
-                    settingMap={createSettingsMapFromArtifact()}
                     closeEditArtifactDialog={closeEditArtifactDialog}
-                    artifactsRelations={artifactsRelations}
                     setIsArtifactEdited={setIsArtifactEdited}
                     setArtifactEdited={setArtifactEdited}
                     setNamesOfSettingsChanged={setNamesOfSettingsChanged}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -68,6 +68,14 @@ class ArtifactService {
             return error.response ? error.response : error.message;
         }
     };
+
+    static deleteRelations = async (artifactRelationIds: any) => {
+        try {
+            return await axios.delete(`${BASE_URL}relations`, { data: artifactRelationIds });
+        } catch (error) {
+            return error.response ? error.response : error.message;
+        }
+    };
     
     static setRelations = async (artifactRelationsList: any) => {
         try {

--- a/FiveRockingFingers/FRF.Web/FRF.Web.csproj
+++ b/FiveRockingFingers/FRF.Web/FRF.Web.csproj
@@ -38,6 +38,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifact.tsx" />
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifactConfirmation.tsx" />
+    <None Remove="ClientApp\src\components\ArtifactsComponents\EditArtifactDialog.tsx" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FRF.Core\FRF.Core.csproj" />
     <ProjectReference Include="..\FRF.Web.Dtos\FRF.Web.Dtos.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Este PR corresponde a la parte del frontend de la modificación de artefactos custom. Se hizo un formulario parecido al de creación donde se puede modificar el nombre del artefacto y las settings (ya sea nombre o valor). Al modificarse el nombre de un setting se borran todas las relaciones asociadas a esa setting

https://user-images.githubusercontent.com/71278846/109206441-9db2dd00-7786-11eb-8a41-5121584fa339.mp4


