### PR TITLE
[FIVE-341] Eliminar bidirección en relaciones de settings

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -82,30 +82,18 @@ namespace FRF.Core.Services
         /// <param name="isAnUpdate">True if is to update, False if is a set</param>
         /// <returns>True if At least one of the artifact relation provided already exist </returns>
         private bool IsAnyRelationRepeated(IList<EntityModels.ArtifactsRelation> dbArtifactRelations,
-            IList<ArtifactsRelation> artifactsRelations, bool isAnUpdate)
+            IList<ArtifactsRelation> artifactsRelations)
         {
-            if (isAnUpdate)
-            {
-                return artifactsRelations.Any(ar => dbArtifactRelations.Any(dbAr =>
-                    (dbAr.Artifact1Id == ar.Artifact1Id && dbAr.Artifact2Id == ar.Artifact2Id &&
-                     dbAr.Artifact1Property.Equals(ar.Artifact1Property, StringComparison.InvariantCultureIgnoreCase) &&
-                     dbAr.Artifact2Property.Equals(ar.Artifact2Property, StringComparison.InvariantCultureIgnoreCase) &&
-                     dbAr.RelationTypeId == ar.RelationTypeId)
-                    ||
-                    (dbAr.Artifact1Id == ar.Artifact2Id && dbAr.Artifact2Id == ar.Artifact1Id &&
-                     dbAr.Artifact1Property.Equals(ar.Artifact2Property, StringComparison.InvariantCultureIgnoreCase) &&
-                     dbAr.Artifact2Property.Equals(ar.Artifact1Property, StringComparison.InvariantCultureIgnoreCase) &&
-                     dbAr.RelationTypeId == ar.RelationTypeId)));
-            }
-
-            return  artifactsRelations.Any(ar => dbArtifactRelations.Any(dbAr =>
+            return artifactsRelations.Any(ar => dbArtifactRelations.Any(dbAr =>
                 (dbAr.Artifact1Id == ar.Artifact1Id && dbAr.Artifact2Id == ar.Artifact2Id &&
                  dbAr.Artifact1Property.Equals(ar.Artifact1Property, StringComparison.InvariantCultureIgnoreCase) &&
-                 dbAr.Artifact2Property.Equals(ar.Artifact2Property, StringComparison.InvariantCultureIgnoreCase))
+                 dbAr.Artifact2Property.Equals(ar.Artifact2Property, StringComparison.InvariantCultureIgnoreCase) &&
+                 dbAr.RelationTypeId == ar.RelationTypeId)
                 ||
                 (dbAr.Artifact1Id == ar.Artifact2Id && dbAr.Artifact2Id == ar.Artifact1Id &&
                  dbAr.Artifact1Property.Equals(ar.Artifact2Property, StringComparison.InvariantCultureIgnoreCase) &&
-                 dbAr.Artifact2Property.Equals(ar.Artifact1Property, StringComparison.InvariantCultureIgnoreCase))));
+                 dbAr.Artifact2Property.Equals(ar.Artifact1Property, StringComparison.InvariantCultureIgnoreCase) &&
+                 dbAr.RelationTypeId == ar.RelationTypeId)));
         }
 
         public async Task<ServiceResponse<List<Artifact>>> GetAll()
@@ -289,7 +277,7 @@ namespace FRF.Core.Services
                     ar.Artifact1Id == artifactRelations[0].Artifact2Id)
                 .ToListAsync();
 
-            var relationsRepeated = IsAnyRelationRepeated(dbArtifactRelations, artifactRelations,isAnUpdate: false);
+            var relationsRepeated = IsAnyRelationRepeated(dbArtifactRelations, artifactRelations);
             if (relationsRepeated)
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationAlreadyExisted, "At least one of the relations already existed"));
 
@@ -366,7 +354,7 @@ namespace FRF.Core.Services
                 .Include(ar => ar.Artifact2)
                 .ToListAsync();
 
-            var relationsWithOriginalRepeated = IsAnyRelationRepeated(relationsOriginal, artifactsRelationsNew,isAnUpdate: true);
+            var relationsWithOriginalRepeated = IsAnyRelationRepeated(relationsOriginal, artifactsRelationsNew);
             if (relationsWithOriginalRepeated)
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the artifact relation provided already exist"));

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactsRelationInsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactsRelationInsertDTO.cs
@@ -16,7 +16,7 @@ namespace FRF.Web.Dtos.Artifacts
         [Required]
         public string Artifact2Property { get; set; }
         [Required]
-        [Range(0, 2)]
+        [Range(0, 1)]
         public int RelationTypeId { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactsRelationUpdateDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactsRelationUpdateDTO.cs
@@ -18,7 +18,7 @@ namespace FRF.Web.Dtos.Artifacts
         [Required]
         public string Artifact2Property { get; set; }
         [Required]
-        [Range(0, 2)]
+        [Range(0, 1)]
         public int RelationTypeId { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactRelationRow.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactRelationRow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import ArtifactRelation from '../../interfaces/ArtifactRelation'
 import { Button } from 'reactstrap';
 import EditArtifactRelation from './EditArtifactRelation';
-import SyncAltIcon from '@material-ui/icons/SyncAlt';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import Artifact from '../../interfaces/Artifact';
@@ -31,8 +30,6 @@ const ArtifactRelationRow = (props: { artifactRelation: ArtifactRelation, artifa
                 return <ArrowForwardIcon />
             case 1:
                 return <ArrowBackIcon />
-            case 2:
-                return <SyncAltIcon />
             default:
                 return <ArrowForwardIcon />
         };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -6,7 +6,6 @@ import Typography from '@material-ui/core/Typography';
 import Artifact from '../../interfaces/Artifact';
 import KeyValueStringPair from '../../interfaces/KeyValueStringPair';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
-import SyncAltIcon from '@material-ui/icons/SyncAlt';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../../services/ArtifactService';
@@ -289,9 +288,6 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                                     </MenuItem>
                                     <MenuItem value="1">
                                         <em><ArrowBackIcon /></em>
-                                    </MenuItem>
-                                    <MenuItem value="2">
-                                        <em><SyncAltIcon /></em>
                                     </MenuItem>
                                 </Select>
                             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/RelationCard.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/RelationCard.tsx
@@ -1,7 +1,6 @@
 ﻿import * as React from 'react';
 import Typography from '@material-ui/core/Typography';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
-import SyncAltIcon from '@material-ui/icons/SyncAlt';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import { IconButton } from '@material-ui/core';
@@ -27,8 +26,6 @@ const RelationCard = (props: { Relation: ArtifactRelation, index: number, delete
                 return <ArrowForwardIcon />;
             case (1):
                 return <ArrowBackIcon />;
-            case (2):
-                return <SyncAltIcon />;
             default:
                 return null;
         }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -7,7 +7,6 @@ import Artifact from '../interfaces/Artifact';
 import KeyValueStringPair from '../interfaces/KeyValueStringPair';
 import ArtifactRelation from '../interfaces/ArtifactRelation';
 import RelationCard from './NewArtifactRelationComponents/RelationCard';
-import SyncAltIcon from '@material-ui/icons/SyncAlt';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
@@ -364,9 +363,6 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     </MenuItem>
                                     <MenuItem value="1">
                                         <em><ArrowBackIcon /></em>
-                                    </MenuItem>
-                                    <MenuItem value="2">
-                                        <em><SyncAltIcon /></em>
                                     </MenuItem>
                                 </Select>
                             }

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -761,7 +761,100 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(artifactsRelationToSave[0].Artifact2Id, artifactsRelationInDb[0].Artifact2Id);
             Assert.Equal(artifactsRelationToSave[0].Artifact1Id, artifactsRelationInDb[0].Artifact1Id);
         }
+        
+        [Fact]
+        public async Task SetRelationAsync_ReturnsNull_WhenIsAnyBidirectionalRelationSameRelationType()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var project = CreateProject();
+            var artifact1 = CreateArtifact(project, artifactType);
+            var artifact2 = CreateArtifact(project, artifactType);
 
+            var artifactRelation1 = new ArtifactsRelation()
+            {
+                Artifact1Id = artifact1.Id,
+                Artifact2Id = artifact2.Id,
+                Artifact1Property = "Mock 1 Property",
+                Artifact2Property = "Mock 2 Property",
+                RelationTypeId = 1
+            };
+            var artifactRelation2 = new ArtifactsRelation()
+            {
+                Artifact1Id = artifact2.Id,
+                Artifact2Id = artifact1.Id,
+                Artifact1Property = "Mock 2 Property",
+                Artifact2Property = "Mock 1 Property",
+                RelationTypeId = 1
+            };
+            artifactsRelationToSave.Add(artifactRelation1);
+            artifactsRelationToSave.Add(artifactRelation2);
+            await _dataAccess.ArtifactsRelation.AddAsync(
+                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
+            await _dataAccess.ArtifactsRelation.AddAsync(
+                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation2));
+
+            await _dataAccess.SaveChangesAsync();
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(artifactsRelationToSave);
+
+            // Assert
+            Assert.False(response.Success);
+            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.NotNull(response.Error);
+            Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
+            Assert.Null(response.Value);
+        }
+
+        [Fact]
+        public async Task SetRelationAsync_ReturnsNull_WhenIsAnyBidirectionalRelationDiferentRelationType()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var project = CreateProject();
+            var artifact1 = CreateArtifact(project, artifactType);
+            var artifact2 = CreateArtifact(project, artifactType);
+
+            var artifactRelation1 = new ArtifactsRelation()
+            {
+                Artifact1Id = artifact1.Id,
+                Artifact2Id = artifact2.Id,
+                Artifact1Property = "Mock 1 Property",
+                Artifact2Property = "Mock 2 Property",
+                RelationTypeId = 1
+            };
+            var artifactRelation2 = new ArtifactsRelation()
+            {
+                Artifact1Id = artifact1.Id,
+                Artifact2Id = artifact2.Id,
+                Artifact1Property = "Mock 1 Property",
+                Artifact2Property = "Mock 2 Property",
+                RelationTypeId = 0
+            };
+            artifactsRelationToSave.Add(artifactRelation1);
+            artifactsRelationToSave.Add(artifactRelation2);
+            await _dataAccess.ArtifactsRelation.AddAsync(
+                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
+            await _dataAccess.ArtifactsRelation.AddAsync(
+                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation2));
+
+            await _dataAccess.SaveChangesAsync();
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(artifactsRelationToSave);
+
+            // Assert
+            Assert.False(response.Success);
+            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.NotNull(response.Error);
+            Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
+            Assert.Null(response.Value);
+        }
         [Fact]
         public async Task UpdateRelationAsync_ReturnsNull_WhenIsAnyArtifactExcept()
         {

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -789,12 +789,9 @@ namespace FRF.Core.Tests.Services
                 Artifact2Property = "Mock 1 Property",
                 RelationTypeId = 1
             };
-            artifactsRelationToSave.Add(artifactRelation1);
             artifactsRelationToSave.Add(artifactRelation2);
             await _dataAccess.ArtifactsRelation.AddAsync(
                 _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
-            await _dataAccess.ArtifactsRelation.AddAsync(
-                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation2));
 
             await _dataAccess.SaveChangesAsync();
 
@@ -836,13 +833,10 @@ namespace FRF.Core.Tests.Services
                 Artifact2Property = "Mock 2 Property",
                 RelationTypeId = 0
             };
-            artifactsRelationToSave.Add(artifactRelation1);
             artifactsRelationToSave.Add(artifactRelation2);
             await _dataAccess.ArtifactsRelation.AddAsync(
                 _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
-            await _dataAccess.ArtifactsRelation.AddAsync(
-                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation2));
-
+            
             await _dataAccess.SaveChangesAsync();
 
             // Act
@@ -916,22 +910,23 @@ namespace FRF.Core.Tests.Services
                 var artifact2Id = artifactIdToUpdate;
 
                 var artifactRelation = CreateArtifactsRelationModel(artifact1Id, artifact2Id);
-                
+
+
                 var artifactRelationDb = _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(CreateArtifactsRelationModel(artifact1Id, artifact2Id));
                 await _dataAccess.ArtifactsRelation.AddAsync(artifactRelationDb);
 
                 artifactRelation.Id = artifactRelationDb.Id;
                 artifactsRelationUpdated.Add(artifactRelation);
                 artifactsRelationInDb.Add(artifactRelationDb);
-                
+
                 i++;
             }
 
             await _dataAccess.SaveChangesAsync();
-            
+
             // Act
             var response = await _classUnderTest.UpdateRelationAsync(artifactIdToUpdate, artifactsRelationUpdated);
-            
+
             // Assert
             Assert.True(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -677,6 +677,40 @@ namespace FRF.Web.Tests.Controllers
             Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
             _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()), Times.Once);
         }
+        [Fact]
+        public async Task SetRelationAsync_ReturnBadRequest_WhenIsaBidirectionalRelation()
+        {
+            // Arrange
+            var artifactsRelationDtos = new List<ArtifactsRelationInsertDTO>();
+            artifactsRelationDtos.Add(new ArtifactsRelationInsertDTO()
+            {
+                Artifact1Id = 1,
+                Artifact2Id = 2,
+                Artifact1Property = "Mock 1 Property ",
+                Artifact2Property = "Mock 2 Property ",
+                RelationTypeId = 1
+            });
+            artifactsRelationDtos.Add(new ArtifactsRelationInsertDTO()
+            {
+                Artifact1Id = 2,
+                Artifact2Id = 1,
+                Artifact1Property = "Mock 1 Property ",
+                Artifact2Property = "Mock 2 Property ",
+                RelationTypeId = 0
+            });
+
+            _artifactsService
+                .Setup(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()))
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "Error Message")));
+
+            // Act
+            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos);
+
+            // Assert
+            var response = Assert.IsType<BadRequestResult>(result);
+            Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
+            _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()), Times.Once);
+        }
 
         [Fact]
         public async Task GetRelationsAsync_ReturnOk()


### PR DESCRIPTION
## Descripción:
Se debe eliminar la posibilidad de crear relaciones bidireccionales (en ambos sentidos). Estas no se van a utilizar en el sistema de ahora en adelante, por lo que tampoco debe existir este tipo de relación.

## Realizado:
- Se eliminó la posibilidad de crear relaciones bidireccionales en ArtifactsService, como también en capa de presentación.
- Se modificaron DTOS ArtifactRelation para que solo reciban valores: 0 y 1,
- Se agregaron Unit Test en ArtifactsServiceTests y ArtifactsControllerTests, para validar lo modificado.