### PR TITLE
[FIVE-345] Control de ciclo infinito de actualización por relaciones

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -13,6 +13,7 @@
         public const int RelationAlreadyExisted = 10;
         public const int RelationNotValid = 11;
         public const int RelationNotExists = 12;
+        public const int RelationCycleDetected = 13;
 
         // User errors
         public const int InvalidCredentials = 20;

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -113,12 +113,28 @@ namespace FRF.Core.Tests.Services
         private CoreModels.ArtifactsRelation CreateArtifactsRelationModel(int artifact1Id,int artifact2Id)
         {
             var random = new Random();
+            var propertyId = random.Next(1000);
             var artifactRelation = new CoreModels.ArtifactsRelation()
             {
                 Artifact1Id = artifact1Id,
                 Artifact2Id = artifact2Id,
                 Artifact1Property = "Mock 1 Property "+propertyId,
                 Artifact2Property = "Mock 2 Property "+propertyId,
+                RelationTypeId = 1
+            };
+
+            return artifactRelation;
+        }
+
+        private CoreModels.ArtifactsRelation CreateArtifactsRelationModel(int artifact1Id, int artifact2Id, string setting1, string setting2)
+        {
+            var random = new Random();
+            var artifactRelation = new CoreModels.ArtifactsRelation()
+            {
+                Artifact1Id = artifact1Id,
+                Artifact2Id = artifact2Id,
+                Artifact1Property = setting1,
+                Artifact2Property = setting2,
                 RelationTypeId = 1
             };
 
@@ -708,7 +724,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsListOfRelations()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var artifactsRelationInDb = new List<DataAccess.EntityModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
@@ -744,7 +760,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenBaseArtifactNoExist()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var baseArtifactId = int.MaxValue;
 
             var artifact = CreateArtifact();
@@ -765,7 +781,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenIsAnyArtifactRepeated()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
@@ -795,7 +811,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenIsAnyRelationRepeated()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
@@ -829,7 +845,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenHasAnyRelationWithoutBaseArtifact()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
@@ -861,7 +877,7 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenHasAnyArtifactFromAnotherProject()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
@@ -879,8 +895,6 @@ namespace FRF.Core.Tests.Services
             var artifact2FromAnotherProject = CreateArtifact(notBaseProject, artifactType);
             var artifactRelationWithArtifactsFromAnotherProject = CreateArtifactsRelationModel(artifactFromAnotherProject.Id, artifact2FromAnotherProject.Id);
             artifactsRelationToSave.Add(artifactRelationWithArtifactsFromAnotherProject);
-
-            artifactsRelationToSave.Add(CreateArtifactsRelationModel(artifact1.Id, artifact2.Id, "[Mock] Property artefact 1", "[Mock] Property artefact 2"));
 
             // Act
 
@@ -916,7 +930,7 @@ namespace FRF.Core.Tests.Services
             newArtifactRelationList.Add(CreateArtifactsRelationModel(artifact3.Id, artifact1.Id, "[Mock] Property artefact 3", "[Mock] Property artefact 1"));
 
             // Act
-            var response = await _classUnderTest.SetRelationAsync(newArtifactRelationList);
+            var response = await _classUnderTest.SetRelationAsync(artifact1.Id, newArtifactRelationList);
 
             // Assert
             Assert.False(response.Success);
@@ -947,7 +961,7 @@ namespace FRF.Core.Tests.Services
             newArtifactRelationList.Add(CreateArtifactsRelationModel(artifact2.Id, artifact1.Id, "[Mock] Property artefact 22", "[Mock] Property artefact 11"));
 
             // Act
-            var response = await _classUnderTest.SetRelationAsync(newArtifactRelationList);
+            var response = await _classUnderTest.SetRelationAsync(artifact1.Id, newArtifactRelationList);
 
             // Assert
             Assert.False(response.Success);

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -850,14 +850,14 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenIsAnyBidirectionalRelationSameRelationType()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact1 = CreateArtifact(project, artifactType);
             var artifact2 = CreateArtifact(project, artifactType);
 
-            var artifactRelation1 = new ArtifactsRelation()
+            var artifactRelation1 = new CoreModels.ArtifactsRelation()
             {
                 Artifact1Id = artifact1.Id,
                 Artifact2Id = artifact2.Id,
@@ -865,7 +865,7 @@ namespace FRF.Core.Tests.Services
                 Artifact2Property = "Mock 2 Property",
                 RelationTypeId = 1
             };
-            var artifactRelation2 = new ArtifactsRelation()
+            var artifactRelation2 = new CoreModels.ArtifactsRelation()
             {
                 Artifact1Id = artifact2.Id,
                 Artifact2Id = artifact1.Id,
@@ -875,7 +875,7 @@ namespace FRF.Core.Tests.Services
             };
             artifactsRelationToSave.Add(artifactRelation2);
             await _dataAccess.ArtifactsRelation.AddAsync(
-                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
+                _mapper.Map<ArtifactsRelation>(artifactRelation1));
 
             await _dataAccess.SaveChangesAsync();
 
@@ -884,7 +884,7 @@ namespace FRF.Core.Tests.Services
 
             // Assert
             Assert.False(response.Success);
-            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
             Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
             Assert.Null(response.Value);
@@ -894,14 +894,14 @@ namespace FRF.Core.Tests.Services
         public async Task SetRelationAsync_ReturnsNull_WhenIsAnyBidirectionalRelationDiferentRelationType()
         {
             // Arange
-            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var artifactsRelationToSave = new List<CoreModels.ArtifactsRelation>();
             var provider = CreateProvider();
             var artifactType = CreateArtifactType(provider);
             var project = CreateProject();
             var artifact1 = CreateArtifact(project, artifactType);
             var artifact2 = CreateArtifact(project, artifactType);
 
-            var artifactRelation1 = new ArtifactsRelation()
+            var artifactRelation1 = new CoreModels.ArtifactsRelation()
             {
                 Artifact1Id = artifact1.Id,
                 Artifact2Id = artifact2.Id,
@@ -909,7 +909,7 @@ namespace FRF.Core.Tests.Services
                 Artifact2Property = "Mock 2 Property",
                 RelationTypeId = 1
             };
-            var artifactRelation2 = new ArtifactsRelation()
+            var artifactRelation2 = new CoreModels.ArtifactsRelation()
             {
                 Artifact1Id = artifact1.Id,
                 Artifact2Id = artifact2.Id,
@@ -919,7 +919,7 @@ namespace FRF.Core.Tests.Services
             };
             artifactsRelationToSave.Add(artifactRelation2);
             await _dataAccess.ArtifactsRelation.AddAsync(
-                _mapper.Map<DataAccess.EntityModels.ArtifactsRelation>(artifactRelation1));
+                _mapper.Map<ArtifactsRelation>(artifactRelation1));
             
             await _dataAccess.SaveChangesAsync();
 
@@ -928,7 +928,7 @@ namespace FRF.Core.Tests.Services
 
             // Assert
             Assert.False(response.Success);
-            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
             Assert.Equal(ErrorCodes.RelationAlreadyExisted, response.Error.Code);
             Assert.Null(response.Value);
@@ -1293,7 +1293,7 @@ namespace FRF.Core.Tests.Services
             var response = await _classUnderTest.DeleteRelationsAsync(artifactRelationIds);
 
             // Assert
-            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
+            Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.False(response.Success);
             Assert.NotNull(response.Error);
             Assert.Equal(ErrorCodes.RelationNotExists, response.Error.Code);
@@ -1308,7 +1308,7 @@ namespace FRF.Core.Tests.Services
             var artifactType = CreateArtifactType(provider);
             var artifact1 = CreateArtifact(project, artifactType);
             var artifact2 = CreateArtifact(project, artifactType);
-            var artifactRelation = CreateArtifactsRelationModel(artifact1.Id, artifact2.Id);
+            var artifactRelation = CreateArtifactsRelationModel(artifact1.Id, artifact2.Id, "[Mock] Property artefact 1", "[Mock] Property artefact 2");
             var artifactRelationMapped = _mapper.Map<FRF.DataAccess.EntityModels.ArtifactsRelation>(artifactRelation);
 
             await _dataAccess.ArtifactsRelation.AddAsync(artifactRelationMapped);
@@ -1324,8 +1324,8 @@ namespace FRF.Core.Tests.Services
 
             // Assert
             Assert.True(response.Success);
-            Assert.IsType<ServiceResponse<IList<ArtifactsRelation>>>(response);
-            var resultValue = Assert.IsAssignableFrom<IList<ArtifactsRelation>>(response.Value);
+            Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
+            var resultValue = Assert.IsAssignableFrom<IList<CoreModels.ArtifactsRelation>>(response.Value);
             Assert.Equal(artifactRelationMapped.Id, resultValue[0].Id);
             Assert.Equal(artifactRelation.Artifact1Id, resultValue[0].Artifact1Id);
             Assert.Equal(artifactRelation.Artifact2Id, resultValue[0].Artifact2Id);


### PR DESCRIPTION
## Descripción
Se debe controlar que no se hagan referencias circulares entre settings para evitar entrar en ciclos de actualizaciones infinitas, ya que al cambiar el valor de una setting actualiza el valor de las settings a las que hace referencia. En la imagen se muestran distintas alternativas para que esto ocurra (por supuesto que hay muchísimas más).
![image](https://user-images.githubusercontent.com/71275374/109669737-2a77e500-7b51-11eb-9d22-531f5ee3aba7.png)

Siguiendo el primer ejemplo, como se actualiza S1 en el artefacto 1, y esta tiene una referencia hacia la S1 del artefacto 2, esta también tiene que actualizarse. Cuando se actualiza la setting del artefacto 2, como esta tiene una referencia hacia la S1 del artefacto 1, esta tiene que actualizarse nuevamente, lo que dispararía una nueva actualización sobre la S1 del artefacto 2, y así sucesivamente. 

## Cambios realizados
Para esto se optó por trabajar las relaciones de los proyectos como un digrafo (grafo dirigido) tomando como nodos los pares [artifactId, setting name] y como las trazas o caminos a las propias relaciones. De esta manera, usando un algoritmo de búsqueda (en este caso DFS) se puede detectar la presencia de ciclos, cubriendo así todos los casos.
En los tests de los métodos SetRelationAsync y UpdateRelationAsync se crearon dos métodos para testear esta funcionalidad, en ambos casos probando que se detecten los ciclos mencionados en los últimos dos ejemplos de la imagen. (El primer ejemplo se detecta como relación duplicada, ya que se relacionan dos veces a los mismos artefactos)

Además de esto, se modificaron algunos de los tests ya existentes para crear los artefactos y sus relaciones en la base de datos de test, ya que por como estaba creado antes, traía varios problemas con dicha detección de ciclos.