### PR TITLE
[FIVE-351] Modificar forma en la que se crean las relaciones entre Artifacts

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -18,6 +18,7 @@
         public const int InvalidCredentials = 20;
         public const int AuthenticationServerCurrentlyUnavailable = 21;
         public const int UserNotExists = 22;
+        public const int UserNotAuthorized = 23;
 
         // External errors
         public const int AmazonApiError = 30;

--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -8,6 +8,7 @@
         public const int CategoryNotExists = 3;
         public const int ProjectNotExists = 4;
         public const int ProviderNotExists = 5;
+        public const int ArtifactFromAnotherProject= 6;
 
         // Relation errors
         public const int RelationAlreadyExisted = 10;
@@ -18,7 +19,6 @@
         public const int InvalidCredentials = 20;
         public const int AuthenticationServerCurrentlyUnavailable = 21;
         public const int UserNotExists = 22;
-        public const int UserNotAuthorized = 23;
 
         // External errors
         public const int AmazonApiError = 30;

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -20,7 +20,6 @@ namespace FRF.Core.Services
         private readonly IMapper _mapper;
         private readonly ISettingsValidator _settingsValidator;
 
-
         public ArtifactsService(DataAccessContext dataContext, IMapper mapper, ISettingsValidator settingsValidator)
         {
             _dataContext = dataContext;
@@ -155,9 +154,9 @@ namespace FRF.Core.Services
 
         private async Task<bool> IsAnyArtifactFromAnotherProject(int baseArtifactId, IList<ArtifactsRelation> artifactsRelations)
         {
-            var baseProjectId = _dataContext.Artifacts.Include(a => a.Project).First(a => a.Id == baseArtifactId).ProjectId;
-            var artifactsIdsFromBaseProject =await _dataContext.Artifacts.Include(a => a.Project)
-                .Where(a => a.Project.Id == baseArtifactId).Select(a => a.Id).ToListAsync();
+            var baseProjectId = _dataContext.Artifacts.First(a => a.Id == baseArtifactId).ProjectId;
+            var artifactsIdsFromBaseProject =await _dataContext.Artifacts
+                .Where(a => a.ProjectId == baseProjectId).Select(a => a.Id).ToListAsync();
             
             var artifactsRelationIds = artifactsRelations
                 .Select(ar => ar.Artifact1Id)

--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsService.cs
@@ -14,7 +14,7 @@ namespace FRF.Core.Services
         Task<ServiceResponse<Artifact>> Update(Artifact artifact);
         Task<ServiceResponse<Artifact>> Delete(int id);
         Task<ServiceResponse<Artifact>> Save(Artifact artifact);
-        Task<ServiceResponse<IList<ArtifactsRelation>>> SetRelationAsync(IList<ArtifactsRelation> artifactRelations);
+        Task<ServiceResponse<IList<ArtifactsRelation>>> SetRelationAsync(int artifactId, IList<ArtifactsRelation> artifactRelations);
         Task<ServiceResponse<IList<ArtifactsRelation>>> GetAllRelationsOfAnArtifactAsync(int artifactId);
         Task<ServiceResponse<IList<ArtifactsRelation>>> GetAllRelationsByProjectIdAsync(int projectId);
         Task<ServiceResponse<ArtifactsRelation>> DeleteRelationAsync(Guid artifactRelationId);

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Web.Authorization
+{
+    public static class ArtifactAuthorization
+    {
+        public const string Ownership = "ArtifactOwnership";
+        public const string RelationsListOwnership = "ArtifactsListOwnership";
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
@@ -1,0 +1,71 @@
+﻿using FRF.DataAccess;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipHandler : AuthorizationHandler<ArtifactOwnershipRequirement>
+    {
+        private const string ArtifactIdParameter = "artifactId";
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ArtifactOwnershipHandler(IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
+        {
+            _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ArtifactOwnershipRequirement requirement)
+        {
+            var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var artifactId = GetArtifactIdFromRequest();
+
+            if (userId == null || !artifactId.HasValue || artifactId <= 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!IsArtifactOfCurrentUser(artifactId, userId))
+            {
+                return Task.CompletedTask;
+            }
+
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        private int? GetArtifactIdFromRequest()
+        {
+            var request = _httpContextAccessor.HttpContext.Request;
+
+            if (!request.RouteValues.TryGetValue(ArtifactIdParameter, out var id)) return null;
+            
+            if (!int.TryParse(id.ToString(), out var artifactId)) return null;
+
+            return artifactId;
+        }
+        private bool IsArtifactOfCurrentUser(int? artifactId, string userId)
+        {
+            var isArtifactOfCurrentUser = false;
+
+            using var scope = _serviceProvider.CreateScope();
+            var dataContext = scope.ServiceProvider.GetRequiredService<DataAccessContext>();
+            if (dataContext.Artifacts.Any(a => a.Id == artifactId))
+            {
+                isArtifactOfCurrentUser = dataContext.Artifacts.Any(ap =>
+                    ap.Project.UsersByProject.Any(ubp => ubp.UserId.Equals(Guid.Parse(userId))) &&
+                    ap.Id == artifactId);
+            }
+
+            return isArtifactOfCurrentUser;
+        }
+
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipPolicyProvider : IAuthorizationPolicyProvider
+    {
+        public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
+
+        public ArtifactOwnershipPolicyProvider(IOptions<AuthorizationOptions> options)
+        {
+            FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+        }
+
+        public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => FallbackPolicyProvider.GetDefaultPolicyAsync();
+
+        public Task<AuthorizationPolicy> GetFallbackPolicyAsync() => FallbackPolicyProvider.GetFallbackPolicyAsync();
+
+        public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+        {
+            if (string.IsNullOrWhiteSpace(policyName))
+            {
+                return FallbackPolicyProvider.GetPolicyAsync(policyName);
+            }
+
+            switch (policyName)
+            {
+                case ArtifactAuthorization.Ownership:
+                {
+                    var policy = new AuthorizationPolicyBuilder();
+                    policy.AddRequirements(new ArtifactOwnershipRequirement());
+                    return Task.FromResult(policy.Build());
+                }
+                case ArtifactAuthorization.RelationsListOwnership:
+                {
+                    var policy = new AuthorizationPolicyBuilder();
+                    policy.AddRequirements(new ArtifactsListOwnershipRequirement());
+                    return Task.FromResult(policy.Build());
+                }
+                default:
+                    return FallbackPolicyProvider.GetPolicyAsync(policyName);
+            }
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipRequirement.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipHandler.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipHandler.cs
@@ -1,0 +1,79 @@
+﻿using FRF.DataAccess;
+using FRF.Web.Dtos.Artifacts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactsListOwnershipHandler : AuthorizationHandler<ArtifactsListOwnershipRequirement>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ArtifactsListOwnershipHandler(IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
+        {
+            _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, ArtifactsListOwnershipRequirement requirement)
+        {
+            var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var artifactsRelations = await GetArtifactsRelationInRequestBody();
+            if (userId == null || artifactsRelations==null )
+            {
+                return;
+            }
+
+            var areAllArtifactsRelationOfCurrentUser = await AreAllArtifactsRelationOfCurrentUser(artifactsRelations, userId);
+            if (!areAllArtifactsRelationOfCurrentUser)
+            {
+                return;
+            }
+
+            context.Succeed(requirement);
+            return;
+        }
+
+        private async Task<IList<ArtifactsRelationInsertDTO>> GetArtifactsRelationInRequestBody()
+        {
+            var request = _httpContextAccessor.HttpContext.Request;
+            request.EnableBuffering();
+            using var reader = new StreamReader(request.Body, Encoding.UTF8, false, leaveOpen: true);
+            var requestBody = await reader.ReadToEndAsync();
+            var artifactsRelations = JsonConvert.DeserializeObject<List<ArtifactsRelationInsertDTO>>(requestBody);
+            request.Body.Position = 0;
+            return artifactsRelations;
+        }
+
+        private async Task<bool> AreAllArtifactsRelationOfCurrentUser(IList<ArtifactsRelationInsertDTO> artifactsRelations, string userId)
+        {
+            var isAuthorized = false;
+            using var scope = _serviceProvider.CreateScope();
+
+            var dataContext = scope.ServiceProvider.GetRequiredService<DataAccessContext>();
+            var artifactsIds = artifactsRelations
+                .Select(ar => ar.Artifact1Id)
+                .Concat(artifactsRelations.Select(ar => ar.Artifact2Id));
+            var artifactsByUser = await dataContext.Artifacts
+                .Include(artifact =>
+                    artifact.Project).Where(artifact => artifact.Project.UsersByProject
+                    .Any(ubp => ubp.UserId == Guid.Parse(userId))).ToListAsync();
+
+            isAuthorized = artifactsIds.All(aid =>
+                artifactsByUser.Any(abu => abu.Id == aid));
+
+            return isAuthorized;
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipRequirement.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipRequirement.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactsListOwnershipRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -4,13 +4,10 @@ import Artifact from '../../interfaces/Artifact';
 import ArtifactsTableRow from './ArtifactsTableRow';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
-import ArtifactRelation from '../../interfaces/ArtifactRelation'
 import NewArtifactDialog from '../NewArtifactDialog';
-import NewArtifactsRelation from '../NewArtifactsRelation';
 import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
-import ArtifactType from '../../interfaces/ArtifactType';
 import EditArtifactDialog from './EditArtifactDialog';
 
 const ArtifactsTable = (props: { projectId: number}) => {
@@ -18,10 +15,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [openSnackbar, setOpenSnackbar] = React.useState(false);
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
     const [showNewArtifactDialog, setShowNewArtifactDialog] = React.useState(false);
-    const [showNewArtifactsRelation, setShowNewArtifactsRelation] = React.useState(false);
     const [showEditArtifactDialog, setEditArtifactDialog] = React.useState(false);
     const [artifactToEdit, setArtifactToEdit] = React.useState<Artifact | null>(null);
-    const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
     const loading = projectBudget=== -1 || artifacts.length === 0;
@@ -66,21 +61,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
         }
     }
 
-    const getRelations = async () => {
-        try {
-            const response = await ArtifactService.getAllRelationsByProjectId(projectId);
-            if (response.status == 200) {
-                setArtifactsRelations(response.data);
-            }
-            else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
-            }
-        }
-        catch {
-            manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
-        }
-    }
-
     const openEditArtifactDialog = () => {
         setEditArtifactDialog(true);
     }
@@ -98,18 +78,9 @@ const ArtifactsTable = (props: { projectId: number}) => {
         setShowNewArtifactDialog(true);
     }
 
-    const openNewArtifactsRelation = () => {
-        setShowNewArtifactsRelation(true);
-    }
-
-    const closeNewArtifactsRelation = () => {
-        setShowNewArtifactsRelation(false);
-    }
-
     React.useEffect(() => {
         getProjectBudget();
         getArtifacts();
-        getRelations();
     }, [projectId]);
 
     const manageOpenSnackbar = (settings: SnackbarSettings) => {
@@ -127,8 +98,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
                         <th>Tipo</th>
                         <th>Precio</th>
                         <th >
-                            <Button className="mx-3" style={{ minHeight: "32px", width: "21%" }} color="success" onClick={openNewArtifactDialog}>Nuevo artefacto</Button>
-                            <Button style={{ minHeight: "32px", width: "20%" }} color="success" onClick={openNewArtifactsRelation}>Nueva relación</Button>
+                            <Button className="mx-3" style={{ minHeight: "32px", width: "19vh" }} color="success" onClick={openNewArtifactDialog}>Nuevo artefacto</Button>
                         </th>
                     </tr>
                 </thead>
@@ -162,16 +132,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 setOpenSnackbar={setOpenSnackbar}
                 setSnackbarSettings={setSnackbarSettings}
             />
-            <NewArtifactsRelation
-                showNewArtifactsRelation={showNewArtifactsRelation}
-                closeNewArtifactsRelation={closeNewArtifactsRelation}
-                projectId={projectId}
-                setOpenSnackbar={setOpenSnackbar}
-                setSnackbarSettings={setSnackbarSettings}
-                artifacts={artifacts}
-                artifactsRelations={artifactsRelations}
-                updateList = {{update: false}}
-            />
             { artifactToEdit ?
                 <EditArtifactDialog
                     showEditArtifactDialog={showEditArtifactDialog}
@@ -180,7 +140,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
                     setSnackbarSettings={setSnackbarSettings}
                     artifactToEdit={artifactToEdit}
                     updateArtifacts={getArtifacts}
-                    updateRelations={getRelations}
                 /> :
                 null
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -29,7 +29,7 @@ const EditArtifactConfirmation = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    updateRelations: Function }) => {
+     }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();
@@ -62,7 +62,6 @@ const EditArtifactConfirmation = (props: {
             props.setOpenSnackbar(true);
         }
         props.updateArtifacts();
-        props.updateRelations();
         props.closeEditArtifactDialog();
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -14,7 +14,7 @@ const EditArtifactDialog = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    updateRelations: Function }) => {
+     }) => {
 
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
@@ -39,7 +39,6 @@ const EditArtifactDialog = (props: {
                     setOpenSnackbar={props.setOpenSnackbar}
                     setSnackbarSettings={props.setSnackbarSettings}
                     updateArtifacts={props.updateArtifacts}
-                    updateRelations={props.updateRelations}
                 />
             }
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -123,6 +123,7 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
                 updateList={{update: true, setUpdate: handleUpdateList}}
+                artifactId={props.artifactId}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
+const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList, artifactId: number }) => {
 
     const classes = useStyles();
     const { handleSubmit, errors, control } = useForm();
@@ -145,7 +145,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
             artifactsRelationsList.push(artifactsRelation);
         });
         try {
-            let response = await ArtifactService.setRelations(artifactsRelationsList);
+            let response = await ArtifactService.setRelations(props.artifactId, artifactsRelationsList);
             if (response.status === 200) {
                 props.setSnackbarSettings({ message: "Las relaciones han sido creadas con éxito", severity: "success" });
                 props.setOpenSnackbar(true);
@@ -185,9 +185,15 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            event.target.value === '' ?
+            setArtifact1(null)
+            :
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            event.target.value === '' ?
+            setArtifact2(null)
+            :
             setArtifact2(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }              
     }
@@ -245,6 +251,28 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         resetState();
     }
 
+    const menuItemBaseArtifact = (artifact: Artifact) => {
+        let baseArtifact = props.artifacts.find(a => a.id === props.artifactId);
+        return baseArtifact === undefined ?
+            <MenuItem value=""><em>None</em></MenuItem>
+            : artifact.id === baseArtifact.id ?
+                (props.artifacts.filter(a => a.id !== artifact.id)
+                    .map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+                :
+                (<MenuItem key={baseArtifact!.id} value={baseArtifact!.id}>{baseArtifact!.name}</MenuItem>);
+    }
+
+    const menuItemRender = (artifact: Artifact) => {
+        return artifact === null ?
+            (props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+            :
+            artifact.id === props.artifactId ?
+                (props.artifacts.filter(a => a.id !== artifact.id)
+                    .map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+                :
+                (props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>));
+    }
+
     return (
         <Dialog open={props.showNewArtifactsRelation}>
             <DialogTitle id="alert-dialog-title">Formulario de para crear relación entre artefactos</DialogTitle>
@@ -279,7 +307,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>)}
+                                    {artifact2===null ? 
+                                    menuItemRender(artifact2!)
+                                    :
+                                    menuItemBaseArtifact(artifact2!)
+                                    }
                                 </Select>
                             }
                             name='artifact1'
@@ -304,7 +336,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>)}
+                                    {artifact1===null ? 
+                                    menuItemRender(artifact1!)
+                                    :
+                                    menuItemBaseArtifact(artifact1!)
+                                    }
                                 </Select>
                             }
                             name='artifact2'

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -21,9 +21,9 @@ class ArtifactService {
         }
     };
 
-    static get = async (id: number) => {
+    static get = async (artifactId: number) => {
         try {
-            return await axios.get(`${ARTIFACTS_URL}/${id}`);
+            return await axios.get(`${ARTIFACTS_URL}/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
@@ -37,17 +37,17 @@ class ArtifactService {
         }
     };
 
-    static update = async (id: number, artifact: any) => {
+    static update = async (artifactId: number, artifact: any) => {
         try {
-            return await axios.put(`${ARTIFACTS_URL}/${id}`, artifact);
+            return await axios.put(`${ARTIFACTS_URL}/${artifactId}`, artifact);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
     };
 
-    static delete = async (id: number) => {
+    static delete = async (artifactId: number) => {
         try {
-            return await axios.delete(`${ARTIFACTS_URL}/${id}`);
+            return await axios.delete(`${ARTIFACTS_URL}/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
@@ -61,9 +61,9 @@ class ArtifactService {
         }
     };
 
-    static deleteRelation = async (id: string) => {
+    static deleteRelation = async (artifactId: string) => {
         try {
-            return await axios.delete(`${BASE_URL}relations/${id}`);
+            return await axios.delete(`${BASE_URL}relations/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -77,9 +77,9 @@ class ArtifactService {
         }
     };
     
-    static setRelations = async (artifactRelationsList: any) => {
+    static setRelations = async (artifactId: number, artifactRelationsList: any) => {
         try {
-            return await axios.post(`${BASE_URL}relations`, artifactRelationsList);
+            return await axios.post(`${ARTIFACTS_URL}/${artifactId}/relations`, artifactRelationsList);
         } catch (error) {
             return error.response ? error.response : error.message;
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FRF.Core.Response;
+using FRF.Web.Authorization;
 
 namespace FRF.Web.Controllers
 {
@@ -45,10 +46,11 @@ namespace FRF.Web.Controllers
             return Ok(artifactsDto);
         }
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetAsync(int id)
+        [HttpGet("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> GetAsync(int artifactId)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
@@ -71,10 +73,11 @@ namespace FRF.Web.Controllers
             return Ok(artifactCreated);
         }
 
-        [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateAsync(int id, ArtifactUpsertDTO artifactDto)
+        [HttpPut("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> UpdateAsync(int artifactId, ArtifactUpsertDTO artifactDto)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
@@ -89,22 +92,25 @@ namespace FRF.Web.Controllers
             return Ok(updatedArtifact);
         }
 
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteAsync(int id)
+        [HttpDelete("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> DeleteAsync(int artifactId)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
                 return NotFound();
             }
 
-            await _artifactsService.Delete(id);
+            await _artifactsService.Delete(artifactId);
 
             return NoContent();
         }
 
         [HttpPost("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> SetRelationAsync(int artifactId, IList<ArtifactsRelationInsertDTO> artifactRelationList)
         {
             var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
@@ -116,6 +122,7 @@ namespace FRF.Web.Controllers
         }
 
         [HttpGet("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
         public async Task<IActionResult> GetRelationsAsync(int artifactId)
         {
             var result = await _artifactsService.GetAllRelationsOfAnArtifactAsync(artifactId);
@@ -145,6 +152,7 @@ namespace FRF.Web.Controllers
         }
 
         [HttpDelete("~/api/relations")]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
         {
             var result = await _artifactsService.DeleteRelationsAsync(artifactRelationIds);
@@ -154,6 +162,8 @@ namespace FRF.Web.Controllers
         }
 
         [HttpPut("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> UpdateRelationsAsync(int artifactId,
             IList<ArtifactsRelationUpdateDTO> artifactRelationUpdatedList)
         {

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -104,11 +104,11 @@ namespace FRF.Web.Controllers
             return NoContent();
         }
 
-        [HttpPost("~/api/relations")]
-        public async Task<IActionResult> SetRelationAsync(IList<ArtifactsRelationInsertDTO> artifactRelationList)
+        [HttpPost("{artifactId}/relations")]
+        public async Task<IActionResult> SetRelationAsync(int artifactId, IList<ArtifactsRelationInsertDTO> artifactRelationList)
         {
             var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
-            var result = await _artifactsService.SetRelationAsync(artifactsRelations);
+            var result = await _artifactsService.SetRelationAsync(artifactId, artifactsRelations);
             if (!result.Success) return BadRequest();
 
             var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);

--- a/FiveRockingFingers/FRF.Web/Startup.cs
+++ b/FiveRockingFingers/FRF.Web/Startup.cs
@@ -12,7 +12,9 @@ using FRF.Core.Base;
 using FRF.Core.Services;
 using FRF.Core.XmlValidation;
 using FRF.DataAccess;
+using FRF.Web.Authorization;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
@@ -134,6 +136,10 @@ namespace FRF.Web
 
 			var autoMapperProfileTypes = AutoMapperProfiles.Select(p => p.GetType()).ToArray();
 			services.AddAutoMapper(autoMapperProfileTypes);
+			services.AddTransient<IAuthorizationPolicyProvider, ArtifactOwnershipPolicyProvider>();
+			services.AddSingleton<IAuthorizationHandler, ArtifactOwnershipHandler>();
+			services.AddSingleton<IAuthorizationHandler, ArtifactsListOwnershipHandler>();
+			services.AddAuthorization();
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -778,7 +778,38 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
             Assert.Null(response.Value);
         }
-        
+
+        [Fact]
+        public async Task SetRelationAsync_ReturnsNull_WhenHasAnyRelationWithoutBaseArtifact()
+        {
+            // Arange
+            var artifactsRelationToSave = new List<ArtifactsRelation>();
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var project = CreateProject();
+            var baseArtifact = _mapper.Map<Core.Models.Artifact>(CreateArtifact(project, artifactType));
+            var i = 0;
+            while (i < 3)
+            {
+                var artifact2 = CreateArtifact(project, artifactType);
+                var artifactRelation = CreateArtifactsRelationModel(baseArtifact.Id, artifact2.Id);
+                artifactsRelationToSave.Add(artifactRelation);
+                i++;
+            }
+            var artifactRelationWithoutBaseArtifact = CreateArtifactsRelationModel(int.MaxValue, int.MaxValue-1);
+            artifactsRelationToSave.Add(artifactRelationWithoutBaseArtifact);
+
+            // Act
+            var response = await _classUnderTest.SetRelationAsync(baseArtifact.Id, artifactsRelationToSave);
+
+            // Assert
+            Assert.False(response.Success);
+            Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
+            Assert.NotNull(response.Error);
+            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
+            Assert.Null(response.Value);
+        }
+
         [Fact]
         public async Task SetRelationAsync_ReturnsNull_WhenIsAnyBidirectionalRelationSameRelationType()
         {

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -23,7 +23,6 @@ namespace FRF.Core.Tests.Services
         private readonly IMapper _mapper = MapperBuilder.Build();
         private readonly DataAccessContextForTest _dataAccess;
         private readonly ArtifactsService _classUnderTest;
-        private readonly DbContextOptions<DataAccessContextForTest> ContextOptions;
         private readonly Mock<ISettingsValidator> _settingsValidator;
 
         public ArtifactsServiceTests()

--- a/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
@@ -1,0 +1,224 @@
+﻿using FRF.DataAccess;
+using FRF.DataAccess.EntityModels;
+using FRF.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Web.Tests.Authorization
+{
+    public class ArtifactOwnershipHandlerTest
+    {
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly DataAccessContextForTest _dataAccess;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+        private readonly ArtifactOwnershipHandler _classUnderTest;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+
+        public ArtifactOwnershipHandlerTest()
+        {
+            _configuration = new Mock<IConfiguration>();
+            _httpContextAccessor = new Mock<IHttpContextAccessor>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _classUnderTest = new ArtifactOwnershipHandler(_serviceProvider.Object, _httpContextAccessor.Object);
+            _dataAccess = new DataAccessContextForTest(Guid.NewGuid(), _configuration.Object);
+            _dataAccess.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Succeeds()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var artifact = CreateArtifact(project);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenArtifactIsNotOfCurrentUser()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var artifact = CreateArtifact(project);
+            var currentUserId = Guid.NewGuid();
+            var anotherUserId = Guid.NewGuid();
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            CreateUserByProject(project, anotherUserId);
+
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenArtifactIdNotExist()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var context = GetAuthorizationHandlerContext(currentUserId); ;
+
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", "9999" }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        private AuthorizationHandlerContext GetAuthorizationHandlerContext(Guid currentUserId)
+        {
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, currentUserId.ToString()),
+            }));
+            var requirements = new List<IAuthorizationRequirement>
+            {
+                new ArtifactOwnershipRequirement()
+            };
+            var context = new AuthorizationHandlerContext(requirements, userPrincipal, null);
+            return context;
+        }
+
+        private void MockServiceProvider()
+        {
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(DataAccessContext)))
+                .Returns(_dataAccess);
+
+            var serviceScope = new Mock<IServiceScope>();
+            serviceScope.Setup(x => x.ServiceProvider).Returns(_serviceProvider.Object);
+
+            var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            serviceScopeFactory
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScope.Object);
+
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactory.Object);
+        }
+
+        private void CreateUserByProject(DataAccess.EntityModels.Project project, Guid userId)
+        {
+            var userByProject = new UsersByProject
+            {
+                ProjectId = project.Id,
+                Project = project,
+                UserId = userId
+            };
+
+            _dataAccess.UsersByProject.Add(userByProject);
+            _dataAccess.SaveChanges();
+        }
+
+        private Provider CreateProvider()
+        {
+            var provider = new Provider();
+            provider.Name = "[Mock] Provider name";
+            _dataAccess.Providers.Add(provider);
+            _dataAccess.SaveChanges();
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
+        {
+            var artifactType = new ArtifactType();
+            artifactType.Name = "[Mock] Artifact type name";
+            artifactType.Description = "[Mock] Artifact type description";
+            artifactType.Provider = provider;
+            _dataAccess.ArtifactType.Add(artifactType);
+            _dataAccess.SaveChanges();
+
+            return artifactType;
+        }
+
+        private Project CreateProject()
+        {
+            var project = new Project();
+            project.Name = "[MOCK] Project name";
+            project.CreatedDate = DateTime.Now;
+            project.ProjectCategories = new List<ProjectCategory>();
+            _dataAccess.Projects.Add(project);
+            _dataAccess.SaveChanges();
+
+            return project;
+        }
+
+        private Artifact CreateArtifact(Project project)
+        {
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var random = new Random();
+            var artifact = new Artifact()
+            {
+                Name = "[Mock] Artifact name " + random.Next(500),
+                CreatedDate = DateTime.Now,
+                Project = project,
+                ProjectId = project.Id,
+                ArtifactType = artifactType,
+                ArtifactTypeId = artifactType.Id
+            };
+            _dataAccess.Artifacts.Add(artifact);
+            _dataAccess.SaveChanges();
+
+            return artifact;
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FRF.Core.Tests;
+using FRF.DataAccess;
+using FRF.DataAccess.EntityModels;
+using FRF.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace FRF.Web.Tests.Authorization
+{
+    public class ArtifactsListOwnershipHandlerTest
+    {
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly DataAccessContextForTest _dataAccess;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+        private readonly ArtifactsListOwnershipHandler _classUnderTest;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+
+        public ArtifactsListOwnershipHandlerTest()
+        {
+            _configuration = new Mock<IConfiguration>();
+            _httpContextAccessor = new Mock<IHttpContextAccessor>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _classUnderTest = new ArtifactsListOwnershipHandler(_serviceProvider.Object, _httpContextAccessor.Object);
+            _dataAccess = new DataAccessContextForTest(Guid.NewGuid(), _configuration.Object);
+            _dataAccess.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Succeeds()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var artifact = CreateArtifact(project);
+            var artifact2 = CreateArtifact(project);
+            var relation = CreateArtifactsRelationModel(artifact.Id, artifact2.Id);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = $"[{{\"artifact1Id\":{artifact.Id},\"artifact2Id\":{artifact2.Id},\"artifact1Property\":\"{relation.Artifact1Property}\",\"artifact2Property\":\"{relation.Artifact2Property}\",\"relationTypeId\":0}}]";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream; 
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenAnyArtifactsRelationIsNotOfCurrentUser()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            var anotherUserId = Guid.NewGuid();
+            CreateUserByProject(project, anotherUserId);
+            var artifact = CreateArtifact(project);
+            var artifact2 = CreateArtifact(project);
+            var relation = CreateArtifactsRelationModel(artifact.Id, artifact2.Id);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = $"[{{\"artifact1Id\":{artifact.Id},\"artifact2Id\":{artifact2.Id},\"artifact1Property\":\"{relation.Artifact1Property}\",\"artifact2Property\":\"{relation.Artifact2Property}\",\"relationTypeId\":0}}]";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream;
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenListOfRelationsIsEmpty()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = "";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", int.MaxValue.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream;
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        private AuthorizationHandlerContext GetAuthorizationHandlerContext(Guid currentUserId)
+        {
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, currentUserId.ToString()),
+            }));
+            var requirements = new List<IAuthorizationRequirement>
+            {
+                new ArtifactsListOwnershipRequirement()
+            };
+            var context = new AuthorizationHandlerContext(requirements, userPrincipal, null);
+            return context;
+        }
+
+        private void MockServiceProvider()
+        {
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(DataAccessContext)))
+                .Returns(_dataAccess);
+
+            var serviceScope = new Mock<IServiceScope>();
+            serviceScope.Setup(x => x.ServiceProvider).Returns(_serviceProvider.Object);
+
+            var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            serviceScopeFactory
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScope.Object);
+
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactory.Object);
+        }
+        private FRF.Core.Models.ArtifactsRelation CreateArtifactsRelationModel(int artifact1Id, int artifact2Id)
+        {
+            var random = new Random();
+            var propertyId = random.Next(1000);
+            var artifactRelation = new FRF.Core.Models.ArtifactsRelation()
+            {
+                Artifact1Id = artifact1Id,
+                Artifact2Id = artifact2Id,
+                Artifact1Property = "Mock 1 Property " + propertyId,
+                Artifact2Property = "Mock 2 Property " + propertyId,
+                RelationTypeId = 1
+            };
+
+            return artifactRelation;
+        }
+        private void CreateUserByProject(DataAccess.EntityModels.Project project, Guid userId)
+        {
+            var userByProject = new UsersByProject
+            {
+                ProjectId = project.Id,
+                Project = project,
+                UserId = userId
+            };
+
+            _dataAccess.UsersByProject.Add(userByProject);
+            _dataAccess.SaveChanges();
+        }
+
+        private Provider CreateProvider()
+        {
+            var provider = new Provider();
+            provider.Name = "[Mock] Provider name";
+            _dataAccess.Providers.Add(provider);
+            _dataAccess.SaveChanges();
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
+        {
+            var artifactType = new ArtifactType();
+            artifactType.Name = "[Mock] Artifact type name";
+            artifactType.Description = "[Mock] Artifact type description";
+            artifactType.Provider = provider;
+            _dataAccess.ArtifactType.Add(artifactType);
+            _dataAccess.SaveChanges();
+
+            return artifactType;
+        }
+
+        private Project CreateProject()
+        {
+            var project = new Project();
+            project.Name = "[MOCK] Project name";
+            project.CreatedDate = DateTime.Now;
+            project.ProjectCategories = new List<ProjectCategory>();
+            _dataAccess.Projects.Add(project);
+            _dataAccess.SaveChanges();
+
+            return project;
+        }
+
+        private Artifact CreateArtifact(Project project)
+        {
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var random = new Random();
+            var artifact = new Artifact()
+            {
+                Name = "[Mock] Artifact name " + random.Next(500),
+                CreatedDate = DateTime.Now,
+                Project = project,
+                ProjectId = project.Id,
+                ArtifactType = artifactType,
+                ArtifactTypeId = artifactType.Id
+            };
+            _dataAccess.Artifacts.Add(artifact);
+            _dataAccess.SaveChanges();
+
+            return artifact;
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using FRF.Core.Tests;
 using FRF.DataAccess;
 using FRF.DataAccess.EntityModels;
 using FRF.Web.Authorization;

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -645,15 +645,15 @@ namespace FRF.Web.Tests.Controllers
                 artifactsRelationDtos.Add(artifactRelation);
             }
             _artifactsService
-                .Setup(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()))
+                .Setup(mock => mock.SetRelationAsync(It.IsAny<int>(),It.IsAny<List<ArtifactsRelation>>()))
                 .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(_mapper.Map<IList<ArtifactsRelation>>(artifactsRelationDtos)));
             // Act
-            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos);
+            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos[0].Artifact1Id,artifactsRelationDtos);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
             Assert.IsType<List<ArtifactsRelationDTO>>(okResult.Value);
-            _artifactsService.Verify(mock=>mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()),Times.Once);
+            _artifactsService.Verify(mock=>mock.SetRelationAsync(It.IsAny<int>(),It.IsAny<List<ArtifactsRelation>>()),Times.Once);
 
         }
 
@@ -666,16 +666,16 @@ namespace FRF.Web.Tests.Controllers
             artifactsRelationDtos.Add(artifactRelation);
 
             _artifactsService
-                .Setup(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()))
+                .Setup(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()))
                 .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "Error Message")));
 
             // Act
-            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos);
+            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos[0].Artifact1Id, artifactsRelationDtos);
 
             // Assert
             var response = Assert.IsType<BadRequestResult>(result);
             Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
-            _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()), Times.Once);
+            _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()), Times.Once);
         }
         [Fact]
         public async Task SetRelationAsync_ReturnBadRequest_WhenIsaBidirectionalRelation()
@@ -700,16 +700,16 @@ namespace FRF.Web.Tests.Controllers
             });
 
             _artifactsService
-                .Setup(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()))
+                .Setup(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()))
                 .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "Error Message")));
 
             // Act
-            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos);
+            var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos[0].Artifact1Id, artifactsRelationDtos);
 
             // Assert
             var response = Assert.IsType<BadRequestResult>(result);
             Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
-            _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<List<ArtifactsRelation>>()), Times.Once);
+            _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()), Times.Once);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/DataAccessContextForTest.cs
+++ b/test/FRF.Web.Tests/DataAccessContextForTest.cs
@@ -1,0 +1,22 @@
+﻿using FRF.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace FRF.Web.Tests
+{
+    public class DataAccessContextForTest : DataAccessContext
+    {
+        private readonly IConfiguration _configuration;
+
+        public DataAccessContextForTest(Guid dbGuid, IConfiguration configuration) : base(
+            new DbContextOptionsBuilder<DataAccessContext>().UseInMemoryDatabase(databaseName: dbGuid.ToString()).Options, configuration)
+
+        {
+            _configuration = configuration;
+        }
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+        }
+    }
+}

--- a/test/FRF.Web.Tests/FRF.Web.Tests.csproj
+++ b/test/FRF.Web.Tests/FRF.Web.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
## Descripción:
La función SetRelation, está recibiendo solo una lista de relaciones que son las que se van a crear. No se están validando si dentro de esa lista, las relaciones estén duplicadas. A su vez la función recibe por parámetro solo la lista de relaciones, se decidió agregar un parámetro más el cual será artifactId.
Con esto se gana que solo las relaciones que se creen pertenezcan a un artefacto en común. De esta manera se reducen los ciclos de iteración, para comparar si la relación ya existe, como también se logra establecer límites para el usuario y tener un mayor control al momento de crear relaciones.

Criterios de aceptación:
- Verificar que en la lista de entrada no haya relaciones repetidas.
- Agregar parámetro artifactId a la función SetRelation y al endpoint SetRelationAsync.
- Crear un método que valide que los artifactsId, que se pasan (tanto por parámetro como dentro de la lista de relaciones), pertenezcas al mismo proyecto.
- Eliminar botón de creación de relación, para que solo sea accesible dentro de un artefacto.
- Modificar llamado a la API del lado del cliente para qué envié un artifactId.
- Agregar UnitTest y modificar los afectados por estos cambios
## Modificaciones:
- Se modificaron parámetros de entrada en función SetRelationAsync, ahora también recibe él, id del artefacto base.
- Se modificaron parámetros de entrada en endpoint SetRelationAsync en ArtifactsController, ahora también recibe él, id del artefacto base.
- Se modificaron y agregaron Unit Test, tanto en ArtifactsServiceTests como en ArtifactsControllerTests para validar las modificaciones realizadas.

*Capa de presentación en PR: #119*