### PR TITLE
[FIVE-351 Front] Modificar forma en la que se crean las relaciones entre Artifacts

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -4,13 +4,10 @@ import Artifact from '../../interfaces/Artifact';
 import ArtifactsTableRow from './ArtifactsTableRow';
 import SnackbarMessage from '../../commons/SnackbarMessage';
 import SnackbarSettings from '../../interfaces/SnackbarSettings'
-import ArtifactRelation from '../../interfaces/ArtifactRelation'
 import NewArtifactDialog from '../NewArtifactDialog';
-import NewArtifactsRelation from '../NewArtifactsRelation';
 import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
-import ArtifactType from '../../interfaces/ArtifactType';
 import EditArtifactDialog from './EditArtifactDialog';
 
 const ArtifactsTable = (props: { projectId: number}) => {
@@ -18,10 +15,8 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [openSnackbar, setOpenSnackbar] = React.useState(false);
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
     const [showNewArtifactDialog, setShowNewArtifactDialog] = React.useState(false);
-    const [showNewArtifactsRelation, setShowNewArtifactsRelation] = React.useState(false);
     const [showEditArtifactDialog, setEditArtifactDialog] = React.useState(false);
     const [artifactToEdit, setArtifactToEdit] = React.useState<Artifact | null>(null);
-    const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
     const loading = projectBudget=== -1 || artifacts.length === 0;
@@ -66,21 +61,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
         }
     }
 
-    const getRelations = async () => {
-        try {
-            const response = await ArtifactService.getAllRelationsByProjectId(projectId);
-            if (response.status == 200) {
-                setArtifactsRelations(response.data);
-            }
-            else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
-            }
-        }
-        catch {
-            manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
-        }
-    }
-
     const openEditArtifactDialog = () => {
         setEditArtifactDialog(true);
     }
@@ -98,18 +78,9 @@ const ArtifactsTable = (props: { projectId: number}) => {
         setShowNewArtifactDialog(true);
     }
 
-    const openNewArtifactsRelation = () => {
-        setShowNewArtifactsRelation(true);
-    }
-
-    const closeNewArtifactsRelation = () => {
-        setShowNewArtifactsRelation(false);
-    }
-
     React.useEffect(() => {
         getProjectBudget();
         getArtifacts();
-        getRelations();
     }, [projectId]);
 
     const manageOpenSnackbar = (settings: SnackbarSettings) => {
@@ -127,8 +98,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
                         <th>Tipo</th>
                         <th>Precio</th>
                         <th >
-                            <Button className="mx-3" style={{ minHeight: "32px", width: "21%" }} color="success" onClick={openNewArtifactDialog}>Nuevo artefacto</Button>
-                            <Button style={{ minHeight: "32px", width: "20%" }} color="success" onClick={openNewArtifactsRelation}>Nueva relación</Button>
+                            <Button className="mx-3" style={{ minHeight: "32px", width: "19vh" }} color="success" onClick={openNewArtifactDialog}>Nuevo artefacto</Button>
                         </th>
                     </tr>
                 </thead>
@@ -162,16 +132,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 setOpenSnackbar={setOpenSnackbar}
                 setSnackbarSettings={setSnackbarSettings}
             />
-            <NewArtifactsRelation
-                showNewArtifactsRelation={showNewArtifactsRelation}
-                closeNewArtifactsRelation={closeNewArtifactsRelation}
-                projectId={projectId}
-                setOpenSnackbar={setOpenSnackbar}
-                setSnackbarSettings={setSnackbarSettings}
-                artifacts={artifacts}
-                artifactsRelations={artifactsRelations}
-                updateList = {{update: false}}
-            />
             { artifactToEdit ?
                 <EditArtifactDialog
                     showEditArtifactDialog={showEditArtifactDialog}
@@ -180,7 +140,6 @@ const ArtifactsTable = (props: { projectId: number}) => {
                     setSnackbarSettings={setSnackbarSettings}
                     artifactToEdit={artifactToEdit}
                     updateArtifacts={getArtifacts}
-                    updateRelations={getRelations}
                 /> :
                 null
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -29,7 +29,7 @@ const EditArtifactConfirmation = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    updateRelations: Function }) => {
+     }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();
@@ -62,7 +62,6 @@ const EditArtifactConfirmation = (props: {
             props.setOpenSnackbar(true);
         }
         props.updateArtifacts();
-        props.updateRelations();
         props.closeEditArtifactDialog();
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -14,7 +14,7 @@ const EditArtifactDialog = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    updateRelations: Function }) => {
+     }) => {
 
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
@@ -39,7 +39,6 @@ const EditArtifactDialog = (props: {
                     setOpenSnackbar={props.setOpenSnackbar}
                     setSnackbarSettings={props.setSnackbarSettings}
                     updateArtifacts={props.updateArtifacts}
-                    updateRelations={props.updateRelations}
                 />
             }
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -123,6 +123,7 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
                 updateList={{update: true, setUpdate: handleUpdateList}}
+                artifactId={props.artifactId}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
+const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList, artifactId: number }) => {
 
     const classes = useStyles();
     const { handleSubmit, errors, control } = useForm();
@@ -145,7 +145,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
             artifactsRelationsList.push(artifactsRelation);
         });
         try {
-            let response = await ArtifactService.setRelations(artifactsRelationsList);
+            let response = await ArtifactService.setRelations(props.artifactId, artifactsRelationsList);
             if (response.status === 200) {
                 props.setSnackbarSettings({ message: "Las relaciones han sido creadas con éxito", severity: "success" });
                 props.setOpenSnackbar(true);

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -185,9 +185,15 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            event.target.value === '' ?
+            setArtifact1(null)
+            :
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            event.target.value === '' ?
+            setArtifact2(null)
+            :
             setArtifact2(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }              
     }
@@ -245,6 +251,28 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         resetState();
     }
 
+    const menuItemBaseArtifact = (artifact: Artifact) => {
+        let baseArtifact = props.artifacts.find(a => a.id === props.artifactId);
+        return baseArtifact === undefined ?
+            <MenuItem value=""><em>None</em></MenuItem>
+            : artifact.id === baseArtifact.id ?
+                (props.artifacts.filter(a => a.id !== artifact.id)
+                    .map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+                :
+                (<MenuItem key={baseArtifact!.id} value={baseArtifact!.id}>{baseArtifact!.name}</MenuItem>);
+    }
+
+    const menuItemRender = (artifact: Artifact) => {
+        return artifact === null ?
+            (props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+            :
+            artifact.id === props.artifactId ?
+                (props.artifacts.filter(a => a.id !== artifact.id)
+                    .map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>))
+                :
+                (props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>));
+    }
+
     return (
         <Dialog open={props.showNewArtifactsRelation}>
             <DialogTitle id="alert-dialog-title">Formulario de para crear relación entre artefactos</DialogTitle>
@@ -279,7 +307,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>)}
+                                    {artifact2===null ? 
+                                    menuItemRender(artifact2!)
+                                    :
+                                    menuItemBaseArtifact(artifact2!)
+                                    }
                                 </Select>
                             }
                             name='artifact1'
@@ -304,7 +336,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {props.artifacts.map(a => <MenuItem key={a.id} value={a.id}>{a.name}</MenuItem>)}
+                                    {artifact1===null ? 
+                                    menuItemRender(artifact1!)
+                                    :
+                                    menuItemBaseArtifact(artifact1!)
+                                    }
                                 </Select>
                             }
                             name='artifact2'

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -77,9 +77,9 @@ class ArtifactService {
         }
     };
     
-    static setRelations = async (artifactRelationsList: any) => {
+    static setRelations = async (artifactId: number, artifactRelationsList: any) => {
         try {
-            return await axios.post(`${BASE_URL}relations`, artifactRelationsList);
+            return await axios.post(`${ARTIFACTS_URL}/${artifactId}/relations`, artifactRelationsList);
         } catch (error) {
             return error.response ? error.response : error.message;
         }


### PR DESCRIPTION
## Descripción:
Ticket base #118.
- Eliminar botón de creación de relación, para que solo sea accesible dentro de un artefacto.
- Modificar llamado a la API del lado del cliente para qué envié un artifactId.
## Modificaciones: 
- Se elimina render de botón *NewArtifactsRelation* junto con los hooks relacionados, dentro de *ArtifactsTable*
- Se agrega prop artifactId en *NewArtifactsRelation*.
- Se modifica llamado a la API *ArtifactService*.
![FIVE351](https://user-images.githubusercontent.com/71275081/110691700-3c4a2f80-81c4-11eb-90df-f24ca5b1f3c0.gif)
