### PR TITLE
[Five-344] (Frontend) Actualización de valores de las settings cuando cambian las relaciones (o valores referenciados)

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -170,7 +170,9 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 setSnackbarSettings={setSnackbarSettings}
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
-                updateList = {{update: false}}
+                updateList={{ update: false }}
+                updateArtifacts={getArtifacts}
+                updateRelations={getRelations}
             />
             { artifactToEdit ?
                 <EditArtifactDialog

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -117,6 +117,18 @@ const ArtifactsTable = (props: { projectId: number}) => {
         setOpenSnackbar(true);
     }
 
+    const getRelationsOfAnArtifact = (artifactId: number) => {
+        const relations: ArtifactRelation[] = [];
+
+        artifactsRelations.forEach(artifactRelation => {
+            if (artifactRelation.artifact1.id === artifactId || artifactRelation.artifact2.id === artifactId) {
+                relations.push(artifactRelation);
+            }
+        });
+
+        return relations;
+    }
+
     return (
         <React.Fragment>
             <Table striped bordered hover responsive>
@@ -183,6 +195,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
                     artifactToEdit={artifactToEdit}
                     updateArtifacts={getArtifacts}
                     updateRelations={getRelations}
+                    artifactsRelations={getRelationsOfAnArtifact(artifactToEdit.id)}
                 /> :
                 null
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -24,6 +24,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
+    const [updateList, setUpdateList] = React.useState(true);
     const loading = projectBudget=== -1 || artifacts.length === 0;
     const {projectId} = props;
 
@@ -112,21 +113,28 @@ const ArtifactsTable = (props: { projectId: number}) => {
         getRelations();
     }, [projectId]);
 
+    React.useEffect(() => {
+        getProjectBudget();
+        if (updateList) {
+            getRelations();
+            getArtifacts();
+            setUpdateList(false);
+        }
+    }, [updateList]);
+
     const manageOpenSnackbar = (settings: SnackbarSettings) => {
         setSnackbarSettings(settings);
         setOpenSnackbar(true);
     }
 
     const getRelationsOfAnArtifact = (artifactId: number) => {
-        const relations: ArtifactRelation[] = [];
-
-        artifactsRelations.forEach(artifactRelation => {
-            if (artifactRelation.artifact1.id === artifactId || artifactRelation.artifact2.id === artifactId) {
-                relations.push(artifactRelation);
-            }
-        });
+        const relations: ArtifactRelation[] = artifactsRelations.filter(relation => relation.artifact1.id === artifactId || relation.artifact2.id === artifactId);
 
         return relations;
+    }
+
+    const handleUpdateList = () => {
+        setUpdateList(true);
     }
 
     return (
@@ -182,9 +190,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
                 setSnackbarSettings={setSnackbarSettings}
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
-                updateList={{ update: false }}
-                updateArtifacts={getArtifacts}
-                updateRelations={getRelations}
+                updateList={{ update: true, setUpdate: handleUpdateList }}
             />
             { artifactToEdit ?
                 <EditArtifactDialog

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -9,6 +9,7 @@ import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
 import EditArtifactDialog from './EditArtifactDialog';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
 
 const ArtifactsTable = (props: { projectId: number}) => {
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
@@ -19,6 +20,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const [artifactToEdit, setArtifactToEdit] = React.useState<Artifact | null>(null);
     const [price, setPrice] = React.useState<string>('');
     const [projectBudget, setProjectBudget] = React.useState<number>(-1);
+    const [updateList, setUpdateList] = React.useState(true);
     const loading = projectBudget=== -1 || artifacts.length === 0;
     const {projectId} = props;
 
@@ -83,6 +85,14 @@ const ArtifactsTable = (props: { projectId: number}) => {
         getArtifacts();
     }, [projectId]);
 
+    React.useEffect(() => {
+        getProjectBudget();
+        if (updateList) {
+            getArtifacts();
+            setUpdateList(false);
+        }
+    }, [updateList]);
+
     const manageOpenSnackbar = (settings: SnackbarSettings) => {
         setSnackbarSettings(settings);
         setOpenSnackbar(true);
@@ -140,6 +150,7 @@ const ArtifactsTable = (props: { projectId: number}) => {
                     setSnackbarSettings={setSnackbarSettings}
                     artifactToEdit={artifactToEdit}
                     updateArtifacts={getArtifacts}
+                    manageOpenSnackbar={manageOpenSnackbar}
                 /> :
                 null
             }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -251,15 +251,11 @@ const EditArtifact = (props: {
     }
 
     const isSettingAtTheEndOfAnyRelation = (settingName: string) => {
-        let flag = false;
+        const flag: ArtifactRelation | undefined = props.artifactsRelations
+            .find((relation) =>
+                isSettingAtTheEndOfRelation(settingName, relation));
 
-        props.artifactsRelations.forEach(relation => {
-            if (isSettingAtTheEndOfRelation(settingName, relation)) {
-                flag = true;
-            }
-        });
-
-        return flag;
+        return flag === undefined ? false : true;
     }
 
     const isSettingAtTheEndOfRelation = (settingName: string, relation: ArtifactRelation) => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -38,8 +38,6 @@ const EditArtifact = (props: {
     const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
     const { closeEditArtifactDialog } = props;
 
-
-
     const createSettingsListFromArtifact = () => {
         let settingsListFromArtifact: Setting[] = [];
         if (props.artifactToEdit.id === 0) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifact.tsx
@@ -7,6 +7,7 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Setting from '../../interfaces/Setting';
 import Artifact from '../../interfaces/Artifact';
+import ArtifactRelation from '../../interfaces/ArtifactRelation';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -30,7 +31,8 @@ const EditArtifact = (props: {
     closeEditArtifactDialog: Function,
     setIsArtifactEdited: Function,
     setArtifactEdited: Function,
-    setNamesOfSettingsChanged: Function }) => {
+    setNamesOfSettingsChanged: Function,
+    artifactsRelations: ArtifactRelation[]}) => {
 
     const classes = useStyles();
     const { register, handleSubmit, errors, setError, clearErrors, control } = useForm();
@@ -248,6 +250,27 @@ const EditArtifact = (props: {
         return settingsObject;
     }
 
+    const isSettingAtTheEndOfAnyRelation = (settingName: string) => {
+        let flag = false;
+
+        props.artifactsRelations.forEach(relation => {
+            if (isSettingAtTheEndOfRelation(settingName, relation)) {
+                flag = true;
+            }
+        });
+
+        return flag;
+    }
+
+    const isSettingAtTheEndOfRelation = (settingName: string, relation: ArtifactRelation) => {
+        if (relation.relationTypeId === 0) {
+            return relation.artifact2Property === settingName;
+        }
+        else {
+            return relation.artifact1Property === settingName;
+        }
+    }
+
     return (
         <>
             <DialogTitle id="alert-dialog-title">Formulario de actualización de artefactos custom</DialogTitle>
@@ -345,6 +368,7 @@ const EditArtifact = (props: {
                                             className={classes.inputF}
                                             onChange={event => { handleInputChange(event, index); onChange(event); }}
                                             autoComplete='off'
+                                            disabled={isSettingAtTheEndOfAnyRelation(setting.name)}
                                         />
                                     )}
                                 />

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -28,8 +28,7 @@ const EditArtifactConfirmation = (props: {
     closeEditArtifactDialog: Function,
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
-    updateArtifacts: Function,
-     }) => {
+    updateArtifacts: Function }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -14,13 +14,35 @@ const EditArtifactDialog = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-     }) => {
+    manageOpenSnackbar: Function}) => {
 
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
     const [isArtifactEdited, setIsArtifactEdited] = React.useState<boolean>(false);
     const [artifactEdited, setArtifactEdited] = React.useState<Artifact>(props.artifactToEdit);
     const [namesOfSettingsChanged, setNamesOfSettingsChanged] = React.useState<string[]>([]);
+    const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
+
+    const getRelations = async () => {
+        try {
+            const response = await ArtifactService.getRelationsAsync(props.artifactToEdit.id);
+            if (response.status == 200) {
+                setArtifactsRelations(response.data);
+            }
+            else {
+                props.manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
+                closeEditArtifactDialog();
+            }
+        }
+        catch {
+            props.manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
+            closeEditArtifactDialog();
+        }
+    }
+
+    React.useEffect(() => {
+        getRelations();
+    }, [artifactEdited]);
 
     return (
         <Dialog open={showEditArtifactDialog}>
@@ -31,6 +53,7 @@ const EditArtifactDialog = (props: {
                     setIsArtifactEdited={setIsArtifactEdited}
                     setArtifactEdited={setArtifactEdited}
                     setNamesOfSettingsChanged={setNamesOfSettingsChanged}
+                    artifactsRelations={artifactsRelations}
                 /> :
                 <EditArtifactConfirmation
                     artifactToEdit={artifactEdited}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -14,7 +14,8 @@ const EditArtifactDialog = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    updateRelations: Function }) => {
+    updateRelations: Function,
+    artifactsRelations: ArtifactRelation[]}) => {
 
     const { showEditArtifactDialog, closeEditArtifactDialog } = props;
 
@@ -31,6 +32,7 @@ const EditArtifactDialog = (props: {
                     setIsArtifactEdited={setIsArtifactEdited}
                     setArtifactEdited={setArtifactEdited}
                     setNamesOfSettingsChanged={setNamesOfSettingsChanged}
+                    artifactsRelations={props.artifactsRelations}
                 /> :
                 <EditArtifactConfirmation
                     artifactToEdit={artifactEdited}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -122,7 +122,9 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setSnackbarSettings={setSnackbarSettings}
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
-                updateList={{update: true, setUpdate: handleUpdateList}}
+                updateList={{ update: true, setUpdate: handleUpdateList }}
+                updateArtifacts={() => void 0}
+                updateRelations={() => void 0}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -123,8 +123,6 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 artifacts={artifacts}
                 artifactsRelations={artifactsRelations}
                 updateList={{ update: true, setUpdate: handleUpdateList }}
-                updateArtifacts={() => void 0}
-                updateRelations={() => void 0}
             />
         </React.Fragment>
     );

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -55,9 +55,7 @@ const NewArtifactsRelation = (props: {
     setSnackbarSettings: Function,
     artifacts: Artifact[],
     artifactsRelations: ArtifactRelation[],
-    updateList: handlerUpdateList,
-    updateArtifacts: Function,
-    updateRelations: Function
+    updateList: handlerUpdateList
 }) => {
 
     const classes = useStyles();
@@ -170,8 +168,6 @@ const NewArtifactsRelation = (props: {
             props.setSnackbarSettings({ message: "Hubo un error al crear las relaciones", severity: "error" });
             props.setOpenSnackbar(true);
         }
-        props.updateArtifacts();
-        props.updateRelations();
         handleClose();       
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -47,7 +47,18 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
+const NewArtifactsRelation = (props: {
+    showNewArtifactsRelation: boolean,
+    closeNewArtifactsRelation: Function,
+    projectId: number,
+    setOpenSnackbar: Function,
+    setSnackbarSettings: Function,
+    artifacts: Artifact[],
+    artifactsRelations: ArtifactRelation[],
+    updateList: handlerUpdateList,
+    updateArtifacts: Function,
+    updateRelations: Function
+}) => {
 
     const classes = useStyles();
     const { handleSubmit, errors, control } = useForm();
@@ -159,6 +170,8 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
             props.setSnackbarSettings({ message: "Hubo un error al crear las relaciones", severity: "error" });
             props.setOpenSnackbar(true);
         }
+        props.updateArtifacts();
+        props.updateRelations();
         handleClose();       
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -92,6 +92,14 @@ class ArtifactService {
             return error.response ? error.response : error.message;
         }
     };
+
+    static getRelationsAsync = async (artifactId: number) => {
+        try {
+            return await axios.get(`${BASE_URL}artifacts/${artifactId}/relations`);
+        } catch (error) {
+            return error.response ? error.response : error.message;
+        }
+    };
     
     static updateArtifactsRelations = async (artifactId: number, artifactRelationsList: any) => {
         try {


### PR DESCRIPTION
En este PR se modificó el formulario de modificación de un artefacto para que no se pueda modificar el valor de una setting que está el final de una relación ya que el valor de estas settings deberían definirse a partir de sus relaciones. En el gif Artefacto1 y Artefacto2, están relacionados con Artefacto3 de la siguiente manera:

![image](https://user-images.githubusercontent.com/71278846/110502664-29f3c700-80da-11eb-8173-07ebc6e8ac4a.png)

Tantos las settings del Artefacto1 como las del Artefacto2 son editables pero la setting del Artefacto3 no, ya que está al final de una relación

![2021-03-09 13-16-22](https://user-images.githubusercontent.com/71278846/110502805-4abc1c80-80da-11eb-9a4f-e9d80af9f8a9.gif)

Otro cambio realizado es que se modificó el formulario de creación de relaciones para que se actualicen los artefactos de la tabla de artefactos al momento de crear una relación y no tener que recargar la página para ver los cambios realizados.