### PR TITLE
[FIVE-361] Implementar filtros de autentificación en ArtifactsController

### DIFF
--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
@@ -3,5 +3,6 @@
     public static class ArtifactAuthorization
     {
         public const string Ownership = "ArtifactOwnership";
+        public const string RelationsListOwnership = "ArtifactsListOwnership";
     }
 }

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactAuthorization.cs
@@ -1,0 +1,7 @@
+﻿namespace FRF.Web.Authorization
+{
+    public static class ArtifactAuthorization
+    {
+        public const string Ownership = "ArtifactOwnership";
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
@@ -59,7 +59,7 @@ namespace FRF.Web.Authorization
             var dataContext = scope.ServiceProvider.GetRequiredService<DataAccessContext>();
             if (dataContext.Artifacts.Any(a => a.Id == artifactId))
             {
-                isArtifactOfCurrentUser = dataContext.Artifacts.Include(artifact => artifact.Project).Any(ap =>
+                isArtifactOfCurrentUser = dataContext.Artifacts.Any(ap =>
                     ap.Project.UsersByProject.Any(ubp => ubp.UserId.Equals(Guid.Parse(userId))) &&
                     ap.Id == artifactId);
             }

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipHandler.cs
@@ -1,0 +1,71 @@
+﻿using FRF.DataAccess;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipHandler : AuthorizationHandler<ArtifactOwnershipRequirement>
+    {
+        private const string ArtifactIdParameter = "artifactId";
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ArtifactOwnershipHandler(IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
+        {
+            _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ArtifactOwnershipRequirement requirement)
+        {
+            var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var artifactId = GetArtifactIdFromRequest();
+
+            if (userId == null || !artifactId.HasValue || artifactId <= 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!IsArtifactOfCurrentUser(artifactId, userId))
+            {
+                return Task.CompletedTask;
+            }
+
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        private int? GetArtifactIdFromRequest()
+        {
+            var request = _httpContextAccessor.HttpContext.Request;
+
+            if (!request.RouteValues.TryGetValue(ArtifactIdParameter, out var id)) return null;
+            
+            if (!int.TryParse(id.ToString(), out var artifactId)) return null;
+
+            return artifactId;
+        }
+        private bool IsArtifactOfCurrentUser(int? artifactId, string userId)
+        {
+            var isArtifactOfCurrentUser = false;
+
+            using var scope = _serviceProvider.CreateScope();
+            var dataContext = scope.ServiceProvider.GetRequiredService<DataAccessContext>();
+            if (dataContext.Artifacts.Any(a => a.Id == artifactId))
+            {
+                isArtifactOfCurrentUser = dataContext.Artifacts.Include(artifact => artifact.Project).Any(ap =>
+                    ap.Project.UsersByProject.Any(ubp => ubp.UserId.Equals(Guid.Parse(userId))) &&
+                    ap.Id == artifactId);
+            }
+
+            return isArtifactOfCurrentUser;
+        }
+
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
@@ -32,6 +32,12 @@ namespace FRF.Web.Authorization
                     policy.AddRequirements(new ArtifactOwnershipRequirement());
                     return Task.FromResult(policy.Build());
                 }
+                case ArtifactAuthorization.RelationsListOwnership:
+                {
+                    var policy = new AuthorizationPolicyBuilder();
+                    policy.AddRequirements(new ArtifactsListOwnershipRequirement());
+                    return Task.FromResult(policy.Build());
+                }
                 default:
                     return FallbackPolicyProvider.GetPolicyAsync(policyName);
             }

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipPolicyProvider.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipPolicyProvider : IAuthorizationPolicyProvider
+    {
+        public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
+
+        public ArtifactOwnershipPolicyProvider(IOptions<AuthorizationOptions> options)
+        {
+            FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+        }
+
+        public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => FallbackPolicyProvider.GetDefaultPolicyAsync();
+
+        public Task<AuthorizationPolicy> GetFallbackPolicyAsync() => FallbackPolicyProvider.GetFallbackPolicyAsync();
+
+        public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+        {
+            if (string.IsNullOrWhiteSpace(policyName))
+            {
+                return FallbackPolicyProvider.GetPolicyAsync(policyName);
+            }
+
+            switch (policyName)
+            {
+                case ArtifactAuthorization.Ownership:
+                {
+                    var policy = new AuthorizationPolicyBuilder();
+                    policy.AddRequirements(new ArtifactOwnershipRequirement());
+                    return Task.FromResult(policy.Build());
+                }
+                default:
+                    return FallbackPolicyProvider.GetPolicyAsync(policyName);
+            }
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipRequirement.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactOwnershipRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactOwnershipRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipHandler.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipHandler.cs
@@ -1,0 +1,79 @@
+﻿using FRF.DataAccess;
+using FRF.Web.Dtos.Artifacts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactsListOwnershipHandler : AuthorizationHandler<ArtifactsListOwnershipRequirement>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ArtifactsListOwnershipHandler(IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
+        {
+            _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, ArtifactsListOwnershipRequirement requirement)
+        {
+            var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var artifactsRelations = await GetArtifactsRelationInRequestBody();
+            if (userId == null || artifactsRelations==null )
+            {
+                return;
+            }
+
+            var areAllArtifactsRelationOfCurrentUser = await AreAllArtifactsRelationOfCurrentUser(artifactsRelations, userId);
+            if (!areAllArtifactsRelationOfCurrentUser)
+            {
+                return;
+            }
+
+            context.Succeed(requirement);
+            return;
+        }
+
+        private async Task<IList<ArtifactsRelationInsertDTO>> GetArtifactsRelationInRequestBody()
+        {
+            var request = _httpContextAccessor.HttpContext.Request;
+            request.EnableBuffering();
+            using var reader = new StreamReader(request.Body, Encoding.UTF8, false, leaveOpen: true);
+            var requestBody = await reader.ReadToEndAsync();
+            var artifactsRelations = JsonConvert.DeserializeObject<List<ArtifactsRelationInsertDTO>>(requestBody);
+            request.Body.Position = 0;
+            return artifactsRelations;
+        }
+
+        private async Task<bool> AreAllArtifactsRelationOfCurrentUser(IList<ArtifactsRelationInsertDTO> artifactsRelations, string userId)
+        {
+            var isAuthorized = false;
+            using var scope = _serviceProvider.CreateScope();
+
+            var dataContext = scope.ServiceProvider.GetRequiredService<DataAccessContext>();
+            var artifactsIds = artifactsRelations
+                .Select(ar => ar.Artifact1Id)
+                .Concat(artifactsRelations.Select(ar => ar.Artifact2Id));
+            var artifactsByUser = await dataContext.Artifacts
+                .Include(artifact =>
+                    artifact.Project).Where(artifact => artifact.Project.UsersByProject
+                    .Any(ubp => ubp.UserId == Guid.Parse(userId))).ToListAsync();
+
+            isAuthorized = artifactsIds.All(aid =>
+                artifactsByUser.Any(abu => abu.Id == aid));
+
+            return isAuthorized;
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipRequirement.cs
+++ b/FiveRockingFingers/FRF.Web/Authorization/ArtifactsListOwnershipRequirement.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace FRF.Web.Authorization
+{
+    public class ArtifactsListOwnershipRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ArtifactService.ts
@@ -21,9 +21,9 @@ class ArtifactService {
         }
     };
 
-    static get = async (id: number) => {
+    static get = async (artifactId: number) => {
         try {
-            return await axios.get(`${ARTIFACTS_URL}/${id}`);
+            return await axios.get(`${ARTIFACTS_URL}/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
@@ -37,17 +37,17 @@ class ArtifactService {
         }
     };
 
-    static update = async (id: number, artifact: any) => {
+    static update = async (artifactId: number, artifact: any) => {
         try {
-            return await axios.put(`${ARTIFACTS_URL}/${id}`, artifact);
+            return await axios.put(`${ARTIFACTS_URL}/${artifactId}`, artifact);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
     };
 
-    static delete = async (id: number) => {
+    static delete = async (artifactId: number) => {
         try {
-            return await axios.delete(`${ARTIFACTS_URL}/${id}`);
+            return await axios.delete(`${ARTIFACTS_URL}/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }
@@ -61,9 +61,9 @@ class ArtifactService {
         }
     };
 
-    static deleteRelation = async (id: string) => {
+    static deleteRelation = async (artifactId: string) => {
         try {
-            return await axios.delete(`${BASE_URL}relations/${id}`);
+            return await axios.delete(`${BASE_URL}relations/${artifactId}`);
         } catch (error) {
             return error.response ? error.response : error.message;
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FRF.Core.Response;
+using FRF.Web.Authorization;
 
 namespace FRF.Web.Controllers
 {
@@ -45,10 +46,11 @@ namespace FRF.Web.Controllers
             return Ok(artifactsDto);
         }
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetAsync(int id)
+        [HttpGet("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> GetAsync(int artifactId)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
@@ -71,10 +73,11 @@ namespace FRF.Web.Controllers
             return Ok(artifactCreated);
         }
 
-        [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateAsync(int id, ArtifactUpsertDTO artifactDto)
+        [HttpPut("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> UpdateAsync(int artifactId, ArtifactUpsertDTO artifactDto)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
@@ -89,22 +92,24 @@ namespace FRF.Web.Controllers
             return Ok(updatedArtifact);
         }
 
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteAsync(int id)
+        [HttpDelete("{artifactId}")]
+        [Authorize(ArtifactAuthorization.Ownership)]
+        public async Task<IActionResult> DeleteAsync(int artifactId)
         {
-            var artifact = await _artifactsService.Get(id);
+            var artifact = await _artifactsService.Get(artifactId);
 
             if (!artifact.Success)
             {
                 return NotFound();
             }
 
-            await _artifactsService.Delete(id);
+            await _artifactsService.Delete(artifactId);
 
             return NoContent();
         }
 
         [HttpPost("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
         public async Task<IActionResult> SetRelationAsync(int artifactId, IList<ArtifactsRelationInsertDTO> artifactRelationList)
         {
             var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
@@ -116,6 +121,7 @@ namespace FRF.Web.Controllers
         }
 
         [HttpGet("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
         public async Task<IActionResult> GetRelationsAsync(int artifactId)
         {
             var result = await _artifactsService.GetAllRelationsOfAnArtifactAsync(artifactId);
@@ -154,6 +160,7 @@ namespace FRF.Web.Controllers
         }
 
         [HttpPut("{artifactId}/relations")]
+        [Authorize(ArtifactAuthorization.Ownership)]
         public async Task<IActionResult> UpdateRelationsAsync(int artifactId,
             IList<ArtifactsRelationUpdateDTO> artifactRelationUpdatedList)
         {

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -110,6 +110,7 @@ namespace FRF.Web.Controllers
 
         [HttpPost("{artifactId}/relations")]
         [Authorize(ArtifactAuthorization.Ownership)]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> SetRelationAsync(int artifactId, IList<ArtifactsRelationInsertDTO> artifactRelationList)
         {
             var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
@@ -151,6 +152,7 @@ namespace FRF.Web.Controllers
         }
 
         [HttpDelete("~/api/relations")]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
         {
             var result = await _artifactsService.DeleteRelationsAsync(artifactRelationIds);
@@ -161,6 +163,7 @@ namespace FRF.Web.Controllers
 
         [HttpPut("{artifactId}/relations")]
         [Authorize(ArtifactAuthorization.Ownership)]
+        [Authorize(ArtifactAuthorization.RelationsListOwnership)]
         public async Task<IActionResult> UpdateRelationsAsync(int artifactId,
             IList<ArtifactsRelationUpdateDTO> artifactRelationUpdatedList)
         {

--- a/FiveRockingFingers/FRF.Web/Startup.cs
+++ b/FiveRockingFingers/FRF.Web/Startup.cs
@@ -12,7 +12,9 @@ using FRF.Core.Base;
 using FRF.Core.Services;
 using FRF.Core.XmlValidation;
 using FRF.DataAccess;
+using FRF.Web.Authorization;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
@@ -134,6 +136,9 @@ namespace FRF.Web
 
 			var autoMapperProfileTypes = AutoMapperProfiles.Select(p => p.GetType()).ToArray();
 			services.AddAutoMapper(autoMapperProfileTypes);
+			services.AddTransient<IAuthorizationPolicyProvider, ArtifactOwnershipPolicyProvider>();
+			services.AddSingleton<IAuthorizationHandler, ArtifactOwnershipHandler>();
+			services.AddAuthorization();
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/FiveRockingFingers/FRF.Web/Startup.cs
+++ b/FiveRockingFingers/FRF.Web/Startup.cs
@@ -138,6 +138,7 @@ namespace FRF.Web
 			services.AddAutoMapper(autoMapperProfileTypes);
 			services.AddTransient<IAuthorizationPolicyProvider, ArtifactOwnershipPolicyProvider>();
 			services.AddSingleton<IAuthorizationHandler, ArtifactOwnershipHandler>();
+			services.AddSingleton<IAuthorizationHandler, ArtifactsListOwnershipHandler>();
 			services.AddAuthorization();
 		}
 

--- a/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
@@ -1,5 +1,4 @@
-﻿using FRF.Core.Tests;
-using FRF.DataAccess;
+﻿using FRF.DataAccess;
 using FRF.DataAccess.EntityModels;
 using FRF.Web.Authorization;
 using Microsoft.AspNetCore.Authorization;

--- a/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactOwnershipHandlerTest.cs
@@ -1,0 +1,225 @@
+﻿using FRF.Core.Tests;
+using FRF.DataAccess;
+using FRF.DataAccess.EntityModels;
+using FRF.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Web.Tests.Authorization
+{
+    public class ArtifactOwnershipHandlerTest
+    {
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly DataAccessContextForTest _dataAccess;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+        private readonly ArtifactOwnershipHandler _classUnderTest;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+
+        public ArtifactOwnershipHandlerTest()
+        {
+            _configuration = new Mock<IConfiguration>();
+            _httpContextAccessor = new Mock<IHttpContextAccessor>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _classUnderTest = new ArtifactOwnershipHandler(_serviceProvider.Object, _httpContextAccessor.Object);
+            _dataAccess = new DataAccessContextForTest(Guid.NewGuid(), _configuration.Object);
+            _dataAccess.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Succeeds()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var artifact = CreateArtifact(project);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenArtifactIsNotOfCurrentUser()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var artifact = CreateArtifact(project);
+            var currentUserId = Guid.NewGuid();
+            var anotherUserId = Guid.NewGuid();
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            CreateUserByProject(project, anotherUserId);
+
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenArtifactIdNotExist()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var context = GetAuthorizationHandlerContext(currentUserId); ;
+
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", "9999" }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        private AuthorizationHandlerContext GetAuthorizationHandlerContext(Guid currentUserId)
+        {
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, currentUserId.ToString()),
+            }));
+            var requirements = new List<IAuthorizationRequirement>
+            {
+                new ArtifactOwnershipRequirement()
+            };
+            var context = new AuthorizationHandlerContext(requirements, userPrincipal, null);
+            return context;
+        }
+
+        private void MockServiceProvider()
+        {
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(DataAccessContext)))
+                .Returns(_dataAccess);
+
+            var serviceScope = new Mock<IServiceScope>();
+            serviceScope.Setup(x => x.ServiceProvider).Returns(_serviceProvider.Object);
+
+            var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            serviceScopeFactory
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScope.Object);
+
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactory.Object);
+        }
+
+        private void CreateUserByProject(DataAccess.EntityModels.Project project, Guid userId)
+        {
+            var userByProject = new UsersByProject
+            {
+                ProjectId = project.Id,
+                Project = project,
+                UserId = userId
+            };
+
+            _dataAccess.UsersByProject.Add(userByProject);
+            _dataAccess.SaveChanges();
+        }
+
+        private Provider CreateProvider()
+        {
+            var provider = new Provider();
+            provider.Name = "[Mock] Provider name";
+            _dataAccess.Providers.Add(provider);
+            _dataAccess.SaveChanges();
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
+        {
+            var artifactType = new ArtifactType();
+            artifactType.Name = "[Mock] Artifact type name";
+            artifactType.Description = "[Mock] Artifact type description";
+            artifactType.Provider = provider;
+            _dataAccess.ArtifactType.Add(artifactType);
+            _dataAccess.SaveChanges();
+
+            return artifactType;
+        }
+
+        private Project CreateProject()
+        {
+            var project = new Project();
+            project.Name = "[MOCK] Project name";
+            project.CreatedDate = DateTime.Now;
+            project.ProjectCategories = new List<ProjectCategory>();
+            _dataAccess.Projects.Add(project);
+            _dataAccess.SaveChanges();
+
+            return project;
+        }
+
+        private Artifact CreateArtifact(Project project)
+        {
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var random = new Random();
+            var artifact = new Artifact()
+            {
+                Name = "[Mock] Artifact name " + random.Next(500),
+                CreatedDate = DateTime.Now,
+                Project = project,
+                ProjectId = project.Id,
+                ArtifactType = artifactType,
+                ArtifactTypeId = artifactType.Id
+            };
+            _dataAccess.Artifacts.Add(artifact);
+            _dataAccess.SaveChanges();
+
+            return artifact;
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
+++ b/test/FRF.Web.Tests/Authorization/ArtifactsListOwnershipHandlerTest.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FRF.Core.Tests;
+using FRF.DataAccess;
+using FRF.DataAccess.EntityModels;
+using FRF.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace FRF.Web.Tests.Authorization
+{
+    public class ArtifactsListOwnershipHandlerTest
+    {
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly DataAccessContextForTest _dataAccess;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+        private readonly ArtifactsListOwnershipHandler _classUnderTest;
+        private readonly Mock<IServiceProvider> _serviceProvider;
+
+        public ArtifactsListOwnershipHandlerTest()
+        {
+            _configuration = new Mock<IConfiguration>();
+            _httpContextAccessor = new Mock<IHttpContextAccessor>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _classUnderTest = new ArtifactsListOwnershipHandler(_serviceProvider.Object, _httpContextAccessor.Object);
+            _dataAccess = new DataAccessContextForTest(Guid.NewGuid(), _configuration.Object);
+            _dataAccess.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Succeeds()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var artifact = CreateArtifact(project);
+            var artifact2 = CreateArtifact(project);
+            var relation = CreateArtifactsRelationModel(artifact.Id, artifact2.Id);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = $"[{{\"artifact1Id\":{artifact.Id},\"artifact2Id\":{artifact2.Id},\"artifact1Property\":\"{relation.Artifact1Property}\",\"artifact2Property\":\"{relation.Artifact2Property}\",\"relationTypeId\":0}}]";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream; 
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenAnyArtifactsRelationIsNotOfCurrentUser()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            var anotherUserId = Guid.NewGuid();
+            CreateUserByProject(project, anotherUserId);
+            var artifact = CreateArtifact(project);
+            var artifact2 = CreateArtifact(project);
+            var relation = CreateArtifactsRelationModel(artifact.Id, artifact2.Id);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = $"[{{\"artifact1Id\":{artifact.Id},\"artifact2Id\":{artifact2.Id},\"artifact1Property\":\"{relation.Artifact1Property}\",\"artifact2Property\":\"{relation.Artifact2Property}\",\"relationTypeId\":0}}]";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", artifact.Id.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream;
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task HandleRequirementAsync_Fail_WhenListOfRelationsIsEmpty()
+        {
+            // Arrange.
+            var project = CreateProject();
+            var currentUserId = Guid.NewGuid();
+            CreateUserByProject(project, currentUserId);
+            var context = GetAuthorizationHandlerContext(currentUserId);
+            var data = "";
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(data));
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = _serviceProvider.Object
+            };
+            var routeArtifact = new Dictionary<string, string>
+            {
+                { "artifactId", int.MaxValue.ToString() }
+            };
+            httpContext.Request.RouteValues = new RouteValueDictionary(routeArtifact);
+            httpContext.Request.Body = stream;
+            _httpContextAccessor.SetupGet(accessor => accessor.HttpContext).Returns(httpContext);
+            MockServiceProvider();
+
+            // Act.
+            await _classUnderTest.HandleAsync(context);
+
+            // Assert.
+            Assert.False(context.HasSucceeded);
+        }
+
+        private AuthorizationHandlerContext GetAuthorizationHandlerContext(Guid currentUserId)
+        {
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, currentUserId.ToString()),
+            }));
+            var requirements = new List<IAuthorizationRequirement>
+            {
+                new ArtifactsListOwnershipRequirement()
+            };
+            var context = new AuthorizationHandlerContext(requirements, userPrincipal, null);
+            return context;
+        }
+
+        private void MockServiceProvider()
+        {
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(DataAccessContext)))
+                .Returns(_dataAccess);
+
+            var serviceScope = new Mock<IServiceScope>();
+            serviceScope.Setup(x => x.ServiceProvider).Returns(_serviceProvider.Object);
+
+            var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+            serviceScopeFactory
+                .Setup(x => x.CreateScope())
+                .Returns(serviceScope.Object);
+
+            _serviceProvider
+                .Setup(x => x.GetService(typeof(IServiceScopeFactory)))
+                .Returns(serviceScopeFactory.Object);
+        }
+        private FRF.Core.Models.ArtifactsRelation CreateArtifactsRelationModel(int artifact1Id, int artifact2Id)
+        {
+            var random = new Random();
+            var propertyId = random.Next(1000);
+            var artifactRelation = new FRF.Core.Models.ArtifactsRelation()
+            {
+                Artifact1Id = artifact1Id,
+                Artifact2Id = artifact2Id,
+                Artifact1Property = "Mock 1 Property " + propertyId,
+                Artifact2Property = "Mock 2 Property " + propertyId,
+                RelationTypeId = 1
+            };
+
+            return artifactRelation;
+        }
+        private void CreateUserByProject(DataAccess.EntityModels.Project project, Guid userId)
+        {
+            var userByProject = new UsersByProject
+            {
+                ProjectId = project.Id,
+                Project = project,
+                UserId = userId
+            };
+
+            _dataAccess.UsersByProject.Add(userByProject);
+            _dataAccess.SaveChanges();
+        }
+
+        private Provider CreateProvider()
+        {
+            var provider = new Provider();
+            provider.Name = "[Mock] Provider name";
+            _dataAccess.Providers.Add(provider);
+            _dataAccess.SaveChanges();
+
+            return provider;
+        }
+
+        private ArtifactType CreateArtifactType(Provider provider)
+        {
+            var artifactType = new ArtifactType();
+            artifactType.Name = "[Mock] Artifact type name";
+            artifactType.Description = "[Mock] Artifact type description";
+            artifactType.Provider = provider;
+            _dataAccess.ArtifactType.Add(artifactType);
+            _dataAccess.SaveChanges();
+
+            return artifactType;
+        }
+
+        private Project CreateProject()
+        {
+            var project = new Project();
+            project.Name = "[MOCK] Project name";
+            project.CreatedDate = DateTime.Now;
+            project.ProjectCategories = new List<ProjectCategory>();
+            _dataAccess.Projects.Add(project);
+            _dataAccess.SaveChanges();
+
+            return project;
+        }
+
+        private Artifact CreateArtifact(Project project)
+        {
+            var provider = CreateProvider();
+            var artifactType = CreateArtifactType(provider);
+            var random = new Random();
+            var artifact = new Artifact()
+            {
+                Name = "[Mock] Artifact name " + random.Next(500),
+                CreatedDate = DateTime.Now,
+                Project = project,
+                ProjectId = project.Id,
+                ArtifactType = artifactType,
+                ArtifactTypeId = artifactType.Id
+            };
+            _dataAccess.Artifacts.Add(artifact);
+            _dataAccess.SaveChanges();
+
+            return artifact;
+        }
+    }
+}

--- a/test/FRF.Web.Tests/DataAccessContextForTest.cs
+++ b/test/FRF.Web.Tests/DataAccessContextForTest.cs
@@ -1,0 +1,22 @@
+﻿using FRF.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace FRF.Web.Tests
+{
+    public class DataAccessContextForTest : DataAccessContext
+    {
+        private readonly IConfiguration _configuration;
+
+        public DataAccessContextForTest(Guid dbGuid, IConfiguration configuration) : base(
+            new DbContextOptionsBuilder<DataAccessContext>().UseInMemoryDatabase(databaseName: dbGuid.ToString()).Options, configuration)
+
+        {
+            _configuration = configuration;
+        }
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+        }
+    }
+}

--- a/test/FRF.Web.Tests/FRF.Web.Tests.csproj
+++ b/test/FRF.Web.Tests/FRF.Web.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\FiveRockingFingers\FRF.Web\FRF.Web.csproj" />
+    <ProjectReference Include="..\FRF.Core.Tests\FRF.Core.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/FRF.Web.Tests/FRF.Web.Tests.csproj
+++ b/test/FRF.Web.Tests/FRF.Web.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit" Version="2.4.0" />
@@ -16,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\FiveRockingFingers\FRF.Web\FRF.Web.csproj" />
-    <ProjectReference Include="..\FRF.Core.Tests\FRF.Core.Tests.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Se implementan filtros Policy-based authorization, para lograr validar los siguientes casos antes de que se ejecute ArtifactController:
    - ArtifactOwnership : si el usuario actualmente conectado posee permiso para invocar el artefacto.
- Se agregó ArtifactOwnershipPolicyProvider el cual utiliza ArtifactAuthorization para implementar el filtro correspondiente, según lo solicitado.
- Se agregaron singletons en Startup para lograr inyección de dependencias y extender vida de: ArtifactOwnershipHandler.
- Se agregaron Unit Test correspondiente a lo realizado.
- Se agregó paquete "Microsoft.EntityFrameworkCore.InMemory" al proyecto FRF.Web.Tests , con el fin de generar un DataAccessContextForTest.
- Se agregó DataAccessContextForTest en proyecto FRF.Web.Tests.