### PR TITLE
[FIVE-342] (Backend) Definir settings relacionables de cada artefacto

### DIFF
--- a/FiveRockingFingers/FRF.Core/Models/Artifact.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Artifact.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 namespace FRF.Core.Models
@@ -14,6 +15,7 @@ namespace FRF.Core.Models
         public Project Project { get; set; }
         public int ArtifactTypeId { get; set; }
         public ArtifactType ArtifactType { get; set; }
+        public Dictionary<string, string> RelationalFields { get; set; }
 
         public virtual decimal GetPrice()
         {

--- a/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsEc2.cs
+++ b/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsEc2.cs
@@ -41,6 +41,14 @@ namespace FRF.Core.Models.AwsArtifacts
         public AwsEc2(XElement settings)
         {
             Settings = settings;
+            RelationalFields = new Dictionary<string, string>();
+            RelationalFields.Add("hoursUsedPerMonth", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfGbStorageInEbs", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfSnapshotsPerMonth", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfGbChangedPerSnapshot", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfIopsPerMonth", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfMbpsThroughput", SettingTypes.Decimal);
+            RelationalFields.Add("numberOfGbTransfer1", SettingTypes.Decimal);
         }
 
         override public decimal GetPrice()

--- a/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsS3.cs
+++ b/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsS3.cs
@@ -16,7 +16,16 @@ namespace FRF.Core.Models.AwsArtifacts
         public int RetrieveRequestsUsed { get; set; }
         public int? InfrequentAccessMultiplier { get; set; }
         public decimal InfrequentAccessStoragePrice { get; set; }
-        public Dictionary<string,PricingDimension> PricingDimensions { get; private set; }
+        public Dictionary<string, PricingDimension> PricingDimensions { get; private set; }
+
+        public AwsS3()
+        {
+            RelationalFields = new Dictionary<string, string>();
+            RelationalFields.Add("writeRequestsUsed", SettingTypes.NaturalNumber);
+            RelationalFields.Add("retrieveRequestsUsed", SettingTypes.NaturalNumber);
+            RelationalFields.Add("storageUsed", SettingTypes.Decimal);
+            RelationalFields.Add("infrequentAccessMultiplier", SettingTypes.Decimal);
+        }
 
         public override decimal GetPrice()
         {

--- a/FiveRockingFingers/FRF.Core/SettingTypes.cs
+++ b/FiveRockingFingers/FRF.Core/SettingTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Core
+{
+    public static class SettingTypes
+    {
+        public const string Decimal = "decimal";
+        public const string NaturalNumber = "naturalNumber";
+    }
+}

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/ArtifactDTO.cs
@@ -12,5 +12,6 @@ namespace FRF.Web.Dtos.Artifacts
         public int ProjectId { get; set; }
         public ArtifactTypeDTO ArtifactType { get; set; }
         public decimal Price { get; set; }
+        public Dictionary<string, string> RelationalFields { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/Artifacts/DictionaryResolver.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Artifacts/DictionaryResolver.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using System.Collections.Generic;
+
+namespace FRF.Web.Dtos.Artifacts
+{
+    public class DictionaryResolver : IValueResolver<Artifact, ArtifactDTO, Dictionary<string, string>>
+    {
+        public Dictionary<string, string> Resolve(Artifact source, ArtifactDTO destination, Dictionary<string, string> destMember, ResolutionContext context)
+        {
+            var fields = new Dictionary<string, string>();
+
+            if (source.RelationalFields == null) return null;
+
+            foreach(var field in source.RelationalFields)
+            {
+                fields.Add(field.Key, field.Value);
+            }
+
+            return fields;
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
@@ -29,6 +29,7 @@ namespace FRF.Web.Dtos
             CreateMap<Categories.CategoryUpsertDTO, Category>();
             CreateMap<Artifact, ArtifactDTO>()
                 .ForMember(dest => dest.Settings, opt => opt.MapFrom<XmlResolver>())
+                .ForMember(dest => dest.RelationalFields, opt => opt.MapFrom<DictionaryResolver>())
                 .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.GetPrice()));
             CreateMap<ArtifactUpsertDTO, Artifact>();
             CreateMap<ArtifactType, ArtifactTypeDTO>()

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -198,12 +198,14 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            setSetting1(null);
             event.target.value === '' ?
             setArtifact1(null)
             :
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            setSetting2(null);
             event.target.value === '' ?
             setArtifact2(null)
             :

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -10,6 +10,7 @@ import RelationCard from './NewArtifactRelationComponents/RelationCard';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
+import { PROVIDERS } from '../Constants';
 
 interface handlerUpdateList{
     update: boolean,
@@ -50,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) =>
 const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
 
     const classes = useStyles();
-    const { handleSubmit, errors, control } = useForm();
+    const { errors, control } = useForm();
     const [artifact1, setArtifact1] = React.useState<Artifact | null>(null);
     const [artifact2, setArtifact2] = React.useState<Artifact | null>(null);
     const [artifact1Settings, setArtifact1Settings] = React.useState<{ [key: string]: string }>({});
@@ -170,13 +171,25 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const updateArtifactsSettings = () => {
         if (artifact1 !== null && artifact1 !== undefined) {
-            setArtifact1Settings(artifact1.settings);
+            if (artifact1.artifactType.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact1.relationalFields).map(([key, value]) => relationalSettings[key] = artifact1.settings[key]);
+                setArtifact1Settings(relationalSettings);
+            } else {
+                setArtifact1Settings(artifact1.settings);
+            }
         }
         else {
             setArtifact1Settings({});
         }
         if (artifact2 !== null && artifact2 !== undefined) {
-            setArtifact2Settings(artifact2.settings);
+            if (artifact2.artifactType.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact2.relationalFields).map(([key, value]) => relationalSettings[key] = artifact2.settings[key]);
+                setArtifact2Settings(relationalSettings);
+            } else {
+                setArtifact2Settings(artifact2.settings);
+            }
         }
         else {
             setArtifact2Settings({});
@@ -185,9 +198,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            setSetting1(null)
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            setSetting2(null)
             setArtifact2(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }              
     }
@@ -245,9 +260,20 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         resetState();
     }
 
+    const toRegularSentence = (value: string) => {
+        if (!value || value.length === 0) return "";
+
+        const result = value.replace(/([A-Z])/g, ' $1');
+        if (/[a-z]/.test(result.charAt(0))) {
+            return `${result.charAt(0).toUpperCase()}${result.slice(1)}`;
+        } else {
+            return result;
+        }
+    }
+
     return (
         <Dialog open={props.showNewArtifactsRelation}>
-            <DialogTitle id="alert-dialog-title">Formulario de para crear relación entre artefactos</DialogTitle>
+            <DialogTitle id="alert-dialog-title">Formulario para crear relación entre artefactos</DialogTitle>
             <DialogContent>
                 {relationList.map((relation, index) => 
                     <RelationCard
@@ -273,7 +299,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     }}
                                     onChange={(event) => handleChange(event)}
                                     defaultValue={''}
-                                    value={artifact1 !== null ? artifact1.id : ''}
+                                    value={artifact1 !== null && artifact1 !== undefined ? artifact1.id : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -298,7 +324,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     }}
                                     onChange={(event) => handleChange(event)}
                                     defaultValue={''}
-                                    value={artifact2 !== null ? artifact2.id : ''}
+                                    value={artifact2 !== null && artifact2 !== undefined ? artifact2.id : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -332,14 +358,14 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting1"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting1 !== null ? setting1.value : null}</FormHelperText>
+                        <FormHelperText>{setting1 !== null ? `${setting1.value} (${artifact1 && toRegularSentence(artifact1.relationalFields[setting1.key])})` : null}</FormHelperText>
                     </FormControl>
                     <FormControl className={classes.selectDirection} error={Boolean(errors.artifactType)}>
                         <InputLabel htmlFor="type-select">Dirección</InputLabel>
@@ -388,14 +414,14 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting2"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting2 !== null ? setting2.value : null}</FormHelperText>
+                        <FormHelperText>{setting2 !== null ? `${setting2.value} (${artifact2 && toRegularSentence(artifact2?.relationalFields[setting2.key])})` : null}</FormHelperText>
                     </FormControl>
                     {isErrorOneRelationCreated ?
                         <Typography gutterBottom className={classes.error}>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Artifact.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Artifact.ts
@@ -1,5 +1,4 @@
-﻿import Project from './Project';
-import ArtifactType from './ArtifactType';
+﻿import ArtifactType from './ArtifactType';
 
 export default interface Artifact {
     id: number;
@@ -9,4 +8,5 @@ export default interface Artifact {
     projectId: number;
     artifactType: ArtifactType;
     price: number;
+    relationalFields: { [key: string]: string };
 }


### PR DESCRIPTION
## Tarea a realizar
Cada tipo de artefacto debe tener un listado de settings que pueden relacionarse, así como también que tipo de valor tienen o esperan cada una de ellas.

## Cambios realizados
Para resolver esto, se definió una nueva propiedad en el modelo de artefactos, RelationalFields. Este es un diccionario con el nombre de la setting a relacionar como clave, y como valor tiene el tipo que esta setting acepta (los dos tipos definidos por el momento se basan en los valores que aceptan los servicios S3 y EC2 de Aws).

El objetivo de esto es tener control sobre las asociaciones de valores que generen los usuarios, por un lado, para que al momento de realizar una relación entre artefactos, solo se puedan relacionar settings del mismo tipo. Es decir, que si una setting espera un valor Entero (por ejemplo la cantidad de requests que recibe al mes), no se pueda asociar una cadena o un decimal. Por otro lado, también se busca tener control sobre las settings que son relacionables de cada artefacto, para evitar que se puedan cambiar aquellos valores que no deben ser modificados.