### PR TITLE
[FIVE-342] (Frontend) Definir settings relacionables de cada artefacto

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -10,6 +10,7 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../../services/ArtifactService';
 import { Select } from '@material-ui/core';
+import { PROVIDERS } from '../../Constants';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -46,8 +47,8 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
 
     const classes = useStyles();
     const {handleSubmit, errors, control } = useForm();
-    const [artifact1, setArtifact1] = React.useState<Artifact | null>(props.artifactRelations.artifact1);
-    const [artifact2, setArtifact2] = React.useState<Artifact | null>(props.artifactRelations.artifact2);
+    const [artifact1, setArtifact1] = React.useState<Artifact | null>(null);
+    const [artifact2, setArtifact2] = React.useState<Artifact | null>(null);
     const [artifact1Settings, setArtifact1Settings] = React.useState<{ [key: string]: string }>({});
     const [artifact2Settings, setArtifact2Settings] = React.useState<{ [key: string]: string }>({});
     const [setting1, setSetting1] = React.useState<KeyValueStringPair | null>(null);
@@ -58,10 +59,37 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
     const [isErrorEmptyField, setIsErrorEmptyField] = React.useState<boolean>(false);
 
     const updateArtifactsSettings = () => {
-            props.updateList(true);
-            setArtifact1Settings(artifact1!.settings);
-            setArtifact2Settings(artifact2!.settings);
+        props.updateList(true);
+        if (artifact1 !== null && artifact1 !== undefined) {
+            if (artifact1.artifactType?.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact1.relationalFields).map(([key, value]) => relationalSettings[key] = artifact1.settings[key]);
+                setArtifact1Settings(relationalSettings);
+            } else {
+                setArtifact1Settings(artifact1.settings);
+            }
+        }
+        else {
+            setArtifact1Settings({});
+        }
+        if (artifact2 !== null && artifact2 !== undefined) {
+            if (artifact2.artifactType?.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact2.relationalFields).map(([key, value]) => relationalSettings[key] = artifact2.settings[key]);
+                setArtifact2Settings(relationalSettings);
+            } else {
+                setArtifact2Settings(artifact2.settings);
+            }
+        }
+        else {
+            setArtifact2Settings({});
+        }
     }
+
+    React.useEffect(() => {
+        setArtifact1(props.artifacts.find(a => a.id === props.artifactRelations.artifact1.id) as Artifact);
+        setArtifact2(props.artifacts.find(a => a.id === props.artifactRelations.artifact2.id) as Artifact);
+    }, [props.open])
 
     React.useEffect(() => {
         updateArtifactsSettings();
@@ -100,8 +128,8 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
 
     const resetState = () => {
         updateArtifactsSettings();
-        setArtifact1(props.artifactRelations.artifact1);
-        setArtifact2(props.artifactRelations.artifact2);
+        setArtifact1(props.artifacts.find(a => a.id === props.artifactRelations.artifact1.id) as Artifact);
+        setArtifact2(props.artifacts.find(a => a.id === props.artifactRelations.artifact2.id) as Artifact);
         setSetting1(null);
         setSetting2(null);
         setRelationTypeId(props.artifactRelations.relationTypeId);
@@ -161,9 +189,11 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            setSetting1(null)
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            setSetting2(null)
             setArtifact2(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
     }
@@ -174,13 +204,23 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
             setSetting1(setting);
         }
         else if (event.target.name === 'setting2') {
-            let setting: KeyValueStringPair = { key: event.target.value as string, value: artifact1Settings[event.target.value as string] };
+            let setting: KeyValueStringPair = { key: event.target.value as string, value: artifact2Settings[event.target.value as string] };
             setSetting2(setting);
         }
     }
 
     const handleRelationTypeChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         setRelationTypeId(event.target.value as number);
+    }
+
+    const toRegularSentence = (value: string) => {
+        // Value will be null only when you select a Custom artifact setting, since their type selection hasn't been implemented
+        // REMOVE ONCE IT'S DONE
+        if (!value) return "";
+
+        const result = value.replace(/([A-Z])/g, ' $1');
+        const final = result.charAt(0).toUpperCase() + result.slice(1);
+        return final;
     }
 
     return (
@@ -259,14 +299,14 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting1"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting1 ? setting1?.value : null}</FormHelperText>
+                        <FormHelperText>{setting1 && `${setting1.value} (${artifact1 && toRegularSentence(artifact1.relationalFields[setting1.key])})`}</FormHelperText>
                     </FormControl>
                     <FormControl className={classes.selectDirection} error={Boolean(errors.artifactType)}>
                         <InputLabel htmlFor="type-select">Dirección</InputLabel>
@@ -313,14 +353,14 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting2"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting2 ? setting2?.value : null}</FormHelperText>
+                        <FormHelperText>{setting2 && `${setting2.value} (${artifact2 && toRegularSentence(artifact2?.relationalFields[setting2.key])})`}</FormHelperText>
                     </FormControl>
                     {errors.settings ?
                         <Typography gutterBottom className={classes.error}>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -10,6 +10,7 @@ import RelationCard from './NewArtifactRelationComponents/RelationCard';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
+import { PROVIDERS } from '../Constants';
 
 interface handlerUpdateList{
     update: boolean,
@@ -50,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) =>
 const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeNewArtifactsRelation: Function, projectId: number, setOpenSnackbar: Function, setSnackbarSettings: Function, artifacts: Artifact[], artifactsRelations: ArtifactRelation[], updateList: handlerUpdateList }) => {
 
     const classes = useStyles();
-    const { handleSubmit, errors, control } = useForm();
+    const { errors, control } = useForm();
     const [artifact1, setArtifact1] = React.useState<Artifact | null>(null);
     const [artifact2, setArtifact2] = React.useState<Artifact | null>(null);
     const [artifact1Settings, setArtifact1Settings] = React.useState<{ [key: string]: string }>({});
@@ -170,13 +171,25 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const updateArtifactsSettings = () => {
         if (artifact1 !== null && artifact1 !== undefined) {
-            setArtifact1Settings(artifact1.settings);
+            if (artifact1.artifactType.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact1.relationalFields).map(([key, value]) => relationalSettings[key] = artifact1.settings[key]);
+                setArtifact1Settings(relationalSettings);
+            } else {
+                setArtifact1Settings(artifact1.settings);
+            }
         }
         else {
             setArtifact1Settings({});
         }
         if (artifact2 !== null && artifact2 !== undefined) {
-            setArtifact2Settings(artifact2.settings);
+            if (artifact2.artifactType.name != PROVIDERS[1]) {
+                var relationalSettings: { [key: string]: string } = {};
+                Object.entries(artifact2.relationalFields).map(([key, value]) => relationalSettings[key] = artifact2.settings[key]);
+                setArtifact2Settings(relationalSettings);
+            } else {
+                setArtifact2Settings(artifact2.settings);
+            }
         }
         else {
             setArtifact2Settings({});
@@ -185,9 +198,11 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
 
     const handleChange = (event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>) => {
         if (event.target.name === 'artifact1') {
+            setSetting1(null)
             setArtifact1(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }
         else if (event.target.name === 'artifact2') {
+            setSetting2(null)
             setArtifact2(props.artifacts.find(a => a.id === event.target.value) as Artifact);
         }              
     }
@@ -245,6 +260,16 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
         resetState();
     }
 
+    const toRegularSentence = (value: string) => {
+        // Value will be null only when you select a Custom artifact setting, since their type selection hasn't been implemented
+        // REMOVE ONCE IT'S DONE
+        if (!value) return "";
+
+        const result = value.replace(/([A-Z])/g, ' $1');
+        const final = result.charAt(0).toUpperCase() + result.slice(1);
+        return final;
+    }
+
     return (
         <Dialog open={props.showNewArtifactsRelation}>
             <DialogTitle id="alert-dialog-title">Formulario de para crear relación entre artefactos</DialogTitle>
@@ -273,7 +298,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     }}
                                     onChange={(event) => handleChange(event)}
                                     defaultValue={''}
-                                    value={artifact1 !== null ? artifact1.id : ''}
+                                    value={artifact1 !== null && artifact1 !== undefined ? artifact1.id : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -298,7 +323,7 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     }}
                                     onChange={(event) => handleChange(event)}
                                     defaultValue={''}
-                                    value={artifact2 !== null ? artifact2.id : ''}
+                                    value={artifact2 !== null && artifact2 !== undefined ? artifact2.id : ''}
                                     error={false}
                                 >
                                     <MenuItem value="">
@@ -332,14 +357,14 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact1Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting1"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting1 !== null ? setting1.value : null}</FormHelperText>
+                        <FormHelperText>{setting1 !== null ? `${setting1.value} (${artifact1 && toRegularSentence(artifact1.relationalFields[setting1.key])})` : null}</FormHelperText>
                     </FormControl>
                     <FormControl className={classes.selectDirection} error={Boolean(errors.artifactType)}>
                         <InputLabel htmlFor="type-select">Dirección</InputLabel>
@@ -388,14 +413,14 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                                     <MenuItem value="">
                                         <em>None</em>
                                     </MenuItem>
-                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{key}</MenuItem>)}
+                                    {Object.entries(artifact2Settings).map(([key, value], index) => <MenuItem key={key} value={key}>{toRegularSentence(key)}</MenuItem>)}
                                 </Select>
                             }
                             name="setting2"
                             control={control}
                             defaultValue={''}
                         />
-                        <FormHelperText>{setting2 !== null ? setting2.value : null}</FormHelperText>
+                        <FormHelperText>{setting2 !== null ? `${setting2.value} (${artifact2 && toRegularSentence(artifact2?.relationalFields[setting2.key])})` : null}</FormHelperText>
                     </FormControl>
                     {isErrorOneRelationCreated ?
                         <Typography gutterBottom className={classes.error}>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Artifact.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Artifact.ts
@@ -1,5 +1,4 @@
-﻿import Project from './Project';
-import ArtifactType from './ArtifactType';
+﻿import ArtifactType from './ArtifactType';
 
 export default interface Artifact {
     id: number;
@@ -9,4 +8,5 @@ export default interface Artifact {
     projectId: number;
     artifactType: ArtifactType;
     price: number;
+    relationalFields: { [key: string]: string };
 }


### PR DESCRIPTION
## Tarea a realizar
Cada tipo de artefacto debe tener un listado de settings que pueden relacionarse, así como también que tipo de valor tienen o esperan cada una de ellas.

## Cambios realizados
Como continuación del PR #126, se modifican los formularios para creación y modificación de relaciones para mostrar solo las settings relacionables de cada artefacto, así como también el tipo de valor que representan.
_____________________________________________________________________________
#### El tipo de la setting se puede ver a la derecha del valor, entre paréntesis

![image](https://user-images.githubusercontent.com/71275374/110968198-02009f80-8336-11eb-84a8-2f5e892c53ae.png)
___________________________________________________________________________
#### El listado con las settings relacionables del artefacto AmazonS3
![image](https://user-images.githubusercontent.com/71275374/110968522-66236380-8336-11eb-8d7a-a844c577578c.png)


