### PR TITLE
[FIVE-378] Modificar forma en la que se renderiza NavMenu sidebar

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsDetails.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsDetails.tsx
@@ -1,5 +1,4 @@
 ﻿import * as React from 'react';
-import NavMenu from '../commons/NavMenu';
 import ArtifactsTable from './ArtifactsComponents/ArtifactsTable';
 import { RouteComponentProps } from 'react-router';
 
@@ -10,10 +9,7 @@ const ArtifactsDetails = ({ match }: RouteComponentProps<TParams>) => {
     const projectId = parseInt(match.params.projectId, 10);
 
     return (
-        <div className='content'>
-            <NavMenu />
-            <ArtifactsTable projectId={projectId} />
-        </div>
+        <ArtifactsTable projectId={projectId} />
     );
 }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/Home.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/Home.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
-import NavMenu from '../commons/NavMenu';
 
 const Home = () => {
     return (
-        <div className='content'>
-            <NavMenu />
-            <div>
-                <h1>{"Lets estimate some projects"}</h1>
-            </div>
+        <div>
+            <h1>{"Lets estimate some projects"}</h1>
         </div>
     );
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelation.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import NavMenu from '../../commons/NavMenu';
 import ArtifactsRelationTable from './ArtifactsRelationTable';
 import { RouteComponentProps } from 'react-router';
 
@@ -14,10 +13,7 @@ const ArtifactsDetails = ({ match }: RouteComponentProps<TParams>) => {
     let artifactId = parseInt(match.params.artifactId, 10);
 
     return (
-        <div className='content'>
-            <NavMenu />
-            <ArtifactsRelationTable artifactId={artifactId} projectId={projectId} />
-        </div>
+      <ArtifactsRelationTable artifactId={artifactId} projectId={projectId} />
     );
 }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/authService.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/authService.tsx
@@ -1,14 +1,29 @@
 import React from "react";
 import { Route, Redirect, RouteComponentProps } from "react-router-dom";
+import ManageProjects from '../../components/ManageProjects';
 import {useUser} from '../../commons/useUser';
+import NavMenu from "../../commons/NavMenu";
 
 const PrivateRoute: React.FC<{
     component: React.FC | (({ match }: RouteComponentProps<any>) => JSX.Element);
     path: string;
     exact: boolean;
 }> = (props) => {
-    const {isLogged} = useUser();
-    return (isLogged) ? (<Route path={props.path} exact={props.exact} component={props.component} />) : (<Redirect to="/login" />);
+    const { isLogged } = useUser();
+    const RouteComponent =  <Route path={props.path} exact={props.exact} component={props.component} />;
+
+    return isLogged ? (
+        props.component === ManageProjects ? (
+            RouteComponent
+        ) : (
+            <div className="content">
+                <NavMenu />
+                {RouteComponent}
+            </div>
+        )
+    ) : (
+        <Redirect to="/login" />
+    );
 };
 
 export default PrivateRoute;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/router/Routes.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/router/Routes.tsx
@@ -12,7 +12,6 @@ import ArtiactsRelation from '../components/NewArtifactRelationComponents/Artifa
 const Routes = () => (
     <Switch>
         <Redirect exact from="/" to="/home" />
-        <Route exact path='/' component={Home} />
         <Route exact path="/login" component={Login} />
         <Route exact path="/signup" component={Signup} />
         <PrivateRoute exact path="/home" component={Home} />


### PR DESCRIPTION
### Descripción:
Cada vez que se cambia de página o se actualiza una, se vuelve a renderizar el componente NavMenu (sidebar). Multiplicando exponencialmente el número de solicitudes a la API.
### Modificaciones:
- Se modificó `authService` para que todas las rutas que no correspondan a `ManageProjects`, rendericen solo una vez el `NavMenu` del sidebar.