### PR TITLE
[FIVE-371-Backend] Modificar almacenamiento de sesión activa en frontend

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/SignInService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignInService.cs
@@ -3,6 +3,8 @@ using FRF.Core.Models;
 using FRF.Core.Response;
 using Microsoft.AspNetCore.Identity;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace FRF.Core.Services
 {
@@ -35,7 +37,7 @@ namespace FRF.Core.Services
                 var result = await _signInManager.PasswordSignInAsync(token, userPassword,
                     userSignIn.RememberMe, lockoutOnFailure: false);
                 return result.Succeeded
-                    ? new ServiceResponse<string>(token.UserID)
+                    ? new ServiceResponse<string>(token.SessionTokens.IdToken)
                     : new ServiceResponse<string>(new Error(ErrorCodes.InvalidCredentials, "There was an error with your email and/or password"));
             }
             catch

--- a/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/SignUpService.cs
@@ -65,7 +65,7 @@ namespace FRF.Core.Services
                 var result =
                     await _signInManager.PasswordSignInAsync(token, newUser.Password, false, false);
                 return result.Succeeded
-                    ? new ServiceResponse<string>(token.UserID)
+                    ? new ServiceResponse<string>(token.SessionTokens.IdToken)
                     : new ServiceResponse<string>(new Error(ErrorCodes.AuthenticationServerCurrentlyUnavailable, "There was an error with the Authentication service"));
             }
             catch

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Signup.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Signup.tsx
@@ -45,7 +45,7 @@ const UserSignupSchema = yup.object().shape({
 
 const Signup = ({ }) => {
     const history = useHistory();
-    const { storageUser, cleanUserStorage } = useUser();
+    const { storeUser, cleanUserStorage } = useUser();
     const { register, handleSubmit, errors, reset } = useForm<userSignUp>({ resolver: yupResolver(UserSignupSchema) });
     const [loading, setLoading] = React.useState(false);
     const [snackbarSettings, setSnackbarSettings] = React.useState<SnackbarSettings>({ message: "", severity: undefined });
@@ -68,7 +68,7 @@ const Signup = ({ }) => {
             })
             .then(response => {
                 if (response.status === 200) {
-                    storageUser(JSON.stringify(response.data), false);
+                    storeUser(JSON.stringify(response.data), false);
                     history.push("/Home");
                 }
             })

--- a/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
@@ -35,9 +35,7 @@ namespace FRF.Web.Controllers
             if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized();
             if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
 
-            var userProfile = await _userService.GetUserPublicProfileAsync(signInDto.Email);
-            var userPublicProfile = _mapper.Map<UserProfileDTO>(userProfile.Value);
-            return Ok(userPublicProfile);
+            return Ok(response.Value);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
@@ -29,7 +29,7 @@ namespace FRF.Web.Controllers
         {
             var userSignUp = _mapper.Map<User>(signUpDto);
             var response = await _signUpService.SignUpAsync(userSignUp);
-            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized();
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return BadRequest();
             if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
             return Ok(response.Value);
         }

--- a/test/FRF.Core.Tests/Services/SignInServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignInServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.Extensions.CognitoAuthentication;
+﻿using System;
+using Amazon.Extensions.CognitoAuthentication;
 using FRF.Core.Response;
 using FRF.Core.Services;
 using Microsoft.AspNetCore.Identity;
@@ -67,12 +68,13 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task SignInAsync_ReturnTrueAndUserProfile()
+        public async Task SignInAsync_ReturnTrueAndUserToken()
         {
             // Arrange
             var userSignin = CreateUserSignIn();
             var cognitoUser = CreateCognitoUser();
             var signInResult = SignInResult.Success;
+            cognitoUser.SessionTokens = new CognitoUserSession("idToken", "accessToken", "refreshToken", DateTime.Now, DateTime.MaxValue);
 
             _userManagerMock
                 .Setup(mock => mock.FindByEmailAsync(It.IsAny<string>()))
@@ -88,7 +90,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.True(result.Success);
-            Assert.Equal(cognitoUser.UserID, result.Value);
+            Assert.Equal(cognitoUser.SessionTokens.IdToken, result.Value);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 

--- a/test/FRF.Web.Tests/Controllers/SignInControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/SignInControllerTest.cs
@@ -37,43 +37,24 @@ namespace FRF.Web.Tests.Controllers
             };
         }
 
-        private UsersProfile CreateUserProfile(Guid userId)
-        {
-            return new UsersProfile
-            {
-                Email = "mock@email.moq",
-                Fullname = "John Doe",
-                UserId = userId,
-                Avatar = null
-            };
-        }
-
         [Fact]
-        public async Task SignIn_WhenAreValidCredentials_ReturnUserProfile()
+        public async Task SignIn_WhenAreValidCredentials_ReturnUserToken()
         {
             // Arrange
             var signInDto = CreateSignInDto();
-            var userId = Guid.NewGuid();
-            var userProfile = CreateUserProfile(userId);
+            var userSessionToken = "mock.session.token";
 
             _signInService
                 .Setup(mock => mock.SignInAsync(It.IsAny<UserSignIn>()))
-                .ReturnsAsync(new ServiceResponse<string>(userId.ToString()));
-            _userService
-                .Setup(mock => mock.GetUserPublicProfileAsync(signInDto.Email))
-                .ReturnsAsync(new ServiceResponse<UsersProfile>(userProfile));
+                .ReturnsAsync(new ServiceResponse<string>(userSessionToken));
 
             // Act
             var response = await _classUnderTest.SignIn(signInDto);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(response);
-            var resultValue = Assert.IsType<UserProfileDTO>(okResult.Value);
-            Assert.Equal(signInDto.Email, resultValue.Email);
-            Assert.Equal(userProfile.Fullname, resultValue.Fullname);
-            Assert.Equal(userId, resultValue.UserId);
+            Assert.Equal(userSessionToken, okResult.Value);
             _signInService.Verify(mock => mock.SignInAsync(It.IsAny<UserSignIn>()), Times.Once);
-            _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
- Se modificó respuestas de los servicios ***SignIn*** y ***Signup***, ahora retornan el ***ID Token*** del usuario actual.
- Se modificó controller Signin controller para que solo retorne el ***ID Token*** del usuario actual.
- Se modificó HTTP Status code (a 400) de respuesta ante credenciales inválidas al momento de registrar un usuario nuevo.
- Se modificaron Unit Test correspondientes a lo realizado.