### PR TITLE
[FIVE-359] (Back) Modificar formulario creación/modificación de artefactos custom para definir tipos en las settings

### DIFF
--- a/FiveRockingFingers/FRF.Core/Models/CustomArtifact.cs
+++ b/FiveRockingFingers/FRF.Core/Models/CustomArtifact.cs
@@ -1,7 +1,23 @@
-﻿namespace FRF.Core.Models
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace FRF.Core.Models
 {
     public class CustomArtifact : Artifact
     {
+        public CustomArtifact(XElement settings)
+        {
+            Settings = settings;
+
+            RelationalFields = new Dictionary<string, string>();
+            foreach (XElement xe in Settings.Elements())
+            {
+                if (xe.Attribute("type") != null)
+                {
+                    RelationalFields.Add(xe.Name.ToString(), xe.Attribute("type").Value.ToString());
+                }
+            }
+        }
         public override decimal GetPrice()
         {
             if (Settings.Element("price") != null)

--- a/FiveRockingFingers/FRF.Core/SettingTypes.cs
+++ b/FiveRockingFingers/FRF.Core/SettingTypes.cs
@@ -4,5 +4,19 @@
     {
         public const string Decimal = "decimal";
         public const string NaturalNumber = "naturalNumber";
+
+        public static bool IsDecimal(string num)
+        {
+            decimal parsedNumber;
+            if(decimal.TryParse(num, out parsedNumber)) return true;
+            return false;
+        }
+
+        public static bool IsNaturalNumber(string num)
+        {
+            int parsedNumber;
+            if (int.TryParse(num, out parsedNumber) && parsedNumber >= 0) return true;
+            return false;
+        }
     }
 }

--- a/test/FRF.Core.Tests/Models/CustomArtifactTests.cs
+++ b/test/FRF.Core.Tests/Models/CustomArtifactTests.cs
@@ -1,4 +1,5 @@
 ﻿using FRF.Core.Models;
+using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
@@ -6,19 +7,13 @@ namespace FRF.Core.Tests.Models
 {
     public class CustomArtifactTests
     {
-        private readonly CustomArtifact _classUnderTest;
-
-        public CustomArtifactTests()
-        {
-            _classUnderTest = new CustomArtifact();
-        }
-
         [Fact]
         public void GetPrice_priceNodeExists_ReturnsPrice()
         {
             // Arrange
             var price = 70;
-            _classUnderTest.Settings = XElement.Parse($"<settings><price>{price}</price></settings>");
+            var settings = XElement.Parse($"<settings><price>{price}</price></settings>");
+            var _classUnderTest = new CustomArtifact(settings);
 
             // Act
             var result = _classUnderTest.GetPrice();
@@ -31,13 +26,36 @@ namespace FRF.Core.Tests.Models
         public void GetPrice_priceNodeNotExists_Returns0()
         {
             // Arrange
-            _classUnderTest.Settings = XElement.Parse("<settings></settings>");
+            var settings = XElement.Parse("<settings></settings>");
+            var _classUnderTest = new CustomArtifact(settings);
 
             // Act
             var result = _classUnderTest.GetPrice();
 
             // Assert
             Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void RelationalFieldsGeneratedCorrectly()
+        {
+            // Arrange
+            XElement settings = new XElement("settings",
+                    new XElement("settingName1", 100, new XAttribute("type", SettingTypes.Decimal)),
+                    new XElement("settingName2", 200, new XAttribute("type", SettingTypes.NaturalNumber)),
+                    new XElement("settingName3", 300, new XAttribute("type", SettingTypes.Decimal)));
+
+            // Act
+            var _classUnderTest = new CustomArtifact(settings);
+
+            // Assert
+            var settingsList = settings.Elements().ToList();
+
+            Assert.Equal(settingsList.Count, _classUnderTest.RelationalFields.Count);
+            foreach(var setting in settingsList)
+            {
+                Assert.Equal(setting.Attribute("type").Value.ToString(), _classUnderTest.RelationalFields[setting.Name.ToString()]);
+            }            
         }
     }
 }


### PR DESCRIPTION
## Tarea a realizar
Este ticket tiene dos grandes tareas, una de front y una de back. En cuanto a la tarea referida al back, se pide _"modificar el guardado de los artefactos custom en base de datos, para que al modificarlos o crearlos, dentro del XML se guarde también el tipo que le corresponde a cada una de las settings."_

## Cambios realizados
Previo a este ticket, el guardado de settings de artefactos custom en base de datos se veía de la siguiente manera:
```
<settings>
  <price>0</price>
  <aaa>1</aaa>
  <bbb>2</bbb>
  <ccc>3</ccc>
</settings>
```
Luego del cambio:
```
<settings>
  <price type="decimal">0</price>
  <aaa type="decimal">1</aaa>
  <bbb type="naturalNumber">2</bbb>
  <ccc type="decimal">3</ccc>
</settings>
```
Para mantener consistencia con artefactos AWS, se mantuvo el uso del diccionario _RelationalFields_ con el par clave/valor siendo "nombre de setting"/"tipo de valor" para la creación y modificación de los Custom. A su vez, durante la creación y modificación de los mismos, se realiza una validación de tipos en cada setting, verificando que el valor asignado sea correspondiente con el tipo. En caso de que no, el método entrega un error de tipo `InvalidSettings` 

Además de esto, también se añadió la lógica en el constructor de Artefactos Custom para crear dicho diccionario _RelationalFields_ a partir del XML.