### PR TITLE
[Five-386] Corrección del componente AwsPricingDimension.tsx

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/Constants.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/Constants.tsx
@@ -2,3 +2,17 @@
 
 export const BASE_URL = process.env.REACT_APP_BASE_URL;
 export const PROVIDERS = ['AWS', 'Custom'];
+
+//Amazon EC2 constants
+export const AMAZON_EC2 = 'AmazonEC2';
+export const COMPUTE_INSTACE = 'Compute Instance';
+export const STORAGE = 'Storage';
+export const STORAGE_SNAPSHOTS = 'Storage Snapshots';
+export const SYSTEM_OPERATIONS = 'System Operation';
+export const PROVISIONED_THROUGHPUT = 'Provisioned Throughput';
+export const DATA_TRANSFER_1 = 'Data Transfer 1';
+export const DATA_TRANSFER_2 = 'Data Transfer 2';
+export const DATA_TRANSFER_3 = 'Data Transfer 3';
+
+//Amazon S3 constants
+export const AMAZON_S3 = 'AmazonS3';

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -8,6 +8,7 @@ import KeyValueStringPair from '../../interfaces/KeyValueStringPair';
 import PricingTerm from '../../interfaces/PricingTerm';
 import AwsArtifactService from '../../services/AwsArtifactService';
 import { useSettingsCreator } from './useSettingsCreator';
+import { usePricingDimensionsValidator } from './usePricingDimensionsValidator';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -40,6 +41,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
     const { showNewArtifactDialog, closeNewArtifactDialog, name, awsSettingsList } = props;
 
     const { createPricingTermSettings } = useSettingsCreator();
+    const { areValidPricingDimensions } = usePricingDimensionsValidator();
 
     const [loading, setLoading] = React.useState<Boolean>(true);
     const [awsPricingDimensionList, setPricingDimensionList] = React.useState<PricingTerm[]>([]);
@@ -140,7 +142,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
                         <div className={classes.circularProgress}>
                             <CircularProgress color="inherit" size={30} />
                         </div> :
-                        awsPricingDimensionList.length === 0 ?
+                        props.name !== null && areValidPricingDimensions(props.name, awsPricingDimensionList) ?
                             <Typography gutterBottom>
                                 Lo sentimos, no hay productos según las especificaciones seleccionadas
                             </Typography> :

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -142,7 +142,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
                         <div className={classes.circularProgress}>
                             <CircularProgress color="inherit" size={30} />
                         </div> :
-                        props.name !== null && areValidPricingDimensions(props.name, awsPricingDimensionList) ?
+                        props.name !== null && !areValidPricingDimensions(props.name, awsPricingDimensionList) ?
                             <Typography gutterBottom>
                                 Lo sentimos, no hay productos según las especificaciones seleccionadas
                             </Typography> :
@@ -157,7 +157,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
             </DialogContent>
             <DialogActions>
                 <Button size="small" color="primary" onClick={event => goPrevStep()}>Atrás</Button>
-                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>Siguiente</Button>
+                <Button size="small" color="primary" type="submit" disabled={props.name !== null && !areValidPricingDimensions(props.name, awsPricingDimensionList)} onClick={handleSubmit(handleConfirm)}>Siguiente</Button>
                 <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
             </DialogActions>
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/usePricingDimensionsValidator.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/usePricingDimensionsValidator.ts
@@ -1,0 +1,37 @@
+﻿import PricingTerm from '../../interfaces/PricingTerm';
+
+export const usePricingDimensionsValidator = () => {
+
+	const areValidAmazonEc2PricingDimensions = (awsPricingDimensionList: PricingTerm[]): boolean => {
+		if (awsPricingDimensionList.length === 0) return false;
+		for (let i = 0; i < awsPricingDimensionList.length; i++) {
+			let awsPricingDimension = awsPricingDimensionList[i];
+			if (awsPricingDimension.product === 'Compute Instance')
+				return true;
+		}
+		return false;
+	};
+
+	const areValidAmazonS3PricingDimensions = (awsPricingDimensionList: PricingTerm[]): boolean => {
+		if (awsPricingDimensionList.length === 0) return false;
+		return true;
+	};
+
+	const areValidPricingDimensions = (serviceCode: string, awsPricingDimensionList: PricingTerm[]): boolean => {
+		let validPricingDimensions = false;
+		switch (serviceCode) {
+			case 'AmazonEC2':
+				validPricingDimensions = areValidAmazonEc2PricingDimensions(awsPricingDimensionList);
+				break;
+			case 'AmazonS3':
+				validPricingDimensions = areValidAmazonS3PricingDimensions(awsPricingDimensionList);
+				break;
+		}
+
+		return validPricingDimensions;
+	};
+
+	return {
+		areValidPricingDimensions: areValidPricingDimensions
+	};
+};

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/usePricingDimensionsValidator.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/usePricingDimensionsValidator.ts
@@ -1,4 +1,5 @@
 ﻿import PricingTerm from '../../interfaces/PricingTerm';
+import { AMAZON_EC2, COMPUTE_INSTACE, AMAZON_S3 } from '../../Constants';
 
 export const usePricingDimensionsValidator = () => {
 
@@ -6,7 +7,7 @@ export const usePricingDimensionsValidator = () => {
 		if (awsPricingDimensionList.length === 0) return false;
 		for (let i = 0; i < awsPricingDimensionList.length; i++) {
 			let awsPricingDimension = awsPricingDimensionList[i];
-			if (awsPricingDimension.product === 'Compute Instance')
+			if (awsPricingDimension.product === COMPUTE_INSTACE)
 				return true;
 		}
 		return false;
@@ -20,10 +21,10 @@ export const usePricingDimensionsValidator = () => {
 	const areValidPricingDimensions = (serviceCode: string, awsPricingDimensionList: PricingTerm[]): boolean => {
 		let validPricingDimensions = false;
 		switch (serviceCode) {
-			case 'AmazonEC2':
+			case AMAZON_EC2:
 				validPricingDimensions = areValidAmazonEc2PricingDimensions(awsPricingDimensionList);
 				break;
-			case 'AmazonS3':
+			case AMAZON_S3:
 				validPricingDimensions = areValidAmazonS3PricingDimensions(awsPricingDimensionList);
 				break;
 		}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/useSettingsCreator.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/useSettingsCreator.ts
@@ -1,5 +1,6 @@
 ﻿import PricingTerm from '../../interfaces/PricingTerm';
 import PricingDimension from '../../interfaces/PricingDimension';
+import { AMAZON_EC2, COMPUTE_INSTACE, STORAGE, STORAGE_SNAPSHOTS, SYSTEM_OPERATIONS, PROVISIONED_THROUGHPUT, DATA_TRANSFER_1, DATA_TRANSFER_2, DATA_TRANSFER_3, AMAZON_S3 } from '../../Constants';
 
 export const useSettingsCreator = () => {
 
@@ -11,28 +12,28 @@ export const useSettingsCreator = () => {
 			let settings = {};
 
 			switch (awsPricingDimension.product) {
-				case 'Compute Instance':
+				case COMPUTE_INSTACE:
 					settings = createPricingTermObject('product0', awsPricingDimension);
 					break;
-				case 'Storage':
+				case STORAGE:
 					settings = createPricingTermObject('product1', awsPricingDimension);
 					break;
-				case 'Storage Snapshot':
+				case STORAGE_SNAPSHOTS:
 					settings = createPricingTermObject('product2', awsPricingDimension);
 					break;
-				case 'System Operation':
+				case SYSTEM_OPERATIONS:
 					settings = createPricingTermObject('product3', awsPricingDimension);
 					break;
-				case 'Provisioned Throughput':
+				case PROVISIONED_THROUGHPUT:
 					settings = createPricingTermObject('product4', awsPricingDimension);
 					break;
-				case 'Data Transfer 1':
+				case DATA_TRANSFER_1:
 					settings = createPricingTermObject('product5-1', awsPricingDimension);
 					break;
-				case 'Data Transfer 2':
+				case DATA_TRANSFER_2:
 					settings = createPricingTermObject('product5-2', awsPricingDimension);
 					break;
-				case 'Data Transfer 3':
+				case DATA_TRANSFER_3:
 					settings = createPricingTermObject('product5-3', awsPricingDimension);
 					break;
 			}
@@ -83,10 +84,10 @@ export const useSettingsCreator = () => {
 		let pricingTermSetting = {};
 
 		switch (serviceCode) {
-			case 'AmazonEC2':
+			case AMAZON_EC2:
 				pricingTermSetting = createAmazonEc2Settings(awsPricingDimensionList);
 				break;
-			case 'AmazonS3':
+			case AMAZON_S3:
 				pricingTermSetting = createAmazonS3Settings(awsPricingDimensionList);
 				break;
 		}


### PR DESCRIPTION
Actualmente al momento de seleccionar las settings de un artefacto Amazon EC2 se muestran todos los productos encontrados en la siguiente pantalla aunque no se haya encontrado una instancia EC2 según los requerimientos del usuario. Se muestra en la siguiente imagen un ejemplo en el que se muestra el "_storage_" y el "_storage snapshot_" sin haber una instancia

![image](https://user-images.githubusercontent.com/71278846/112885980-bb39d600-90a7-11eb-9fc0-495fe2845426.png)

En este PR se busca en que caso de no encontrarse una instancia se muestre que no se encontró ningún producto asociado a los requisitos completados por el usuario y que el boton de siguiente se deshabilite.

![image](https://user-images.githubusercontent.com/71278846/112885309-fd164c80-90a6-11eb-800e-a0c441be8dec.png)

**Cambios realizados:**

- Se creó el componente usePricingDimensionsValidator para validar si los pricingDimensions del componente AwsPricingDimension son válidos o no
- Se modificó el componente AwsPricingDimension para que use el componente usePricingDimensionsValidator para verificar si los pricingDimensions encontrados fueron válidos o no
- Se modificó el componente AwsPricingDimension para que el boton de siguiente este anulado en caso de que la no se pase la validación de los "PricingDimensions"
- Se colocaron todos los strings importantes de los componentes usePricingDimensionsValidator y useSettingsCreator dentro de constantes en el componente Constants
