### PR TITLE
[FIVE-387] Modificar los formularios donde se completan el nombre y el tipo de artefactos

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
@@ -16,7 +16,7 @@ import ArtifactType from '../interfaces/ArtifactType';
 const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, projectId: number, updateList: Function, setOpenSnackbar: Function , setSnackbarSettings: Function }) => {
 
     const [step, setStep] = React.useState<number>(1);
-    const [artifactTypeId, setArtifactTypeId] = React.useState<number | null>(null);
+    const [artifactType, setArtifactType] = React.useState<ArtifactType | null>(null);
     const [name, setName] = React.useState<string | null>("");
     const [provider, setProvider] = React.useState<string | null>("");
     const [settingsList, setSettingsList] = React.useState<Setting[]>([{ name: "", value: "" }]);
@@ -38,7 +38,7 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
 
     const handleCancel = () => {
         setStep(1);
-        setArtifactTypeId(null);
+        setArtifactType(null);
         setName(null);
         setProvider(null);
         setSettingsList([{ name: "", value: "" }]);
@@ -84,9 +84,9 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
                         handleNextStep={handleNextStep}
                         handlePreviousStep={handlePreviousStep}
                         setName={setName}
-                        setArtifactTypeId={setArtifactTypeId}
+                        setArtifactType={setArtifactType}
                         name={name}
-                        artifactTypeId={artifactTypeId}
+                        artifactType={artifactType}
                         getArtifactTypes={getArtifactTypes}
                     />
                 );
@@ -94,10 +94,11 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
             else {
                 return (
                     <AwsForm
+                        name={name}
                         showNewArtifactDialog={props.showNewArtifactDialog}
                         closeNewArtifactDialog={handleCancel}
                         projectId={props.projectId}
-                        setArtifactTypeId={setArtifactTypeId}
+                        setArtifactType={setArtifactType}
                         updateList={props.updateList}
                         handleNextStep={handleNextStep}
                         handlePreviousStep={handlePreviousStep}
@@ -132,7 +133,7 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
                     <SettingsAwsForm
                         showNewArtifactDialog={props.showNewArtifactDialog}
                         closeNewArtifactDialog={handleCancel}
-                        name={name}
+                        artifactType={artifactType}
                         updateList={props.updateList}
                         handleNextStep={handleNextStep}
                         handlePreviousStep={handlePreviousStep}
@@ -150,7 +151,7 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
                     <AwsPricingDimension
                         showNewArtifactDialog={props.showNewArtifactDialog}
                         closeNewArtifactDialog={handleCancel}
-                        name={name}
+                        artifactType={artifactType}
                         handleNextStep={handleNextStep}
                         handlePreviousStep={handlePreviousStep}
                         settingsList={settingsList}
@@ -174,7 +175,7 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
                         provider={provider}
                         name={name}
                         projectId={props.projectId}
-                        artifactTypeId={artifactTypeId}
+                        artifactType={artifactType}
                         updateList={props.updateList}
                         setOpenSnackbar={props.setOpenSnackbar}
                         setSnackbarSettings={props.setSnackbarSettings}
@@ -195,7 +196,7 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
                         provider={provider}
                         name={name}
                         projectId={props.projectId}
-                        artifactTypeId={artifactTypeId}
+                        artifactType={artifactType}
                         updateList={props.updateList}
                         setOpenSnackbar={props.setOpenSnackbar}
                         setSnackbarSettings={props.setSnackbarSettings}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsForm.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsForm.tsx
@@ -3,13 +3,15 @@ import Typography from '@material-ui/core/Typography';
 import Autocomplete from '@material-ui/lab/Autocomplete/Autocomplete';
 import * as React from 'react';
 import ArtifactType from '../../interfaces/ArtifactType';
+import { Controller, useForm } from 'react-hook-form';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
       flexWrap: 'wrap',
-    }, autoComplete: {
+    },
+    autoComplete: {
       padding: 2,
       marginTop: 10,
       width: 350
@@ -19,17 +21,23 @@ const useStyles = makeStyles((theme: Theme) =>
       width: '90%',
       display: 'flex',
       alignItems: 'center'
-    }
+      },
+      inputF: {
+          padding: 2,
+          margin: 'auto',
+          width: 350
+      }
   }),
 );
 
-const AwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, projectId: number, updateList: Function, setArtifactTypeId: Function, handleNextStep: Function, handlePreviousStep: Function, setName: Function, getArtifactTypes: Function }) => {
+const AwsForm = (props: { name: string | null, showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, projectId: number, updateList: Function, setArtifactType: Function, handleNextStep: Function, handlePreviousStep: Function, setName: Function, getArtifactTypes: Function }) => {
     const classes = useStyles();
     const [formError, setFormError] = React.useState(false);
     const [selectedArtifactType, setSelectedArtifactType] = React.useState<ArtifactType | null>(null);
     const [inputSelectedArtifactType, setInputSelectedArtifactType] = React.useState("");
     const [artifactTypes, setArtifactTypes] = React.useState([] as ArtifactType[]);
     const { showNewArtifactDialog, closeNewArtifactDialog } = props;
+    const { handleSubmit, register, control, errors } = useForm();
 
     React.useEffect(() => {
         (async () => {
@@ -39,14 +47,13 @@ const AwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog
     }, [])
 
     //Create the artifact after submit
-    const handleConfirm = async () => {
+    const handleConfirm = async (data: { artifactType: object, name: string }) => {
         if (selectedArtifactType === null) {
             setFormError(true);
             return;
         }
-        props.setArtifactTypeId(selectedArtifactType.id);
-        const name = selectedArtifactType.name;
-        props.setName(name);
+        props.setArtifactType(selectedArtifactType);
+        props.setName(data.name);
         props.handleNextStep();
     }
 
@@ -101,12 +108,25 @@ const AwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog
                     />
                 <FormHelperText error={formError}>Requerido*</FormHelperText>
             </FormControl>
-
+            <FormControl className={classes.formControl} >
+                <TextField
+                    inputRef={register({ required: true, validate: { isValid: value => value.trim() != "" } })}
+                    error={errors.name ? true : false}
+                    id="name"
+                    name="name"
+                    label="Nombre del artefacto"
+                    variant="outlined"
+                    className={classes.inputF}
+                    fullWidth
+                    defaultValue={props.name}
+                />          
+                <FormHelperText error={formError}>Requerido*</FormHelperText>
+            </FormControl>            
             <DialogActions>
                 <Button size="small" color="primary" onClick={handlePreviousStep}>
                     Atrás
                 </Button>
-                <Button size="small" color="primary" type="submit" onClick={handleConfirm}>
+                <Button size="small" color="primary" type="submit" onClick={handleSubmit(handleConfirm)}>
                     Siguiente
                 </Button>
                 <Button size="small" color="secondary" onClick={handleCancel}>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -8,6 +8,7 @@ import KeyValueStringPair from '../../interfaces/KeyValueStringPair';
 import PricingTerm from '../../interfaces/PricingTerm';
 import AwsArtifactService from '../../services/AwsArtifactService';
 import { useSettingsCreator } from './useSettingsCreator';
+import ArtifactType from '../../interfaces/ArtifactType';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -33,11 +34,11 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, name: string | null, handleNextStep: Function, handlePreviousStep: Function, settingsList: Setting[], setSettingsList: Function, settingsMap: { [key: string]: number[] }, setSettingsMap: Function, awsSettingsList: KeyValueStringPair[], settings: object, setSettings: Function, setAwsPricingTerm: Function, setSnackbarSettings: Function, setOpenSnackbar: Function }) => {
+const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, artifactType: ArtifactType | null, handleNextStep: Function, handlePreviousStep: Function, settingsList: Setting[], setSettingsList: Function, settingsMap: { [key: string]: number[] }, setSettingsMap: Function, awsSettingsList: KeyValueStringPair[], settings: object, setSettings: Function, setAwsPricingTerm: Function, setSnackbarSettings: Function, setOpenSnackbar: Function }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();
-    const { showNewArtifactDialog, closeNewArtifactDialog, name, awsSettingsList } = props;
+    const { showNewArtifactDialog, closeNewArtifactDialog, artifactType, awsSettingsList } = props;
 
     const { createPricingTermSettings } = useSettingsCreator();
 
@@ -46,31 +47,36 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
 
     React.useEffect(() => {
         getPricingDimensions();
-    }, [name, awsSettingsList]);
+    }, [artifactType, awsSettingsList]);
 
     const getPricingDimensions = async () => {
-        if (name) {
-            let statusOk = 200;
-            try {
+        let statusOk = 200;
+        try {
+            if (artifactType !== null) {
                 setLoading(true);
-                const response = await AwsArtifactService.GetProductsAsync(name, awsSettingsList);
+                const response = await AwsArtifactService.GetProductsAsync(artifactType.name, awsSettingsList);
                 if (response.status === statusOk) {
                     setPricingDimensionList(response.data);
                     setLoading(false);
                 }
             }
-            catch (error) {
-                props.setSnackbarSettings({ message: "Fuera de servicio. Por favor intente mas tarde.", severity: "error" });
+            else {
+                props.setSnackbarSettings({ message: "Ha ocurrido un error al cargar el tipo de artefacto", severity: "error" });
                 props.setOpenSnackbar(true);
                 closeNewArtifactDialog();
             }
+        }
+        catch (error) {
+            props.setSnackbarSettings({ message: "Fuera de servicio. Por favor intente mas tarde.", severity: "error" });
+            props.setOpenSnackbar(true);
+            closeNewArtifactDialog();
         }
     }
 
     //Create the artifact after submit
     const handleConfirm = async () => {
-        if (!props.name) return;
-        props.setSettings({ settings: createSettings(props.name) });
+        if (artifactType === null) return;
+        props.setSettings({ settings: createSettings(artifactType.name) });
         props.handleNextStep();
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/AwsPricingDimension.tsx
@@ -148,7 +148,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
                         <div className={classes.circularProgress}>
                             <CircularProgress color="inherit" size={30} />
                         </div> :
-                        props.name !== null && !areValidPricingDimensions(props.name, awsPricingDimensionList) ?
+                        artifactType !== null && !areValidPricingDimensions(artifactType.name, awsPricingDimensionList) ?
                             <Typography gutterBottom>
                                 Lo sentimos, no hay productos según las especificaciones seleccionadas
                             </Typography> :
@@ -163,7 +163,7 @@ const AwsPricingDimension = (props: { showNewArtifactDialog: boolean, closeNewAr
             </DialogContent>
             <DialogActions>
                 <Button size="small" color="primary" onClick={event => goPrevStep()}>Atrás</Button>
-                <Button size="small" color="primary" type="submit" disabled={props.name !== null && !areValidPricingDimensions(props.name, awsPricingDimensionList)} onClick={handleSubmit(handleConfirm)}>Siguiente</Button>
+                <Button size="small" color="primary" type="submit" disabled={artifactType !== null && !areValidPricingDimensions(artifactType.name, awsPricingDimensionList)} onClick={handleSubmit(handleConfirm)}>Siguiente</Button>
                 <Button size="small" color="secondary" onClick={handleCancel}>Cancelar</Button>
             </DialogActions>
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, provider: string | null, name: string | null, projectId: number, artifactTypeId: number | null, setOpenSnackbar: Function, setSnackbarSettings: Function, handlePreviousStep: Function, settingsList: Setting[], settings: object, updateList: Function, awsPricingTerm: PricingTerm | null }) => {
+const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, provider: string | null, name: string | null, projectId: number, artifactType: ArtifactType | null, setOpenSnackbar: Function, setSnackbarSettings: Function, handlePreviousStep: Function, settingsList: Setting[], settings: object, updateList: Function, awsPricingTerm: PricingTerm | null, settingTypes: { [key: string]: string } }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import Setting from '../../interfaces/Setting';
 import PricingTerm from '../../interfaces/PricingTerm';
 import ArtifactService from '../../services/ArtifactService';
+import ArtifactType from '../../interfaces/ArtifactType';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -19,18 +20,18 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, provider: string | null, name: string | null, projectId: number, artifactTypeId: number | null, setOpenSnackbar: Function, setSnackbarSettings: Function, handlePreviousStep: Function, settingsList: Setting[], settings: object, updateList: Function, awsPricingTerm: PricingTerm | null }) => {
+const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, provider: string | null, name: string | null, projectId: number, artifactType: ArtifactType | null, setOpenSnackbar: Function, setSnackbarSettings: Function, handlePreviousStep: Function, settingsList: Setting[], settings: object, updateList: Function, awsPricingTerm: PricingTerm | null }) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();
-    const { showNewArtifactDialog, closeNewArtifactDialog, provider, name, projectId, artifactTypeId, setOpenSnackbar, setSnackbarSettings, settingsList, updateList } = props;
+    const { showNewArtifactDialog, closeNewArtifactDialog, provider, name, projectId, artifactType, setOpenSnackbar, setSnackbarSettings, settingsList, updateList } = props;
 
     //Create the artifact after submit
     const handleConfirm = async () => {
         const artifactToCreate = {
             name: name,
             provider: provider,
-            artifactTypeId: artifactTypeId,
+            artifactTypeId: artifactType?.id,
             projectId: projectId,
             settings: props.settings
         };

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/CustomForm.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/CustomForm.tsx
@@ -2,7 +2,7 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import * as React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import ArtifactType from '../../interfaces/ArtifactType';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -22,32 +22,32 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const CustomForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, handleNextStep: Function, handlePreviousStep: Function, setName: Function, setArtifactTypeId: Function, name: string | null, artifactTypeId: number | null, getArtifactTypes: Function }) => {
+const CustomForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, handleNextStep: Function, handlePreviousStep: Function, setName: Function, setArtifactType: Function, name: string | null, artifactType: ArtifactType | null, getArtifactTypes: Function }) => {
 
     const classes = useStyles();
 
-    const { register, handleSubmit, errors, control, getValues } = useForm();
+    const { register, handleSubmit, errors, getValues } = useForm();
     const { showNewArtifactDialog, closeNewArtifactDialog } = props;
 
-    const [artifactTypes, setArtifactTypes] = React.useState([] as ArtifactType[]);
+    const [artifactType, setArtifactType] = React.useState<ArtifactType | null>(null);
 
     React.useEffect(() => {
         (async () => {
-            let artifactTypes = await props.getArtifactTypes(1);
-            setArtifactTypes(artifactTypes);
+            let artifactTypeAux = await props.getArtifactTypes(1);
+            setArtifactType(artifactTypeAux[0]);
         })();
     }, [])
 
-    const handleConfirm = async (data: { name: string, artifactType: string }) => {
+    const handleConfirm = async (data: { name: string }) => {
         props.setName(data.name);
-        props.setArtifactTypeId(data.artifactType);
+        props.setArtifactType(artifactType);
         props.handleNextStep();
     }
 
     const handlePreviousStep = () => {
         let data = getValues();
         props.setName(data.name);
-        props.setArtifactTypeId(data.artifactType);
+        props.setArtifactType(artifactType);
         props.handlePreviousStep();
     }
 
@@ -63,29 +63,6 @@ const CustomForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDia
                     A continuación ingrese el tipo y el nombre de su nuevo artefacto custom
                 </Typography>
                 <form className={classes.container}>
-                    <FormControl className={classes.formControl} error={Boolean(errors.artifactType)}>
-                        <InputLabel htmlFor="type-select">Tipo de artefacto</InputLabel>
-                        <Controller
-                            as={
-                                <Select
-                                    inputProps={{
-                                        name: 'artifactType',
-                                        id: 'type-select'
-                                    }}
-                                >
-                                    <MenuItem value="">
-                                        <em>None</em>
-                                    </MenuItem>
-                                    {artifactTypes.map(at => <MenuItem key={at.id} value={at.id}>{at.name}</MenuItem>)}
-                                </Select>
-                            }
-                            name="artifactType"
-                            rules={{ required: true }}
-                            control={control}
-                            defaultValue={props.artifactTypeId}
-                        />
-                        <FormHelperText>Requerido*</FormHelperText>
-                    </FormControl>
                     <TextField
                         inputRef={register({ required: true, validate: { isValid: value => value.trim() != "" } })}
                         error={errors.name ? true : false}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/SettingsAwsForm.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/SettingsAwsForm.tsx
@@ -6,6 +6,7 @@ import KeyValueStringPair from '../../interfaces/KeyValueStringPair';
 import AwsArtifactService from '../../services/AwsArtifactService';
 import { withTheme } from "@rjsf/core";
 import { Theme as MaterialUITheme } from "@rjsf/material-ui";
+import ArtifactType from '../../interfaces/ArtifactType';
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -32,11 +33,11 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-const SettingsAwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, name: string | null, updateList: Function, handleNextStep: Function, handlePreviousStep: Function, setAwsSettingsList: Function, setSettingsList: Function, setSnackbarSettings: Function, setOpenSnackbar: Function }) => {
+const SettingsAwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, artifactType: ArtifactType | null, updateList: Function, handleNextStep: Function, handlePreviousStep: Function, setAwsSettingsList: Function, setSettingsList: Function, setSnackbarSettings: Function, setOpenSnackbar: Function }) => {
 
     const classes = useStyles();
     const Form = withTheme(MaterialUITheme);
-    const { showNewArtifactDialog, closeNewArtifactDialog, name } = props;
+    const { showNewArtifactDialog, closeNewArtifactDialog, artifactType } = props;
 
     //Hook for save the user's settings input
     const [loading, setLoading] = React.useState<Boolean>(true);
@@ -45,24 +46,29 @@ const SettingsAwsForm = (props: { showNewArtifactDialog: boolean, closeNewArtifa
 
     React.useEffect(() => {
         getRequireFields();
-    }, [name]);
+    }, [artifactType]);
 
     const getRequireFields = async () => {
-        if (name) {
-            let statusOk = 200;
-            try {
+        let statusOk = 200;
+        try {            
+            if (artifactType !== null) {
                 setLoading(true);
-                const response = await AwsArtifactService.GetRequiredFieldsAsync(name);
+                const response = await AwsArtifactService.GetRequiredFieldsAsync(artifactType?.name);
                 if (response.status === statusOk) {
                     setSchema(response.data);
                     setLoading(false);
                 }
             }
-            catch (error) {
-                props.setSnackbarSettings({ message: "Fuera de servicio. Por favor intente mas tarde.", severity: "error" });
+            else {
+                props.setSnackbarSettings({ message: "Ha ocurrido un error al cargar el tipo de artefacto", severity: "error" });
                 props.setOpenSnackbar(true);
                 closeNewArtifactDialog();
-            }           
+            }
+        }
+        catch (error) {
+            props.setSnackbarSettings({ message: "Fuera de servicio. Por favor intente mas tarde.", severity: "error" });
+            props.setOpenSnackbar(true);
+            closeNewArtifactDialog();
         }
     }
 


### PR DESCRIPTION
Actualmente al momento de crear un artefacto de AWS, como se nombre se guarda el tipo de artefacto. Es decir que si se elige crear un artefacto AmazonS3 el nombre con el que se guardará será AmazonS3. En la siguiente imagen se muestra una captura del formulario actualmente.

![image](https://user-images.githubusercontent.com/71278846/113172846-3671c800-921f-11eb-9e43-91a03ac191ca.png)


En este PR se busca modificar el formulario de creación de artefactos de AWS para permitir completar el nombre de los artefactos de AWS con un valor elegido por el usuario. A continuación se muestra como quedaría este formulario

![image](https://user-images.githubusercontent.com/71278846/113171925-55238f00-921e-11eb-8938-da096c106dec.png)


Al mismo tiempo de modificó el formulario de creación de artefactos Custom para que no permita seleccionar el tipo de artefacto ya que será siempre Custom.

Formulario de artefactos Custom anterior:

![image](https://user-images.githubusercontent.com/71278846/113172763-1f32da80-921f-11eb-80a1-88ecc77eb4f1.png)

Formulario de artefactos Custom nuevo:

![image](https://user-images.githubusercontent.com/71278846/113172121-82703d00-921e-11eb-98f5-9bd8dfa6a990.png)

**Cambios realizados:**

- Se modificó el formulario NewArtifactDialog para que guarde el artifactType seleccionado y no solamente el artifactTypeId ya que se necesita el nombre del artifactType en el resto de las pantallas del wizard para la creación de artefactos
- Se modificó el formulario AwsForm para agregar un campo que permita agregarle un nombre al artefacto
- Se modificó el formulario CustomForm para que no permita seleccionar el tipo de artefacto ya que siempre será "Custom"
- Se modificarons los componentes AwsPricingDimension, SettingsAwsForm y Confirmation para que trabajen con el artifactType y no el artifactTypeId
