### PR TITLE
[FIVE-388] Modificar símbolos especiales aceptados en password

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, Checkbox, FormControlLabel, Paper, TextField } from "@material-ui/core";
+import { Button, Checkbox, FormControlLabel, Paper, TextField, Tooltip, Typography } from "@material-ui/core";
 import axios from "axios";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -27,9 +27,12 @@ const UserLoginSchema = yup.object().shape({
         .required('Requerido.').email('Debe ser un email valido.'),
     password: yup.string()
         .trim()
-        .min(8, 'Debe tener al menos 8 caracteres.')
-        .matches(/^(?=.*\d)(?=.*[a-z])(?=.*[@#$%^&+=.\-_*])(?=.*[A-Z]).{8,}$/, 'Debe incluir al menos un numero, un caracter en mayuscula y un simbolo.')
-        .required('Requerido.'),
+        .required('Requerido.')
+        .matches(/(?=.*[@#$%^&+=.\-_*])/, 'Debe incluir al menos un simbolo distinto de + o =')
+        .test("hasPlusOrEqual","No puede incluir los simbolos + o =",(password)=> !/(\+|=)/.test(password!))
+        .test("hasAnyNumber","Debe incluir al menos un numero.",(password)=> /(?=.*\d)/.test(password!))
+        .test("hasAnyUppercase","Debe incluir al menos un caracter en mayuscula.",(password)=> /(?=.*[A-Z])/.test(password!))
+        .test("hasMinLenght",'Debe tener al menos 8 caracteres.',(password)=> /(.{8,}$)/.test(password!))
 });
 
 const Login = () => {
@@ -97,6 +100,9 @@ const Login = () => {
                 <FormGroup className="campo-form">
                     <Label for="password" md={4}>Password</Label>
                     <Col sm={9}>
+                    <Tooltip title={
+                    <Typography variant="body2">Debe tener al menos 8 caracteres, un numero, un caracter en mayuscula y un simbolo distinto de + o =
+                    </Typography>} placement="right" arrow>
                         <TextField
                             inputRef={register}
                             type="password"
@@ -104,6 +110,7 @@ const Login = () => {
                             size="small"
                             error={!!errors.password}
                             helperText={errors.password ? errors.password.message : ''} />
+                    </Tooltip>
                     </Col>
                 </FormGroup>
                 <FormControlLabel className="alinea-centro"

--- a/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/SignUpServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Extensions.CognitoAuthentication;
@@ -130,13 +131,14 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
-        public async Task SignUpAsync_ReturnTrue()
+        public async Task SignUpAsync_ReturnTrueAndUserToken()
         {
             // Arrange
             var newUser = CreateUser();
             var cognitoUser = CreateCognitoUser();
             var userSignin = CreateUserSignIn();
             var signInResult = SignInResult.Success;
+            cognitoUser.SessionTokens = new CognitoUserSession("idToken", "accessToken", "refreshToken", DateTime.Now, DateTime.MaxValue);
 
             _userManagerMock
                 .Setup(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()))
@@ -166,7 +168,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.IsType<ServiceResponse<string>>(result);
             Assert.True(result.Success);
-            Assert.Equal(cognitoUser.UserID, result.Value);
+            Assert.Equal(cognitoUser.SessionTokens.IdToken, result.Value);
 
             _userManagerMock.Verify(mock => mock.FindByEmailAsync(It.IsAny<string>()), Times.Once);
 


### PR DESCRIPTION
### Descripción:
Se detectó que el servicio de AWS Cognito, no acepta los siguientes símbolos especiales: `+` y `=`.
#### Password: ***Foobar123=***
![nonalphanumeric2](https://user-images.githubusercontent.com/71275081/113187655-7a6cc900-922f-11eb-9cf8-7d3ce135ed6c.png)
#### Password: ***Foobar123+***
![nonalphanumeric1](https://user-images.githubusercontent.com/71275081/113187656-7b055f80-922f-11eb-8a5c-03d373295e63.png)

### Realizado:
- Se modificó y agrego validación de password en los componentes Signup y Login.
- Se modificó modo de operación en hook useForm, se pasó de modo onSubmit a onChange.
- Se corrigió Unit test SignUpServiceTest -> SignUpAsync_ReturnTrueAndUserToken.