### PR TITLE
[FIVE-343] (BackEnd) Crear control de tipo en el valor de las settings y relaciones

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -152,17 +152,10 @@ namespace FRF.Core.Services
                 .Any(a => a.Artifact1Id != baseArtifactId && a.Artifact2Id != baseArtifactId);
         }
 
-        private async Task<bool> IsAnyArtifactFromAnotherProject(int baseArtifactId, IList<ArtifactsRelation> artifactsRelations)
+        private bool AreAllArtifactFromTheSameProject(IList<Artifact> artifacts)
         {
-            var baseProjectId = _dataContext.Artifacts.First(a => a.Id == baseArtifactId).ProjectId;
-            var artifactsIdsFromBaseProject =await _dataContext.Artifacts
-                .Where(a => a.ProjectId == baseProjectId).Select(a => a.Id).ToListAsync();
-            
-            var artifactsRelationIds = artifactsRelations
-                .Select(ar => ar.Artifact1Id)
-                .Concat(artifactsRelations.Select(ar => ar.Artifact2Id));
-
-            return artifactsRelationIds.Except(artifactsIdsFromBaseProject).Any();
+            var projectId = artifacts.First().ProjectId;
+            return artifacts.All(art => art.ProjectId == projectId);
         }
 
         public async Task<ServiceResponse<List<Artifact>>> GetAll()
@@ -403,11 +396,11 @@ namespace FRF.Core.Services
             if (!artifactResponse.Success)
                 return new ServiceResponse<IList<ArtifactsRelation>>(artifactResponse.Error);
 
-            var artifactsExist = await DoArtifactsExist(artifactRelations);
-            if (artifactsExist) return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.ArtifactNotExists, "At least one of the artifact Ids provided doesn't exist"));
+            var artifactsInNewRelations = await GetAllArtifactsInRelations(artifactRelations);
+            if (!artifactsInNewRelations.Success) return new ServiceResponse<IList<ArtifactsRelation>>(artifactsInNewRelations.Error);
 
-            var isAnyArtifactFromAnotherProject =await IsAnyArtifactFromAnotherProject(artifactId, artifactRelations);
-            if (isAnyArtifactFromAnotherProject)
+            var areAllArtifactFromTheSameProject = AreAllArtifactFromTheSameProject(artifactsInNewRelations.Value);
+            if (!areAllArtifactFromTheSameProject)
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.ArtifactFromAnotherProject,
                     "At least one of the artifact provided is from another project. "));
 
@@ -421,7 +414,7 @@ namespace FRF.Core.Services
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the artifact relation provided is repeat"));
 
-            var areNewRelationTypesValid = await AreRelationTypesValid(artifactRelations);
+            var areNewRelationTypesValid = AreRelationTypesValid(artifactRelations, artifactsInNewRelations.Value);
             if (!areNewRelationTypesValid)
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the relations has different types"));
@@ -569,10 +562,9 @@ namespace FRF.Core.Services
             if (!artifactResponse.Success)
                 return new ServiceResponse<IList<ArtifactsRelation>>(artifactResponse.Error);
 
-            var artifactsExist = await DoArtifactsExist(artifactsRelationsNew);
-            if (artifactsExist)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.ArtifactNotExists,
-                    "At least one of the artifact Ids provided doesn't exist"));
+            var artifactsInNewRelations = await GetAllArtifactsInRelations(artifactsRelationsNew);
+            if (!artifactsInNewRelations.Success)
+                return new ServiceResponse<IList<ArtifactsRelation>>(artifactsInNewRelations.Error);
 
             var existProjectId = await _dataContext.Projects.AnyAsync(p => p.Id == artifactResponse.Value.ProjectId);
             if (!existProjectId)
@@ -582,8 +574,6 @@ namespace FRF.Core.Services
 
             var artifactsRelations = await _dataContext.ArtifactsRelation
                 .Where(ar => ar.Artifact1.ProjectId == artifactResponse.Value.ProjectId || ar.Artifact2.ProjectId == artifactResponse.Value.ProjectId)
-                .Include(ar => ar.Artifact1)
-                .Include(ar => ar.Artifact2)
                 .ToListAsync();
 
             var relationsOriginal = artifactsRelations
@@ -592,7 +582,6 @@ namespace FRF.Core.Services
 
             var relationInNewListRepeated = IsAnyRelationRepeated(artifactsRelationsNew);
             if (relationInNewListRepeated)
-
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the artifact relation provided is repeat"));
 
@@ -601,7 +590,7 @@ namespace FRF.Core.Services
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the artifact relation provided already exist"));
 
-            var areNewRelationTypesValid = await AreRelationTypesValid(artifactsRelationsNew);
+            var areNewRelationTypesValid = AreRelationTypesValid(artifactsRelationsNew, artifactsInNewRelations.Value);
             if (!areNewRelationTypesValid)
                 return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
                     "At least one of the relations has different types"));
@@ -1071,10 +1060,8 @@ namespace FRF.Core.Services
             return true;
         }
 
-        private async Task<bool> AreRelationTypesValid(IList<ArtifactsRelation> relations)
+        private bool AreRelationTypesValid(IList<ArtifactsRelation> relations, IList<Artifact> artifacts)
         {
-            var artifacts = await GetAllArtifactsInRelations(relations);
-
             foreach (ArtifactsRelation relation in relations)
             {
                 var typeSetting1 = artifacts.Single(art => art.Id == relation.Artifact1Id).RelationalFields[relation.Artifact1Property];
@@ -1085,7 +1072,7 @@ namespace FRF.Core.Services
             return true;
         }
 
-        private async Task<List<Artifact>> GetAllArtifactsInRelations(IList<ArtifactsRelation> relations)
+        private async Task<ServiceResponse<List<Artifact>>> GetAllArtifactsInRelations(IList<ArtifactsRelation> relations)
         {
             List<int> Ids = new List<int>();
             foreach (ArtifactsRelation relation in relations)
@@ -1103,9 +1090,13 @@ namespace FRF.Core.Services
                 .Where(a => Ids.Contains(a.Id))
                 .ToListAsync();
 
-            var mappedArtifacts = MapArtifacts(artifacts);
+            if (artifacts.Count < Ids.Count)
+            {
+                return new ServiceResponse<List<Artifact>>(new Error(ErrorCodes.ArtifactNotExists, "At least one of the artifact Ids provided doesn't exist"));
+            }
 
-            return mappedArtifacts;
+            var mappedArtifacts = MapArtifacts(artifacts);
+            return new ServiceResponse<List<Artifact>>(mappedArtifacts);
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/Constants.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/Constants.tsx
@@ -1,8 +1,11 @@
 ﻿// Constants definitions for access on ClientApp
 
 export const BASE_URL = process.env.REACT_APP_BASE_URL;
-export const PROVIDERS = ['AWS', 'Custom'];
 export const SETTINGTYPES = ['decimal', 'naturalNumber'];
+
+export const CUSTOM_PROVIDER = 'Custom';
+export const AWS_PROVIDER = 'AWS';
+export const PROVIDERS = [AWS_PROVIDER, CUSTOM_PROVIDER];
 
 //Amazon EC2 constants
 export const AMAZON_EC2 = 'AmazonEC2';

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/HelperArtifactRelation.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/HelperArtifactRelation.ts
@@ -1,0 +1,111 @@
+﻿import { PROVIDERS } from "../../Constants";
+import Artifact from "../../interfaces/Artifact";
+import KeyValueStringPair from "../../interfaces/KeyValueStringPair";
+
+export function updateArtifactsSettings(
+    artifact1: Artifact | null,
+    artifact2: Artifact | null,
+    setArtifact1Settings: Function,
+    setArtifact2Settings: Function
+) {
+    if (artifact1 !== null && artifact1 !== undefined) {
+        if (artifact1.artifactType?.name != PROVIDERS[1]) {
+            var relationalSettings: { [key: string]: string } = {};
+            Object.entries(artifact1.relationalFields).map(([key, value]) => relationalSettings[key] = artifact1.settings[key]);
+            setArtifact1Settings(relationalSettings);
+        } else {
+            setArtifact1Settings(artifact1.settings);
+        }
+    }
+    else {
+        setArtifact1Settings({});
+    }
+    if (artifact2 !== null && artifact2 !== undefined) {
+        if (artifact2.artifactType?.name != PROVIDERS[1]) {
+            var relationalSettings: { [key: string]: string } = {};
+            Object.entries(artifact2.relationalFields).map(([key, value]) => relationalSettings[key] = artifact2.settings[key]);
+            setArtifact2Settings(relationalSettings);
+        } else {
+            setArtifact2Settings(artifact2.settings);
+        }
+    }
+    else {
+        setArtifact2Settings({});
+    }
+}
+
+export function toRegularSentence(
+    value: string
+) {
+    if (!value || value.length === 0) return "";
+
+    const result = value.replace(/([A-Z])/g, ' $1');
+    if (/[a-z]/.test(result.charAt(0))) {
+        return `${result.charAt(0).toUpperCase()}${result.slice(1)}`;
+    } else {
+        return result;
+    }
+}
+
+export function handleArtifactChange(
+    event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>,
+    setSetting1: Function,
+    setArtifact1: Function,
+    setSetting2: Function,
+    setArtifact2: Function,
+    artifacts: Artifact[]
+) {
+    if (event.target.name === 'artifact1') {
+        setSetting1(null);
+        event.target.value === '' ?
+            setArtifact1(null)
+            :
+            setArtifact1(artifacts.find(a => a.id === event.target.value) as Artifact);
+    }
+    else if (event.target.name === 'artifact2') {
+        setSetting2(null);
+        event.target.value === '' ?
+            setArtifact2(null)
+            :
+            setArtifact2(artifacts.find(a => a.id === event.target.value) as Artifact);
+    }
+}
+
+export function handleSettingChange(
+    event: React.ChangeEvent<{ name?: string | undefined; value: unknown }>,
+    artifact1Settings: { [key: string]: string },
+    artifact2Settings: { [key: string]: string },
+    setSetting1: Function,
+    setSetting2: Function
+) {
+    if (event.target.name === 'setting1') {
+        if (!event.target.value) {
+            setSetting1(null);
+            return;
+        }
+        let setting: KeyValueStringPair = { key: event.target.value as string, value: artifact1Settings[event.target.value as string] };
+        setSetting1(setting);
+    }
+    else if (event.target.name === 'setting2') {
+        if (!event.target.value) {
+            setSetting2(null);
+            return;
+        }
+        let setting: KeyValueStringPair = { key: event.target.value as string, value: artifact2Settings[event.target.value as string] };
+        setSetting2(setting);
+    }
+}
+
+export function differentSettingTypes(
+    setting1: KeyValueStringPair | null,
+    setting2: KeyValueStringPair | null,
+    artifact1: Artifact | null,
+    artifact2: Artifact | null
+) {
+    if (setting1 && setting2) {
+        if (artifact1?.relationalFields[setting1.key] !== artifact2?.relationalFields[setting2.key]) {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Tarea a realizar
_Se debe modificar la creación de relaciones para solo permitir crear relaciones entre settings que esperen y aporten el mismo tipo de valor (un entero a una setting que espera un entero por ejemplo)._

## Cambios realizados
Se incorpora un nuevo método en el servicio de artefactos para obtener todos los artefactos de un listado de relaciones. Esto es necesario para la validación de tipos entre settings relacionadas, ya que para obtener el tipo, es necesario tener instanciado el artefacto, por que el diccionario RelationalFields (que es el que tiene el par [_nombre de setting_|_tipo de setting_]) se llena dentro de los constructores.
Asimismo, para evitar múltiples consultas por información similar, se reutilizan estos artefactos para otras dos validaciones más (verificar que existan los artefactos en base de datos según sus Ids, y que todos formen parte del mismo proyecto), en lugar de volver a consultar la base de datos.