### PR TITLE
[FIVE-392] Corregir getPrice AwsS3 para servicios One Zone Infrequent Access.

### DIFF
--- a/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsS3.cs
+++ b/FiveRockingFingers/FRF.Core/Models/AwsArtifacts/AwsS3.cs
@@ -81,12 +81,16 @@ namespace FRF.Core.Models.AwsArtifacts
 
         private decimal GetStandardPrice()
         {
+            var endRange2 = 0m;
             var endRange1 = (decimal) PricingDimensions[AwsS3Descriptions.Range0].EndRange;
-            var endRange2 = (decimal) PricingDimensions[AwsS3Descriptions.Range2].EndRange;
-            if (endRange1 == 0 || endRange2 == 0) return 0;
+            var isEndRange2 = PricingDimensions.ContainsKey(AwsS3Descriptions.Range2);
+            if (isEndRange2)
+                endRange2 = (decimal) PricingDimensions[AwsS3Descriptions.Range2].EndRange;
+
+            if (endRange1 == 0) return 0;
 
             decimal storageCost;
-            if (StorageUsed <= endRange1)
+            if (StorageUsed <= endRange1 || endRange1 == -1)
                 storageCost = PricingDimensions[AwsS3Descriptions.Range0].PricePerUnit * StorageUsed;
 
             else if (StorageUsed >= endRange1 && StorageUsed <= endRange2)

--- a/test/FRF.Core.Tests/Models/AwsArtifacts/AwsS3Test.cs
+++ b/test/FRF.Core.Tests/Models/AwsArtifacts/AwsS3Test.cs
@@ -78,6 +78,35 @@ namespace FRF.Core.Tests.Models
         }
 
         [Fact]
+        public void GetPrice_WhenIsOneZoneInfrequent_ReturnDecimalPrice()
+        {
+            // Arrange
+            var writeRequestsUsed = 2000;
+            var retrieveRequestsUsed = 3000;
+            var storageUsed = 1024;
+            var standardPricePerUnitTier1 = "0.023";
+            var standardPricePerUnitTier2 = "0.021";
+            var standardPricePerUnitTier3 = "0.022";
+            var writeRequestsPrice = "4E-07";
+            var retrieveRequestsPrice = "5E-06";
+            var endRange1 = -1;
+
+            const decimal FinalCost = 10.2558000m;
+
+            _classUnderTest.Settings = RetrieveOneZoneSettings(writeRequestsUsed, retrieveRequestsUsed, storageUsed, standardPricePerUnitTier1
+                , standardPricePerUnitTier2, standardPricePerUnitTier3, writeRequestsPrice,
+                retrieveRequestsPrice, endRange1);
+            _classUnderTest.StorageUsed = storageUsed;
+            _classUnderTest.RetrieveRequestsUsed = retrieveRequestsUsed;
+            _classUnderTest.WriteRequestsUsed = writeRequestsUsed;
+            
+            // Act
+            var result = _classUnderTest.GetPrice();
+            // Assert
+            Assert.IsType<decimal>(result);
+            Assert.Equal(FinalCost,result);
+        }
+        [Fact]
         public void GetPrice_StandardServiceWhenInvalidEndRange_Return0()
         {
             // Arrange
@@ -311,5 +340,64 @@ namespace FRF.Core.Tests.Models
             return settings;
         }
         #endregion
+
+        #region RetrieveOneZoneSettings
+        private XElement RetrieveOneZoneSettings(int writeRequestsUsed, int retrieveRequestsUsed, int storageUsed,
+            string? standardPricePerUnitTier1, string? standardPricePerUnitTier2, string? standardPricePerUnitTier3,
+            string writeRequestsPrice, string retrieveRequestsPrice, int endRange1)
+        {
+            var settingsXML =
+                "{\"location\": \"US East (N. Virginia)\",\"volumeType\": " +
+                "\"One Zone - Infrequent Access\"," +
+                "\"storageClass\": \"Infrequent Access\",   " +
+                "\"storageUsed\": \"" + storageUsed + "\"," +
+                "\"writeRequestsUsed\": \"" + writeRequestsUsed + "\"," +
+                "\"retrieveRequestsUsed\": \"" + retrieveRequestsUsed + "\"," +
+                "\"product0\": " +
+                "{\"sku\": \"KRY2B57FKTA8GJW7\"," +
+                "\"term\": \"OnDemand\"," +
+                "\"leaseContractLength\": []," +
+                "\"offeringClass\": []," +
+                "\"purchaseOption\": []," +
+                "\"pricingDimensions\": " +
+                "{\"range0\": " +
+                "{\"unit\": \"GB-Mo\"," +
+                "\"endRange\": \"" + endRange1 + "\"," +
+                "\"description\": \"$0.01 per GB-Month of storage used in One Zone-Infrequent Access\"," +
+                "\"rateCode\": \"KRY2B57FKTA8GJW7.JRTCKXETXF.6YS6EN2CT7\"," +
+                "\"beginRange\": \"0\"," +
+                "\"currency\": \"USD\"," +
+                "\"pricePerUnit\": \"0.01\"}}}," +
+                "\"product1\": {\"sku\": \"B7AD99B3N6FTT9TR\"," +
+                "\"term\": \"OnDemand\"," +
+                "\"leaseContractLength\": []," +
+                "\"offeringClass\": []," +
+                "\"purchaseOption\": []," +
+                "\"pricingDimensions\": {\"range0\": {\"unit\": \"Requests\"," +
+                "\"endRange\": \"-1\"," +
+                "\"description\": \"POST or LIST requests to One Zone-Infrequent Access\"," +
+                "\"rateCode\": \"B7AD99B3N6FTT9TR.JRTCKXETXF.6YS6EN2CT7\"," +
+                "\"beginRange\": \"0\"," +
+                "\"currency\": \"USD\"," +
+                "\"pricePerUnit\": \"" + writeRequestsPrice + "\"}}}," +
+                "\"product2\": {\"sku\": \"Q8UHH97856JSTGFA\"," +
+                "\"term\": \"OnDemand\"," +
+                "\"leaseContractLength\": []," +
+                "\"offeringClass\": []," +
+                "\"purchaseOption\": []," +
+                "\"pricingDimensions\": {\"range0\": {\"unit\": \"Requests\"," +
+                "\"endRange\": \"-1\"," +
+                "\"description\": \"$0.01 per 10 GET and all other requests  to One Zone-Infrequent Access\"," +
+                "\"rateCode\": \"Q8UHH97856JSTGFA.JRTCKXETXF.6YS6EN2CT7\"," +
+                "\"beginRange\": \"0\"," +
+                "\"currency\": \"USD\"," +
+                "\"pricePerUnit\": \"" + retrieveRequestsPrice + "\"}}}}";
+
+            XNode node = JsonConvert.DeserializeXNode(settingsXML, "settings");
+            var settings = XElement.Parse(node.ToString());
+            return settings;
+        }
+        #endregion
+
     }
 }


### PR DESCRIPTION
### Descripción:
Al crearse un artefacto AwsS3 de tipo One Zone Infrequent Access, el mismo solo cuenta con un range de precios para el almacenamiento (`<Range0>`), por lo tanto la función que calcula el precio buscaba más de un nodo de tipo range, en este caso `<Range1>` y al no encontrarlo se producía que la misma devolviese NULL al no encontrarlo. 

### Modificaciones:
- Se realizaron correcciones en la función GetPrice del modelo AwsS3, ya que se producía un error al calcular el precio de los productos de tipo One Zone Infrequent Access.
- Se creó unit test para validar modificación.