### PR TITLE
[FIVE-394] Modificar el método GetAttributeValue para traer todos los valores posibles un atributo de un servicio de Amazon

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/IArtifactsProviderService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IArtifactsProviderService.cs
@@ -12,7 +12,6 @@ namespace FRF.Core.Services
     public interface IArtifactsProviderService
     {
         Task<ServiceResponse<List<KeyValuePair<string, string>>>> GetNamesAsync();
-        Task<ServiceResponse<List<ProviderArtifactSetting>>> GetAttributesAsync(string serviceCode);
         Task<ServiceResponse<List<PricingTerm>>> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode);
         Task<ServiceResponse<JObject>> GetRequiredFieldsAsync(string serviceCode);
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/AwsArtifactsProviderController.cs
@@ -37,15 +37,6 @@ namespace FRF.Web.Controllers
             return Ok(response.Value);
         }
 
-        [HttpGet("attributes")]
-        public async Task<IActionResult> GetAttributesAsync(string serviceCode)
-        {
-            var response = await _artifactsProviderService.GetAttributesAsync(serviceCode);
-
-            var attributes = _mapper.Map<List<ProviderArtifactSettingDTO>>(response.Value);
-            return Ok(attributes);
-        }
-
         [HttpPost("products")]
         public async Task<IActionResult> GetProductsAsync(List<KeyValuePair<string, string>> settings, string serviceCode)
         {

--- a/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
+++ b/test/FRF.Core.Tests/Services/AwsArtifactsProviderServiceTest.cs
@@ -134,7 +134,7 @@ namespace FRF.Core.Tests.Services
 
             var responseGetAttributeValue = new GetAttributeValuesResponse
             {
-                NextToken = "[Mock] Next token",
+                NextToken = null,
                 AttributeValues = attributeValues
             };
 
@@ -192,85 +192,6 @@ namespace FRF.Core.Tests.Services
             var propertie1 = (JObject)resultValue.SelectToken($"{propertiesJsonElement}.{principalPropertie}.{propertiesJsonElement}.{propertieName}");
             var enums = (JArray)propertie1[enumJsonElement];
             Assert.Equal(enums[0].ToString(), attributeValue.Value);
-        }
-
-        [Fact]
-        public async Task GetAttributesAsync_ReturnList()
-        {
-            // Arange
-            var serviceCode = "[Mock] Service Code";
-            var attributeNames = new List<string>
-            {
-                "[Mock] Service Name"
-            };
-            var service = new Service
-            {
-                AttributeNames = attributeNames,
-                ServiceCode = serviceCode
-            };
-            var services = new List<Service>
-            {
-                service
-            };
-            var response = new DescribeServicesResponse
-            {
-                FormatVersion = "[Mock] Format Version",
-                NextToken = "[Mock] Next token",
-                Services = services
-            };
-
-            var attributeValue = new AttributeValue
-            {
-                Value = "[Mock] Attribute Value"
-            };
-
-            var attributeValues = new List<AttributeValue>
-            {
-                attributeValue
-            };
-
-            var response2 = new GetAttributeValuesResponse
-            {
-                NextToken = "[Mock] Next token",
-                AttributeValues = attributeValues
-            };
-
-            _client
-                .Setup(mock => mock.DescribeServicesAsync(It.IsAny<DescribeServicesRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(response);
-            _client
-                .Setup(mock => mock.GetAttributeValuesAsync(It.IsAny<GetAttributeValuesRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(response2);
-
-            // Act
-            var result = await _classUnderTest.GetAttributesAsync(serviceCode);
-
-            // Assert
-            Assert.IsType<ServiceResponse<List<ProviderArtifactSetting>>>(result);
-            Assert.True(result.Success);
-
-            var settingsList = result.Value;
-            Assert.NotEmpty(settingsList);
-
-            Assert.Equal(service.AttributeNames[0], settingsList[0].Name.Key);
-            Assert.Equal(attributeValue.Value, settingsList[0].Values[0]);
-            _client.Verify(mock => mock.DescribeServicesAsync(It.IsAny<DescribeServicesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-            _client.Verify(mock => mock.GetAttributeValuesAsync(It.IsAny<GetAttributeValuesRequest>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task GetAttributesAsync_ReturnsEmptyList()
-        {
-            // Arange
-            var serviceCode = "[Mock] Service Code";
-
-            // Act
-            var result = await _classUnderTest.GetAttributesAsync(serviceCode);
-
-            // Assert
-            Assert.IsType<ServiceResponse<List<ProviderArtifactSetting>>>(result);
-            Assert.True(result.Success);
-            Assert.Empty(result.Value);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/AwsArtifactsProviderControllerTest.cs
@@ -143,30 +143,6 @@ namespace FRF.Web.Tests.Controllers
         }
 
         [Fact]
-        public async Task GetAttributesAsync_ReturnsOk()
-        {
-            // Arrange
-            var serviceCode = "[Mock] Service code";
-            var artifactSettings = CreateArtifactSetting();
-
-            _artifactProviderService
-                .Setup(mock => mock.GetAttributesAsync(It.IsAny<string>()))
-                .ReturnsAsync(new ServiceResponse<List<ProviderArtifactSetting>>(artifactSettings));
-
-            // Act
-            var result = await _classUnderTest.GetAttributesAsync(serviceCode);
-
-            // Assert
-            var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnValue = Assert.IsType<List<ProviderArtifactSettingDTO>>(okResult.Value);
-
-            Assert.Equal(artifactSettings[0].Name.Key, returnValue[0].Name.Key);
-            Assert.Equal(artifactSettings[0].Name.Value, returnValue[0].Name.Value);
-            Assert.Equal(artifactSettings[0].Values[0], returnValue[0].Values[0]);
-            _artifactProviderService.Verify(mock => mock.GetAttributesAsync(serviceCode), Times.Once);
-        }
-
-        [Fact]
         public async Task GetProductsAsync_ReturnsOk()
         {
             // Arrange


### PR DESCRIPTION
Actualmente al momento de traer el campo _"RequiredFields"_ de un tipo de artefactos, la gran mayoría de los campos, son completados con los valores posibles que se traen desde la _pricing api_ de Amazon. El problema es que, por defecto, la api de amazon solo devuelve un máximo de 100 valores. En este PR se modifica el método GetAttributeValueAsync (que es utilizado dentro del método GetRequiredFieldsAsync) para que devuelva todos los valores posibles de un campo especifico y no solamente los primeros 100.

Además se elimina el método GetAttributesAsync ya que no es utilizado para nada y puede provocar problemas al tratar de usarse ya que busca todos los valores posibles de **todos los atributos posibles** de un servicio de Amazon sin ningún tipo de control. El inconveniente es que hay atributos con muchisimos valores posibles (como ser el sku) lo que provoca que el método tarde bastante tiempo en completarse.

**Cambios realizados**

-Se modificó el método GetAttributeValueAsync del servicio AwsArtifactsProviderService para que traiga todos los valores posibles de un atributo de un servicio de Amazon y no solamente los primeros 100
-Se elimana el método GetAttributesAsync del controller AwsArtifactsProviderController y del servicio AwsArtifactsProviderService