### PR TITLE
[FIVE-391] Controlar modificación de tipo de settings

### DIFF
--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -746,7 +746,11 @@ namespace FRF.Core.Services
         private async Task<List<Guid>> GetRelationsToDeleteOfUpdatedArtifact(int artifactId, XElement updatedSettings, XElement originalSettings)
         {
             var changedSettingsName = FindSettingsWithNamesChanged(updatedSettings, originalSettings);
-            var artifactsRelationsIdsToDelete = await FindRelationsToDeleteOfUpdatedArtifact(artifactId, changedSettingsName);
+            var changedSettingsTypes = FindSettingsWithTypesChanged(updatedSettings, originalSettings);
+
+            var changedSettings = changedSettingsName.Concat(changedSettingsTypes).ToList();
+
+            var artifactsRelationsIdsToDelete = await FindRelationsToDeleteOfUpdatedArtifact(artifactId, changedSettings);
             return artifactsRelationsIdsToDelete;
         }
 
@@ -763,6 +767,22 @@ namespace FRF.Core.Services
             }
 
             return changedSettingsName;
+        }
+
+        private List<string> FindSettingsWithTypesChanged(XElement updatedSettings, XElement originalSettings)
+        {
+            var changedSettings = new List<string>();
+
+            foreach (var setting in updatedSettings.Elements())
+            {
+                var originalSetting = originalSettings.Element(setting.Name);
+                if (!setting.HasElements && originalSetting != null && setting.Attribute("type").Value.ToString() != originalSetting.Attribute("type").Value.ToString())
+                {
+                    changedSettings.Add(setting.Name.ToString());
+                }
+            }
+
+            return changedSettings;
         }
 
         private async Task<List<Guid>> FindRelationsToDeleteOfUpdatedArtifact(int artifactId, List<string> changedSettingsName)

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -29,10 +29,25 @@ const EditArtifactConfirmation = (props: {
     setOpenSnackbar: Function,
     setSnackbarSettings: Function,
     updateArtifacts: Function,
-    settingTypes: { [key: string]: string } }) => {
+    settingTypes: { [key: string]: string },
+    originalSettingTypes: { [key: string]: string }
+}) => {
 
     const classes = useStyles();
     const { handleSubmit } = useForm();
+
+    const [namesOfSettingsTypeChange, setNamesOfSettingsTypeChange] = React.useState<string[]>([]);
+
+    // Update the names of the settings that changed types
+    React.useEffect(() => {
+        let changedSettingsList: string[] = [];
+        Object.keys(props.originalSettingTypes).forEach(key => {
+            if (props.settingTypes[key] && props.originalSettingTypes[key] !== props.settingTypes[key]) {
+                changedSettingsList.push(key);
+            }
+        });
+        setNamesOfSettingsTypeChange(changedSettingsList);
+    }, [props.settingTypes, props.originalSettingTypes]);
 
     //Create the artifact after submit
     const handleConfirm = async () => {
@@ -73,17 +88,33 @@ const EditArtifactConfirmation = (props: {
         <>
             <DialogTitle id="alert-dialog-title">Confirmación</DialogTitle>
             <DialogContent>
+                {props.namesOfSettingsChanged.length > 0 || namesOfSettingsTypeChange.length > 0 ?
+                    <Typography gutterBottom color="secondary" className={classes.title}>
+                        Tenga en cuenta que al modificar el nombre o tipo de alguna de las settings se borrarán
+                        las relaciones asociadas.
+                    </Typography> :
+                    null
+                }
                 {props.namesOfSettingsChanged.length > 0 ?
                     <>
-                    <Typography gutterBottom color="secondary" className={classes.title}>
-                        Tenga en cuenta que al modificar el nombre de alguna de las settings se borrará
-                        las relaciones asociadas.
-                        Las settings cuyos nombres serán modificados son:
-                    </Typography>
-                        <br />
-                        <br />
+                        <Typography gutterBottom color="secondary" className={classes.title}>
+                            Las settings cuyos nombres serán modificados son:
+                        </Typography>
                         <li className={classes.listStyleNone}>
                             {props.namesOfSettingsChanged.map(name => {
+                                return (<ul>{name}</ul>);
+                            })}
+                        </li>
+                    </> :
+                    null
+                }
+                {namesOfSettingsTypeChange.length > 0 ?
+                    <>
+                        <Typography gutterBottom color="secondary" className={classes.title}>
+                            Las settings cuyos tipos serán modificados son:
+                        </Typography>
+                        <li className={classes.listStyleNone}>
+                            {namesOfSettingsTypeChange.map(name => {
                                 return (<ul>{name}</ul>);
                             })}
                         </li>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -25,6 +25,8 @@ const EditArtifactDialog = (props: {
     const [namesOfSettingsChanged, setNamesOfSettingsChanged] = React.useState<string[]>([]);
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
 
+    const [originalSettingTypes, setOriginalSettingTypes] = React.useState<{ [key: string]: string }>();
+
     const getRelations = async () => {
         try {
             const response = await ArtifactService.getRelationsAsync(props.artifactToEdit.id);
@@ -45,6 +47,10 @@ const EditArtifactDialog = (props: {
     React.useEffect(() => {
         getRelations();
     }, [artifactEdited]);
+
+    React.useEffect(() => {
+        setOriginalSettingTypes(props.artifactToEdit.relationalFields);
+    }, [props.artifactToEdit])
 
     return (
         <Dialog open={showEditArtifactDialog}>
@@ -67,6 +73,7 @@ const EditArtifactDialog = (props: {
                     setSnackbarSettings={props.setSnackbarSettings}
                     updateArtifacts={props.updateArtifacts}
                     settingTypes={settingTypes}
+                    originalSettingTypes={originalSettingTypes}
                 />
             }
         </Dialog>

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/HelperArtifactRelation.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/HelperArtifactRelation.ts
@@ -1,4 +1,4 @@
-﻿import { PROVIDERS } from "../../Constants";
+﻿import { PROVIDERS, CUSTOM_PROVIDER } from "../../Constants";
 import Artifact from "../../interfaces/Artifact";
 import KeyValueStringPair from "../../interfaces/KeyValueStringPair";
 
@@ -9,7 +9,7 @@ export function updateArtifactsSettings(
     setArtifact2Settings: Function
 ) {
     if (artifact1 !== null && artifact1 !== undefined) {
-        if (artifact1.artifactType?.name != PROVIDERS[1]) {
+        if (artifact1.artifactType?.name != CUSTOM_PROVIDER) {
             var relationalSettings: { [key: string]: string } = {};
             Object.entries(artifact1.relationalFields).map(([key, value]) => relationalSettings[key] = artifact1.settings[key]);
             setArtifact1Settings(relationalSettings);
@@ -21,7 +21,7 @@ export function updateArtifactsSettings(
         setArtifact1Settings({});
     }
     if (artifact2 !== null && artifact2 !== undefined) {
-        if (artifact2.artifactType?.name != PROVIDERS[1]) {
+        if (artifact2.artifactType?.name != CUSTOM_PROVIDER) {
             var relationalSettings: { [key: string]: string } = {};
             Object.entries(artifact2.relationalFields).map(([key, value]) => relationalSettings[key] = artifact2.settings[key]);
             setArtifact2Settings(relationalSettings);


### PR DESCRIPTION
## Tarea a realizar
Se debe hacer control sobre la modificación de las settings en los artefactos custom. En caso de modificar el tipo de la setting, se debe informar que antes de realizarse la modificación se eliminarían todas las relaciones de dicha setting, y en caso de confirmase, se debe hacer efectiva dicha eliminación.

## Cambios realizados
Ahora se detectan que settings han cambiado de tipo en la modificación del artefacto, se listan en la confirmación, y en caso de cambiar, se eliminan sus relaciones.

En la imagen se ve como se listan las settings que cambian (por un lado las que cambian de nombre, y por otro las que cambian de tipo) y como se elimina una relación preexistente por el cambio de tipo.

![five391](https://user-images.githubusercontent.com/71275374/113621025-7ecf2280-9631-11eb-9453-8eafece2bfb5.gif)
