### PR TITLE
[FIVE-396] Modificar mensajes de alerta al cliente según la respuesta de la API

### DIFF
--- a/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
@@ -1,0 +1,24 @@
+// Not exists errors
+export const ARTIFACT_NOT_EXISTS: number = 1;
+export const ARTIFACT_TYPE_NOT_EXISTS: number = 2;
+export const CATEGORY_NOT_EXISTS: number = 3;
+export const PROJECT_NOT_EXISTS: number = 4;
+export const PROVIDER_NOT_EXISTS: number = 5;
+export const ARTIFACT_FROM_ANOTHER_PROJECT: number = 6;
+
+// Relation errors
+export const RELATION_AL_READY_EXISTED: number = 10;
+export const RELATION_NOT_VALID: number = 11;
+export const RELATION_NOT_EXISTS: number = 12;
+export const RELATION_CYCLE_DETECTED: number = 13;
+
+// User errors
+export const INVALID_CREDENTIALS: number = 20;
+export const AUTHENTICATION_SERVER_CURRENTLY_UNAVAILABLE: number = 21;
+export const USER_NOT_EXISTS: number = 22;
+
+// External errors
+export const AMAZON_API_ERROR: number = 30;
+
+//Artifacts errors
+export const INVALID_ARTIFACT_SETTINGS: number = 40;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
@@ -8,9 +8,11 @@ export const ARTIFACT_FROM_ANOTHER_PROJECT: number = 6;
 
 // Relation errors
 export const RELATION_AL_READY_EXISTED: number = 10;
-export const RELATION_NOT_VALID: number = 11;
-export const RELATION_NOT_EXISTS: number = 12;
-export const RELATION_CYCLE_DETECTED: number = 13;
+export const RELATION_NOT_VALID_DIFFERENT_BASE_ARTIFACT: number = 11;
+export const RELATION_NOT_VALID_REPEATED = 12;
+export const RELATION_NOT_VALID_DIFFERENT_TYPE = 13;
+export const RELATION_NOT_EXISTS = 14;
+export const RELATION_CYCLE_DETECTED = 15;
 
 // User errors
 export const INVALID_CREDENTIALS: number = 20;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
@@ -1,6 +1,79 @@
 import * as React from 'react';
+import * as Errors from '../ErrorCodes';
 
-export function extractErrorCode(errorData: string): number {
+export function extractErrorCode(errorData: string): number | null {
+    if (errorData === null || errorData.trim() === '') return null;
     let text: RegExp = new RegExp(/\b(^|\s)([0-9]+)($|:){1}\B/g);
     return parseInt(text.exec(errorData)![0]);
+}
+
+export function handleErrorMessage(responseData: string, baseErrorMessage: string, setSnackbarSettings: Function, setOpenSnackbar: Function | undefined) {
+    let errorCode = extractErrorCode(responseData);
+    if (setOpenSnackbar === undefined) setOpenSnackbar = () => { };
+    switch (errorCode) {
+        case Errors.PROJECT_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El proyecto no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El artefacto no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.INVALID_ARTIFACT_SETTINGS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ Las propiedades son invalidas o alguna de ellas no corresponden a su tipo`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_TYPE_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El tipo de artefacto seleccionado no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ La relacion no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_FROM_ANOTHER_PROJECT:
+            setSnackbarSettings({ message: `Al menos uno de los artefactos corresponde a otro proyecto`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_DIFFERENT_BASE_ARTIFACT:
+            setSnackbarSettings({ message: `Al menos una de las relaciones corresponde a otro artefacto base`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_REPEATED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones está repetida`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_DIFFERENT_TYPE:
+            setSnackbarSettings({ message: `Al menos una de las relaciones es de tipo incompatible`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_AL_READY_EXISTED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones ya existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_CYCLE_DETECTED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones generaran un ciclo infinito`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.PROVIDER_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El proveedor solicitado no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.USER_NOT_EXISTS:
+            setSnackbarSettings({ message: `Hubo un error al obtener el perfil del usuario o el mismo no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.CATEGORY_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ Al menos una de las categorias no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case null:
+            setSnackbarSettings({ message: `El artefacto no existe o no tienes autorizacion al mismo 🔒`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        default:
+            setSnackbarSettings({ message: `${baseErrorMessage}`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+    }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import * as Errors from '../ErrorCodes';
 
-export function extractErrorCode(errorData: string): number | null {
-    if (errorData === null || errorData.trim() === '') return null;
-    let text: RegExp = new RegExp(/\b(^|\s)([0-9]+)($|:){1}\B/g);
-    return parseInt(text.exec(errorData)![0]);
-}
+interface IErrorResponse {
+    code: number;
+    message: string;
+  } 
 
-export function handleErrorMessage(responseData: string, baseErrorMessage: string, setSnackbarSettings: Function, setOpenSnackbar: Function | undefined) {
-    let errorCode = extractErrorCode(responseData);
+export function handleErrorMessage(responseData: IErrorResponse, baseErrorMessage: string, setSnackbarSettings: Function, setOpenSnackbar: Function | undefined) {
     if (setOpenSnackbar === undefined) setOpenSnackbar = () => { };
-    switch (errorCode) {
+    switch (responseData.code) {
         case Errors.PROJECT_NOT_EXISTS:
             setSnackbarSettings({ message: `${baseErrorMessage}:\ El proyecto no existe`, severity: "error" });
             setOpenSnackbar(true);

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export function extractErrorCode(errorData: string): number {
+    let text: RegExp = new RegExp(/\b(^|\s)([0-9]+)($|:){1}\B/g);
+    return parseInt(text.exec(errorData)![0]);
+}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -66,14 +66,14 @@ const ArtifactsTable = (props: { projectId: number}) => {
             else {
                 handleErrorMessage(
                     response.data,
-                    "Hubo un error al cargar los artifacts",
+                    "Hubo un error al cargar los artefactos",
                     manageOpenSnackbar,
                     undefined
                 );
             }
         }
         catch {
-            manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
+            manageOpenSnackbar({ message: "Hubo un error al cargar los artefactos", severity: "error" });
         }
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -9,8 +9,7 @@ import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
 import EditArtifactDialog from './EditArtifactDialog';
-import { extractErrorCode } from '../../commons/Helpers';
-import * as Errors from '../../ErrorCodes';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ArtifactsTable = (props: { projectId: number}) => {
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
@@ -32,6 +31,14 @@ const ArtifactsTable = (props: { projectId: number}) => {
           if(response.status === 200){
             setPrice(response.data.toFixed(2));
           }
+          else{
+            handleErrorMessage(
+                response.data,
+                "Hubo un error al obtener el costo",
+                manageOpenSnackbar,
+                undefined
+              );
+          }
         } catch {
           setPrice('');
         }
@@ -52,20 +59,17 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const getArtifacts = async () => {
         try {
             const response = await ArtifactService.getAllByProjectId(projectId);
-            switch (response.status) {
-                case 200:
-                    setArtifacts(response.data);
-                    getTotalPrice();
-                    break;
-                case 400:
-                    const errorCode = extractErrorCode(response.data);
-                    errorCode === Errors.PROJECT_NOT_EXISTS ?
-                        manageOpenSnackbar({ message: `No hay projectos con ID: ${projectId}`, severity: "error" }) :
-                        manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
-                    break;
-                default:
-                    manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
-                    break;
+            if (response.status === 200) {
+                setArtifacts(response.data);
+                getTotalPrice();
+            }
+            else {
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al cargar los artifacts",
+                    manageOpenSnackbar,
+                    undefined
+                );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactToDelete: Artifact, openSnackbar: Function, updateList: Function }) => {
 
@@ -11,14 +12,18 @@ const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactT
 
     const handleConfirm = async () => {
         try {
-            const response = await ArtifactService.delete(props.artifactToDelete.id)
-
+            const response = await ArtifactService.delete(props.artifactToDelete.id);
             if (response.status == 204) {
                 props.openSnackbar({ message: "El artefacto ha sido borrado con éxito", severity: "success" });
                 props.updateList();
             }
             else {
-                props.openSnackbar({ message: "Hubo un error al borrar el artefacto", severity: "error" });
+                handleErrorMessage(
+                  response.data,
+                  "Hubo un error al borrar el artefacto",
+                  props.openSnackbar,
+                  undefined
+                );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import Typography from '@material-ui/core/Typography';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
-
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -53,8 +53,12 @@ const EditArtifactConfirmation = (props: {
                 props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
                 props.setOpenSnackbar(true);
             } else {
-                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
-                props.setOpenSnackbar(true);
+                handleErrorMessage(
+                  response.data,
+                  "Hubo un error al modificar el artefacto",
+                  props.setSnackbarSettings,
+                  props.setOpenSnackbar
+                );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -5,7 +5,7 @@ import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import EditArtifact from './EditArtifact';
 import EditArtifactConfirmation from './EditArtifactConfirmation';
-
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const EditArtifactDialog = (props: {
     artifactToEdit: Artifact,
@@ -32,7 +32,12 @@ const EditArtifactDialog = (props: {
                 setArtifactsRelations(response.data);
             }
             else {
-                props.manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al cargar las relaciones entre artefactos",
+                    props.manageOpenSnackbar,
+                    undefined
+                  );
                 closeEditArtifactDialog();
             }
         }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Project from '../../interfaces/Project';
 import ProjectService from '../../services/ProjectService';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 export default function ConfirmationDialog(props: { keepMounted: boolean, open: boolean, project: Project | null, onClose: Function, resetView: Function, openSnackbar: Function, updateProjects: Function }) {
     const { onClose, project, open, updateProjects } = props;
@@ -18,11 +19,14 @@ export default function ConfirmationDialog(props: { keepMounted: boolean, open: 
                 if (response.status === 204) {
                     props.openSnackbar({ message: "Se eliminó el proyecto con éxito", severity: "success" });
                     updateProjects();
-                } else if (response.status === 404) {
-                    props.openSnackbar({ message: "No se encontró el proyecto a eliminar", severity: "info" });
                 }
                 else {
-                    props.openSnackbar({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
+                  handleErrorMessage(
+                    response.data,
+                    "Ocurrió un error al eliminar el proyecto",
+                    props.openSnackbar,
+                    undefined
+                  );
                 }
             }
             catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -14,6 +14,7 @@ import ProjectService from '../../services/ProjectService';
 import UserService from '../../services/UserService';
 import { HelperAddUser } from './HelperAddUser';
 import { ValidateEmail } from "./ValidateEmail";
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles({
     root: {
@@ -126,7 +127,12 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
             props.openSnackbar({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
             props.updateProjects();
         } else {
-            props.openSnackbar({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
+            handleErrorMessage(
+                response.data,
+                "Ocurrió un error al modificar el proyecto",
+                props.openSnackbar,
+                undefined
+              );
         }
         props.updateCategories();
         props.cancelEdit();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -15,6 +15,7 @@ import { HelperAddUser } from "./HelperAddUser";
 import ManageCategories from "./ManageCategories";
 import { ValidateEmail } from "./ValidateEmail";
 import { useUser } from '../../commons/useUser';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles({
     inputF: {
@@ -113,7 +114,12 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
             props.openSnackbar({ message: "El proyecto ha sido creado con éxito", severity: "success" });
             props.updateProjects();
         } else {
-            props.openSnackbar({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
+          handleErrorMessage(
+            response.data,
+            "Ocurrió un error al crear el proyecto",
+            props.openSnackbar,
+            undefined
+          );
         }
         clearState();
         props.updateCategories();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
@@ -12,6 +12,7 @@ import PricingTerm from '../interfaces/PricingTerm';
 import { PROVIDERS } from '../Constants';
 import ArtifactTypeService from '../services/ArtifactTypeService';
 import ArtifactType from '../interfaces/ArtifactType';
+import { handleErrorMessage } from '../commons/Helpers';
 
 const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, projectId: number, updateList: Function, setOpenSnackbar: Function , setSnackbarSettings: Function }) => {
 
@@ -54,9 +55,13 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
             if (response.status === 200) {
                 return response.data as ArtifactType[];
             } else {
-                props.setSnackbarSettings({ message: "Hubo un problema al cargar los tipos de artefactos.", severity: "error" });
-                props.setOpenSnackbar(true);
-                return [];
+              handleErrorMessage(
+                response.data,
+                "Hubo un problema al cargar los tipos de artefactos.",
+                props.setSnackbarSettings,
+                props.setOpenSnackbar
+              );
+              return [];
             }
         } catch {
             props.setSnackbarSettings({ message: "Hubo un problema al cargar los tipos de artefactos.", severity: "error" });

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -7,7 +7,8 @@ import Setting from '../../interfaces/Setting';
 import PricingTerm from '../../interfaces/PricingTerm';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactType from '../../interfaces/ArtifactType';
-
+import { extractErrorCode } from '../../commons/Helpers';
+import * as Errors from '../../ErrorCodes';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -36,9 +37,10 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
             settings: props.settings,
             relationalFields: props.settingTypes
         };
-
+///To do : HASTA ACA LLEGUE
         try {
             const response = await ArtifactService.save(artifactToCreate);
+            let errorCode: number = 0;
             if (response.status === 200) {
                 setSnackbarSettings({ message: "El artefacto ha sido creado con éxito", severity: "success" });
                 setOpenSnackbar(true);
@@ -46,6 +48,29 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
             } else {
                 setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
                 setOpenSnackbar(true);
+            }
+            switch (response.status) {
+                case 200:
+                    setSnackbarSettings({ message: "El artefacto ha sido creado con éxito", severity: "success" });
+                    setOpenSnackbar(true);
+                    updateList();
+                    break;
+                case 400:
+                    errorCode = extractErrorCode(response.data);
+                    errorCode === Errors.PROJECT_NOT_EXISTS ?
+                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+                    setOpenSnackbar(true);
+                    break;
+                case 404:
+                    errorCode = extractErrorCode(response.data);
+                    errorCode === Errors.PROJECT_NOT_EXISTS ?
+                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+                    setOpenSnackbar(true);
+                    break;
+                default:
+                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
+                    setOpenSnackbar(true);
+                    break;
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -7,8 +7,7 @@ import Setting from '../../interfaces/Setting';
 import PricingTerm from '../../interfaces/PricingTerm';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactType from '../../interfaces/ArtifactType';
-import { extractErrorCode } from '../../commons/Helpers';
-import * as Errors from '../../ErrorCodes';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -37,40 +36,20 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
             settings: props.settings,
             relationalFields: props.settingTypes
         };
-///To do : HASTA ACA LLEGUE
         try {
             const response = await ArtifactService.save(artifactToCreate);
-            let errorCode: number = 0;
             if (response.status === 200) {
                 setSnackbarSettings({ message: "El artefacto ha sido creado con éxito", severity: "success" });
                 setOpenSnackbar(true);
                 updateList();
-            } else {
-                setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-                setOpenSnackbar(true);
             }
-            switch (response.status) {
-                case 200:
-                    setSnackbarSettings({ message: "El artefacto ha sido creado con éxito", severity: "success" });
-                    setOpenSnackbar(true);
-                    updateList();
-                    break;
-                case 400:
-                    errorCode = extractErrorCode(response.data);
-                    errorCode === Errors.PROJECT_NOT_EXISTS ?
-                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-                    setOpenSnackbar(true);
-                    break;
-                case 404:
-                    errorCode = extractErrorCode(response.data);
-                    errorCode === Errors.PROJECT_NOT_EXISTS ?
-                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-                    setOpenSnackbar(true);
-                    break;
-                default:
-                    setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-                    setOpenSnackbar(true);
-                    break;
+            else {
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al crear el artefacto",
+                    setSnackbarSettings,
+                    setOpenSnackbar
+                );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -9,6 +9,7 @@ import Artifact from '../../interfaces/Artifact';
 import Typography from '@material-ui/core/Typography/Typography';
 import { Link } from 'react-router-dom';
 import NewArtifactsRelation from '../NewArtifactsRelation';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }) => {
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
@@ -26,7 +27,12 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setArtifactsRelations(response.data);
             }
             else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al cargar las relaciones",
+                manageOpenSnackbar,
+                undefined
+              );
             }
         }
         catch {
@@ -42,7 +48,12 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setArtifacts(response.data);
             }
             else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar los artefactos", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al cargar los artefactos",
+                manageOpenSnackbar,
+                undefined
+              );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import RelationCard from './RelationCard';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, artifactRelationToDelete: ArtifactRelation, openSnackbar: Function, updateList: Function }) => {
     const [relationList, setRelationList] = React.useState<ArtifactRelation[]>([]);
@@ -18,7 +19,12 @@ const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, arti
                 props.updateList(true);
             }
             else {
-                props.openSnackbar({ message: "Hubo un error al borrar la relacion", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al borrar la relacion",
+                props.openSnackbar,
+                undefined
+              );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -11,6 +11,7 @@ import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../../services/ArtifactService';
 import { Select } from '@material-ui/core';
 import { updateArtifactsSettings, toRegularSentence, handleArtifactChange, handleSettingChange, differentSettingTypes } from './HelperArtifactRelation';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -158,7 +159,12 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                 props.openSnackbar({ message: "La relacion ha sido modificada con éxito", severity: "success" });
                 props.updateList();
             } else {
-                props.openSnackbar({ message: "Hubo un error al modificar la relacion", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al modificar la relacion",
+                props.openSnackbar,
+                undefined
+              );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -11,6 +11,7 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
 import { updateArtifactsSettings, toRegularSentence, handleArtifactChange, handleSettingChange, differentSettingTypes } from './NewArtifactRelationComponents/HelperArtifactRelation';
+import { handleErrorMessage } from '../commons/Helpers';
 
 interface handlerUpdateList{
     update: boolean,
@@ -158,8 +159,12 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                 props.setOpenSnackbar(true);
                 if(props.updateList.update && props.updateList.setUpdate) props.updateList.setUpdate();
             } else {
-                props.setSnackbarSettings({ message: "Hubo un error al crear las relaciones", severity: "error" });
-                props.setOpenSnackbar(true);
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al crear las relaciones",
+                props.setSnackbarSettings,
+                props.setOpenSnackbar
+              );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
@@ -12,6 +12,7 @@ import SnackbarSettings from '../../interfaces/SnackbarSettings';
 import "./authStyle.css";
 import { BASE_URL } from '../../Constants';
 import { useUser } from '../../commons/useUser'
+import { handleErrorMessage } from '../../commons/Helpers';
 
 interface userLogin {
     email: string;
@@ -72,7 +73,7 @@ const Login = () => {
                 }
                 else {
                     cleanUserStorage();
-                    manageOpenSnackbar({ message: "Error al iniciar sesion!", severity: "error" });
+                    manageOpenSnackbar({ message: "Hubo un error con el servidor de autenticación! Intente nuevamente más tarde.", severity: "error" });
                     setLoading(false);
                     reset();
                 }


### PR DESCRIPTION
### Algunos ejemplos antes de implementar las modificaciones:
![viejoError](https://user-images.githubusercontent.com/71275081/114048841-4a41ad80-9861-11eb-9db8-5a7cb3f380f9.PNG)
![viejoErrorDelet](https://user-images.githubusercontent.com/71275081/114048846-4ada4400-9861-11eb-8b7a-6abbe6fa85f9.PNG)

### Ahora:
![nuevoError](https://user-images.githubusercontent.com/71275081/114049956-42363d80-9862-11eb-90e1-ca14e68b1616.PNG)
![nuevoErrorDelet](https://user-images.githubusercontent.com/71275081/114049378-c805b900-9861-11eb-9155-51d8c788faa3.PNG)

- Se modificó la manera en la que se manejan las respuestas ante llamadas a la API que retornan _HTTP Status code_ fuera del 200.
- Se creó archivo de constantes `ErrorCodes` para almacenar distintos códigos de errores.
- Se creó helper `Helpers.ts` para almacenar funciones auxiliares que se invoquen de manera global.