### PR TITLE
[FIVE-395] Modificar respuestas de controllers integrando ServiceResponse

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -12,9 +12,11 @@
 
         // Relation errors
         public const int RelationAlreadyExisted = 10;
-        public const int RelationNotValid = 11;
-        public const int RelationNotExists = 12;
-        public const int RelationCycleDetected = 13;
+        public const int RelationNotValidDifferentBaseArtifact = 11;
+        public const int RelationNotValidRepeated = 12;
+        public const int RelationNotValidDifferentType = 13;
+        public const int RelationNotExists = 14;
+        public const int RelationCycleDetected = 15;
 
         // User errors
         public const int InvalidCredentials = 20;

--- a/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ArtifactsService.cs
@@ -406,17 +406,17 @@ namespace FRF.Core.Services
 
             var hasAnyRelationWithoutBaseArtifact = HasAnyRelationWithoutBaseArtifact(artifactId, artifactRelations);
             if (hasAnyRelationWithoutBaseArtifact)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidDifferentBaseArtifact,
                     "At least one of the artifact relation provided does not involve the base artifact. "));
 
             var isAnyNewRelationRepeated = IsAnyRelationRepeated(artifactRelations);
             if (isAnyNewRelationRepeated)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated,
                     "At least one of the artifact relation provided is repeat"));
 
             var areNewRelationTypesValid = AreRelationTypesValid(artifactRelations, artifactsInNewRelations.Value);
             if (!areNewRelationTypesValid)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidDifferentType,
                     "At least one of the relations has different types"));
 
             var projectRelationsResponse = await GetAllRelationsByProjectIdAsync(artifactResponse.Value.ProjectId);
@@ -582,17 +582,17 @@ namespace FRF.Core.Services
 
             var relationInNewListRepeated = IsAnyRelationRepeated(artifactsRelationsNew);
             if (relationInNewListRepeated)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated,
                     "At least one of the artifact relation provided is repeat"));
 
             var relationsWithOriginalRepeated = IsAnyRelationRepeated(_mapper.Map<List<ArtifactsRelation>>(artifactsRelations), artifactsRelationsNew, isAnUpdate: true);
             if (relationsWithOriginalRepeated)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated,
                     "At least one of the artifact relation provided already exist"));
 
             var areNewRelationTypesValid = AreRelationTypesValid(artifactsRelationsNew, artifactsInNewRelations.Value);
             if (!areNewRelationTypesValid)
-                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid,
+                return new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidDifferentType,
                     "At least one of the relations has different types"));
 
             var cycleDetected = IsCircularReference(_mapper.Map<List<ArtifactsRelation>>(artifactsRelations), artifactsRelationsNew, true);

--- a/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
@@ -16,6 +16,7 @@ namespace FRF.Web.Dtos.Projects
         [Range(1, 1000000000000, ErrorMessage = "Budget have to be greater than {1}")]
         public int? Budget { get; set; }
         public IList<ProjectCategoryDTO> ProjectCategories { get; set; }
+        [Required, MinLength(1)]
         public IList<UserProfileUpsertDTO> Users { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/ErrorCodes.ts
@@ -1,0 +1,26 @@
+// Not exists errors
+export const ARTIFACT_NOT_EXISTS: number = 1;
+export const ARTIFACT_TYPE_NOT_EXISTS: number = 2;
+export const CATEGORY_NOT_EXISTS: number = 3;
+export const PROJECT_NOT_EXISTS: number = 4;
+export const PROVIDER_NOT_EXISTS: number = 5;
+export const ARTIFACT_FROM_ANOTHER_PROJECT: number = 6;
+
+// Relation errors
+export const RELATION_AL_READY_EXISTED: number = 10;
+export const RELATION_NOT_VALID_DIFFERENT_BASE_ARTIFACT: number = 11;
+export const RELATION_NOT_VALID_REPEATED = 12;
+export const RELATION_NOT_VALID_DIFFERENT_TYPE = 13;
+export const RELATION_NOT_EXISTS = 14;
+export const RELATION_CYCLE_DETECTED = 15;
+
+// User errors
+export const INVALID_CREDENTIALS: number = 20;
+export const AUTHENTICATION_SERVER_CURRENTLY_UNAVAILABLE: number = 21;
+export const USER_NOT_EXISTS: number = 22;
+
+// External errors
+export const AMAZON_API_ERROR: number = 30;
+
+//Artifacts errors
+export const INVALID_ARTIFACT_SETTINGS: number = 40;

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/commons/Helpers.ts
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import * as Errors from '../ErrorCodes';
+
+interface IErrorResponse {
+    code: number;
+    message: string;
+  } 
+
+export function handleErrorMessage(responseData: IErrorResponse, baseErrorMessage: string, setSnackbarSettings: Function, setOpenSnackbar: Function | undefined) {
+    if (setOpenSnackbar === undefined) setOpenSnackbar = () => { };
+    switch (responseData.code) {
+        case Errors.PROJECT_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El proyecto no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El artefacto no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.INVALID_ARTIFACT_SETTINGS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ Las propiedades son invalidas o alguna de ellas no corresponden a su tipo`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_TYPE_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El tipo de artefacto seleccionado no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ La relacion no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.ARTIFACT_FROM_ANOTHER_PROJECT:
+            setSnackbarSettings({ message: `Al menos uno de los artefactos corresponde a otro proyecto`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_DIFFERENT_BASE_ARTIFACT:
+            setSnackbarSettings({ message: `Al menos una de las relaciones corresponde a otro artefacto base`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_REPEATED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones está repetida`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_NOT_VALID_DIFFERENT_TYPE:
+            setSnackbarSettings({ message: `Al menos una de las relaciones es de tipo incompatible`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_AL_READY_EXISTED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones ya existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.RELATION_CYCLE_DETECTED:
+            setSnackbarSettings({ message: `Al menos una de las relaciones generaran un ciclo infinito`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.PROVIDER_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ El proveedor solicitado no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.USER_NOT_EXISTS:
+            setSnackbarSettings({ message: `Hubo un error al obtener el perfil del usuario o el mismo no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case Errors.CATEGORY_NOT_EXISTS:
+            setSnackbarSettings({ message: `${baseErrorMessage}:\ Al menos una de las categorias no existe`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        case null:
+            setSnackbarSettings({ message: `El artefacto no existe o no tienes autorizacion al mismo 🔒`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+        default:
+            setSnackbarSettings({ message: `${baseErrorMessage}`, severity: "error" });
+            setOpenSnackbar(true);
+            break;
+    }
+}

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ArtifactsTable.tsx
@@ -9,7 +9,7 @@ import ArtifactService from '../../services/ArtifactService';
 import ProjectService from '../../services/ProjectService';
 import ArtifactsTotalPrice from './ArtifactsTotalPrice';
 import EditArtifactDialog from './EditArtifactDialog';
-import ArtifactRelation from '../../interfaces/ArtifactRelation';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ArtifactsTable = (props: { projectId: number}) => {
     const [artifacts, setArtifacts] = React.useState<Artifact[]>([]);
@@ -31,6 +31,14 @@ const ArtifactsTable = (props: { projectId: number}) => {
           if(response.status === 200){
             setPrice(response.data.toFixed(2));
           }
+          else{
+            handleErrorMessage(
+                response.data,
+                "Hubo un error al obtener el costo",
+                manageOpenSnackbar,
+                undefined
+              );
+          }
         } catch {
           setPrice('');
         }
@@ -51,16 +59,21 @@ const ArtifactsTable = (props: { projectId: number}) => {
     const getArtifacts = async () => {
         try {
             const response = await ArtifactService.getAllByProjectId(projectId);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 setArtifacts(response.data);
                 getTotalPrice();
             }
             else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al cargar los artefactos",
+                    manageOpenSnackbar,
+                    undefined
+                );
             }
         }
         catch {
-            manageOpenSnackbar({ message: "Hubo un error al cargar los artifacts", severity: "error" });
+            manageOpenSnackbar({ message: "Hubo un error al cargar los artefactos", severity: "error" });
         }
     }
 

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/ConfirmationDialog.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactToDelete: Artifact, openSnackbar: Function, updateList: Function }) => {
 
@@ -11,14 +12,18 @@ const ConfirmationDialog = (props: { open: boolean, setOpen: Function, artifactT
 
     const handleConfirm = async () => {
         try {
-            const response = await ArtifactService.delete(props.artifactToDelete.id)
-
+            const response = await ArtifactService.delete(props.artifactToDelete.id);
             if (response.status == 204) {
                 props.openSnackbar({ message: "El artefacto ha sido borrado con éxito", severity: "success" });
                 props.updateList();
             }
             else {
-                props.openSnackbar({ message: "Hubo un error al borrar el artefacto", severity: "error" });
+                handleErrorMessage(
+                  response.data,
+                  "Hubo un error al borrar el artefacto",
+                  props.openSnackbar,
+                  undefined
+                );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactConfirmation.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import Typography from '@material-ui/core/Typography';
 import Artifact from '../../interfaces/Artifact';
 import ArtifactService from '../../services/ArtifactService';
-
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -53,8 +53,12 @@ const EditArtifactConfirmation = (props: {
                 props.setSnackbarSettings({ message: "El artefacto ha sido modificado con éxito", severity: "success" });
                 props.setOpenSnackbar(true);
             } else {
-                props.setSnackbarSettings({ message: "Hubo un error al modificar el artefacto", severity: "error" });
-                props.setOpenSnackbar(true);
+                handleErrorMessage(
+                  response.data,
+                  "Hubo un error al modificar el artefacto",
+                  props.setSnackbarSettings,
+                  props.setOpenSnackbar
+                );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ArtifactsComponents/EditArtifactDialog.tsx
@@ -5,7 +5,7 @@ import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import EditArtifact from './EditArtifact';
 import EditArtifactConfirmation from './EditArtifactConfirmation';
-
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const EditArtifactDialog = (props: {
     artifactToEdit: Artifact,
@@ -32,7 +32,12 @@ const EditArtifactDialog = (props: {
                 setArtifactsRelations(response.data);
             }
             else {
-                props.manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones entre artefactos", severity: "error" });
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al cargar las relaciones entre artefactos",
+                    props.manageOpenSnackbar,
+                    undefined
+                  );
                 closeEditArtifactDialog();
             }
         }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/ConfirmationDialog.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Project from '../../interfaces/Project';
 import ProjectService from '../../services/ProjectService';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 export default function ConfirmationDialog(props: { keepMounted: boolean, open: boolean, project: Project | null, onClose: Function, resetView: Function, openSnackbar: Function, updateProjects: Function }) {
     const { onClose, project, open, updateProjects } = props;
@@ -18,11 +19,14 @@ export default function ConfirmationDialog(props: { keepMounted: boolean, open: 
                 if (response.status === 204) {
                     props.openSnackbar({ message: "Se eliminó el proyecto con éxito", severity: "success" });
                     updateProjects();
-                } else if (response.status === 404) {
-                    props.openSnackbar({ message: "No se encontró el proyecto a eliminar", severity: "info" });
                 }
                 else {
-                    props.openSnackbar({ message: "Ocurrió un error al eliminar el proyecto", severity: "error" });
+                  handleErrorMessage(
+                    response.data,
+                    "Ocurrió un error al eliminar el proyecto",
+                    props.openSnackbar,
+                    undefined
+                  );
                 }
             }
             catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -14,6 +14,7 @@ import ProjectService from '../../services/ProjectService';
 import UserService from '../../services/UserService';
 import { HelperAddUser } from './HelperAddUser';
 import { ValidateEmail } from "./ValidateEmail";
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles({
     root: {
@@ -126,7 +127,12 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
             props.openSnackbar({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
             props.updateProjects();
         } else {
-            props.openSnackbar({ message: "Ocurrió un error al modificar el proyecto", severity: "error" });
+            handleErrorMessage(
+                response.data,
+                "Ocurrió un error al modificar el proyecto",
+                props.openSnackbar,
+                undefined
+              );
         }
         props.updateCategories();
         props.cancelEdit();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -15,6 +15,7 @@ import { HelperAddUser } from "./HelperAddUser";
 import ManageCategories from "./ManageCategories";
 import { ValidateEmail } from "./ValidateEmail";
 import { useUser } from '../../commons/useUser';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles({
     inputF: {
@@ -113,7 +114,12 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
             props.openSnackbar({ message: "El proyecto ha sido creado con éxito", severity: "success" });
             props.updateProjects();
         } else {
-            props.openSnackbar({ message: "Ocurrió un error al crear el proyecto", severity: "error" });
+          handleErrorMessage(
+            response.data,
+            "Ocurrió un error al crear el proyecto",
+            props.openSnackbar,
+            undefined
+          );
         }
         clearState();
         props.updateCategories();

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialog.tsx
@@ -12,6 +12,7 @@ import PricingTerm from '../interfaces/PricingTerm';
 import { PROVIDERS } from '../Constants';
 import ArtifactTypeService from '../services/ArtifactTypeService';
 import ArtifactType from '../interfaces/ArtifactType';
+import { handleErrorMessage } from '../commons/Helpers';
 
 const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArtifactDialog: Function, projectId: number, updateList: Function, setOpenSnackbar: Function , setSnackbarSettings: Function }) => {
 
@@ -54,9 +55,13 @@ const NewArtifactDialog = (props: { showNewArtifactDialog: boolean, closeNewArti
             if (response.status === 200) {
                 return response.data as ArtifactType[];
             } else {
-                props.setSnackbarSettings({ message: "Hubo un problema al cargar los tipos de artefactos.", severity: "error" });
-                props.setOpenSnackbar(true);
-                return [];
+              handleErrorMessage(
+                response.data,
+                "Hubo un problema al cargar los tipos de artefactos.",
+                props.setSnackbarSettings,
+                props.setOpenSnackbar
+              );
+              return [];
             }
         } catch {
             props.setSnackbarSettings({ message: "Hubo un problema al cargar los tipos de artefactos.", severity: "error" });

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactDialogComponents/Confirmation.tsx
@@ -7,7 +7,7 @@ import Setting from '../../interfaces/Setting';
 import PricingTerm from '../../interfaces/PricingTerm';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactType from '../../interfaces/ArtifactType';
-
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -36,16 +36,20 @@ const Confirmation = (props: { showNewArtifactDialog: boolean, closeNewArtifactD
             settings: props.settings,
             relationalFields: props.settingTypes
         };
-
         try {
             const response = await ArtifactService.save(artifactToCreate);
             if (response.status === 200) {
                 setSnackbarSettings({ message: "El artefacto ha sido creado con éxito", severity: "success" });
                 setOpenSnackbar(true);
                 updateList();
-            } else {
-                setSnackbarSettings({ message: "Hubo un error al crear el artefacto", severity: "error" });
-                setOpenSnackbar(true);
+            }
+            else {
+                handleErrorMessage(
+                    response.data,
+                    "Hubo un error al crear el artefacto",
+                    setSnackbarSettings,
+                    setOpenSnackbar
+                );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/ArtifactsRelationTable.tsx
@@ -9,6 +9,7 @@ import Artifact from '../../interfaces/Artifact';
 import Typography from '@material-ui/core/Typography/Typography';
 import { Link } from 'react-router-dom';
 import NewArtifactsRelation from '../NewArtifactsRelation';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }) => {
     const [artifactsRelations, setArtifactsRelations] = React.useState<ArtifactRelation[]>([]);
@@ -26,7 +27,12 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setArtifactsRelations(response.data);
             }
             else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar las relaciones", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al cargar las relaciones",
+                manageOpenSnackbar,
+                undefined
+              );
             }
         }
         catch {
@@ -42,7 +48,12 @@ const ArtifactsRelationTable = (props: { artifactId: number, projectId: number }
                 setArtifacts(response.data);
             }
             else {
-                manageOpenSnackbar({ message: "Hubo un error al cargar los artefactos", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al cargar los artefactos",
+                manageOpenSnackbar,
+                undefined
+              );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/DeleteArtifactsRelation.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ArtifactService from '../../services/ArtifactService';
 import ArtifactRelation from '../../interfaces/ArtifactRelation';
 import RelationCard from './RelationCard';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, artifactRelationToDelete: ArtifactRelation, openSnackbar: Function, updateList: Function }) => {
     const [relationList, setRelationList] = React.useState<ArtifactRelation[]>([]);
@@ -18,7 +19,12 @@ const DeleteArtifactsRelation = (props: { open: boolean, setOpen: Function, arti
                 props.updateList(true);
             }
             else {
-                props.openSnackbar({ message: "Hubo un error al borrar la relacion", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al borrar la relacion",
+                props.openSnackbar,
+                undefined
+              );
             }
         }
         catch {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactRelationComponents/EditArtifactRelation.tsx
@@ -11,6 +11,7 @@ import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../../services/ArtifactService';
 import { Select } from '@material-ui/core';
 import { updateArtifactsSettings, toRegularSentence, handleArtifactChange, handleSettingChange, differentSettingTypes } from './HelperArtifactRelation';
+import { handleErrorMessage } from '../../commons/Helpers';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -158,7 +159,12 @@ const EditArtifactRelation = (props: { open: boolean, closeEditArtifactsRelation
                 props.openSnackbar({ message: "La relacion ha sido modificada con éxito", severity: "success" });
                 props.updateList();
             } else {
-                props.openSnackbar({ message: "Hubo un error al modificar la relacion", severity: "error" });
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al modificar la relacion",
+                props.openSnackbar,
+                undefined
+              );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/NewArtifactsRelation.tsx
@@ -11,6 +11,7 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArtifactService from '../services/ArtifactService';
 import { updateArtifactsSettings, toRegularSentence, handleArtifactChange, handleSettingChange, differentSettingTypes } from './NewArtifactRelationComponents/HelperArtifactRelation';
+import { handleErrorMessage } from '../commons/Helpers';
 
 interface handlerUpdateList{
     update: boolean,
@@ -158,8 +159,12 @@ const NewArtifactsRelation = (props: { showNewArtifactsRelation: boolean, closeN
                 props.setOpenSnackbar(true);
                 if(props.updateList.update && props.updateList.setUpdate) props.updateList.setUpdate();
             } else {
-                props.setSnackbarSettings({ message: "Hubo un error al crear las relaciones", severity: "error" });
-                props.setOpenSnackbar(true);
+              handleErrorMessage(
+                response.data,
+                "Hubo un error al crear las relaciones",
+                props.setSnackbarSettings,
+                props.setOpenSnackbar
+              );
             }
         }
         catch (error) {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/auth/Login.tsx
@@ -12,6 +12,7 @@ import SnackbarSettings from '../../interfaces/SnackbarSettings';
 import "./authStyle.css";
 import { BASE_URL } from '../../Constants';
 import { useUser } from '../../commons/useUser'
+import { handleErrorMessage } from '../../commons/Helpers';
 
 interface userLogin {
     email: string;
@@ -72,7 +73,7 @@ const Login = () => {
                 }
                 else {
                     cleanUserStorage();
-                    manageOpenSnackbar({ message: "Error al iniciar sesion!", severity: "error" });
+                    manageOpenSnackbar({ message: "Hubo un error con el servidor de autenticación! Intente nuevamente más tarde.", severity: "error" });
                     setLoading(false);
                     reset();
                 }

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactTypesController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactTypesController.cs
@@ -37,7 +37,7 @@ namespace FRF.Web.Controllers
             var artifactTypes = await _artifactTypesService.GetAllByProviderAsync(providerName);
             if (!artifactTypes.Success)
             {
-                return NotFound();
+                return NotFound($"Error {artifactTypes.Error.Code}: {artifactTypes.Error.Message}");
             }
 
             var artifactTypesDto = _mapper.Map<IEnumerable<ArtifactTypeDTO>>(artifactTypes.Value);

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactTypesController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactTypesController.cs
@@ -37,7 +37,7 @@ namespace FRF.Web.Controllers
             var artifactTypes = await _artifactTypesService.GetAllByProviderAsync(providerName);
             if (!artifactTypes.Success)
             {
-                return NotFound($"Error {artifactTypes.Error.Code}: {artifactTypes.Error.Message}");
+                return NotFound(artifactTypes.Error);
             }
 
             var artifactTypesDto = _mapper.Map<IEnumerable<ArtifactTypeDTO>>(artifactTypes.Value);

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -41,6 +41,11 @@ namespace FRF.Web.Controllers
         {
             var artifacts = await _artifactsService.GetAllByProjectId(projectId);
 
+            if (!artifacts.Success)
+            {
+                return BadRequest($"Error {artifacts.Error.Code}: {artifacts.Error.Message}");
+            }
+
             var artifactsDto = _mapper.Map<IEnumerable<ArtifactDTO>>(artifacts.Value);
 
             return Ok(artifactsDto);
@@ -54,7 +59,7 @@ namespace FRF.Web.Controllers
 
             if (!artifact.Success)
             {
-                return NotFound();
+                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
             }
 
             var artifactDto = _mapper.Map<ArtifactDTO>(artifact.Value);
@@ -68,6 +73,15 @@ namespace FRF.Web.Controllers
             var artifact = _mapper.Map<Artifact>(artifactDto);
 
             var response = await _artifactsService.Save(artifact);
+            if (!response.Success)
+            {
+                if (response.Error.Code == ErrorCodes.InvalidArtifactSettings)
+                {
+                    return BadRequest($"Error {response.Error.Code}: {response.Error.Message}");
+                }
+
+                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+            }
             var artifactCreated = _mapper.Map<ArtifactDTO>(response.Value);
 
             return Ok(artifactCreated);
@@ -81,7 +95,12 @@ namespace FRF.Web.Controllers
 
             if (!artifact.Success)
             {
-                return NotFound();
+                if (artifact.Error.Code == ErrorCodes.InvalidArtifactSettings)
+                {
+                    return BadRequest($"Error {artifact.Error.Code}: {artifact.Error.Message}");
+                }
+
+                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
             }
 
             _mapper.Map(artifactDto, artifact.Value);
@@ -100,7 +119,7 @@ namespace FRF.Web.Controllers
 
             if (!artifact.Success)
             {
-                return NotFound();
+                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
             }
 
             await _artifactsService.Delete(artifactId);
@@ -115,7 +134,15 @@ namespace FRF.Web.Controllers
         {
             var artifactsRelations = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationList);
             var result = await _artifactsService.SetRelationAsync(artifactId, artifactsRelations);
-            if (!result.Success) return BadRequest();
+            if (!result.Success)
+            {
+                if (result.Error.Code == ErrorCodes.ArtifactNotExists ||
+                    result.Error.Code == ErrorCodes.ProjectNotExists)
+                {
+                    return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                }
+                return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+            }
 
             var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);
             return Ok(artifactsResult);
@@ -126,7 +153,10 @@ namespace FRF.Web.Controllers
         public async Task<IActionResult> GetRelationsAsync(int artifactId)
         {
             var result = await _artifactsService.GetAllRelationsOfAnArtifactAsync(artifactId);
-
+            if (!result.Success)
+            {
+                return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+            }
             var artifactsRelationsDTO = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);
             return Ok(artifactsRelationsDTO);
         }
@@ -136,7 +166,7 @@ namespace FRF.Web.Controllers
         {
             var result = await _artifactsService.GetAllRelationsByProjectIdAsync(projectId);
 
-             if (!result.Success) return BadRequest();
+             if (!result.Success) return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
 
              return Ok(_mapper.Map<IList<ArtifactsRelationDTO>>(result.Value));
 
@@ -146,7 +176,7 @@ namespace FRF.Web.Controllers
         public async Task<IActionResult> DeleteRelationAsync(Guid relationId)
         {
             var result = await _artifactsService.DeleteRelationAsync(relationId);
-            if (!result.Success) return NotFound();
+            if (!result.Success) return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
 
             return NoContent();
         }
@@ -156,7 +186,14 @@ namespace FRF.Web.Controllers
         public async Task<IActionResult> DeleteRelationsAsync(IList<Guid> artifactRelationIds)
         {
             var result = await _artifactsService.DeleteRelationsAsync(artifactRelationIds);
-            if (!result.Success) return NotFound();
+            if (!result.Success)
+                switch (result.Error.Code)
+                {
+                    case ErrorCodes.ArtifactNotExists:
+                        return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                    case ErrorCodes.InvalidArtifactSettings:
+                        return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+                }
 
             return NoContent();
         }
@@ -169,10 +206,15 @@ namespace FRF.Web.Controllers
         {
             var artifactsRelationsList = _mapper.Map<IList<ArtifactsRelation>>(artifactRelationUpdatedList);
             var result = await _artifactsService.UpdateRelationAsync(artifactId, artifactsRelationsList);
-
-            if (!result.Success && result.Error.Code == ErrorCodes.ArtifactNotExists) return NotFound();
-
-            if (!result.Success && result.Error.Code == ErrorCodes.RelationNotValid) return BadRequest();
+            if (!result.Success)
+            {
+                if (result.Error.Code == ErrorCodes.ArtifactNotExists ||
+                    result.Error.Code == ErrorCodes.ProjectNotExists)
+                {
+                    return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                }
+                return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+            }
 
             var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);
             return Ok(artifactsResult);

--- a/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ArtifactsController.cs
@@ -43,7 +43,7 @@ namespace FRF.Web.Controllers
 
             if (!artifacts.Success)
             {
-                return BadRequest($"Error {artifacts.Error.Code}: {artifacts.Error.Message}");
+                return BadRequest(artifacts.Error);
             }
 
             var artifactsDto = _mapper.Map<IEnumerable<ArtifactDTO>>(artifacts.Value);
@@ -59,7 +59,7 @@ namespace FRF.Web.Controllers
 
             if (!artifact.Success)
             {
-                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
+                return NotFound(artifact.Error);
             }
 
             var artifactDto = _mapper.Map<ArtifactDTO>(artifact.Value);
@@ -77,10 +77,10 @@ namespace FRF.Web.Controllers
             {
                 if (response.Error.Code == ErrorCodes.InvalidArtifactSettings)
                 {
-                    return BadRequest($"Error {response.Error.Code}: {response.Error.Message}");
+                    return BadRequest(response.Error);
                 }
 
-                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+                return NotFound(response.Error);
             }
             var artifactCreated = _mapper.Map<ArtifactDTO>(response.Value);
 
@@ -97,10 +97,10 @@ namespace FRF.Web.Controllers
             {
                 if (artifact.Error.Code == ErrorCodes.InvalidArtifactSettings)
                 {
-                    return BadRequest($"Error {artifact.Error.Code}: {artifact.Error.Message}");
+                    return BadRequest(artifact.Error);
                 }
 
-                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
+                return NotFound(artifact.Error);
             }
 
             _mapper.Map(artifactDto, artifact.Value);
@@ -119,7 +119,7 @@ namespace FRF.Web.Controllers
 
             if (!artifact.Success)
             {
-                return NotFound($"Error {artifact.Error.Code}: {artifact.Error.Message}");
+                return NotFound(artifact.Error);
             }
 
             await _artifactsService.Delete(artifactId);
@@ -139,9 +139,9 @@ namespace FRF.Web.Controllers
                 if (result.Error.Code == ErrorCodes.ArtifactNotExists ||
                     result.Error.Code == ErrorCodes.ProjectNotExists)
                 {
-                    return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                    return NotFound(result.Error);
                 }
-                return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+                return BadRequest(result.Error);
             }
 
             var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);
@@ -155,7 +155,7 @@ namespace FRF.Web.Controllers
             var result = await _artifactsService.GetAllRelationsOfAnArtifactAsync(artifactId);
             if (!result.Success)
             {
-                return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                return NotFound(result.Error);
             }
             var artifactsRelationsDTO = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);
             return Ok(artifactsRelationsDTO);
@@ -166,7 +166,7 @@ namespace FRF.Web.Controllers
         {
             var result = await _artifactsService.GetAllRelationsByProjectIdAsync(projectId);
 
-             if (!result.Success) return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+             if (!result.Success) return BadRequest(result.Error);
 
              return Ok(_mapper.Map<IList<ArtifactsRelationDTO>>(result.Value));
 
@@ -176,7 +176,7 @@ namespace FRF.Web.Controllers
         public async Task<IActionResult> DeleteRelationAsync(Guid relationId)
         {
             var result = await _artifactsService.DeleteRelationAsync(relationId);
-            if (!result.Success) return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+            if (!result.Success) return NotFound(result.Error);
 
             return NoContent();
         }
@@ -190,9 +190,9 @@ namespace FRF.Web.Controllers
                 switch (result.Error.Code)
                 {
                     case ErrorCodes.ArtifactNotExists:
-                        return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                        return NotFound(result.Error);
                     case ErrorCodes.InvalidArtifactSettings:
-                        return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+                        return BadRequest(result.Error);
                 }
 
             return NoContent();
@@ -211,9 +211,9 @@ namespace FRF.Web.Controllers
                 if (result.Error.Code == ErrorCodes.ArtifactNotExists ||
                     result.Error.Code == ErrorCodes.ProjectNotExists)
                 {
-                    return NotFound($"Error {result.Error.Code}: {result.Error.Message}");
+                    return NotFound(result.Error);
                 }
-                return BadRequest($"Error {result.Error.Code}: {result.Error.Message}");
+                return BadRequest(result.Error);
             }
 
             var artifactsResult = _mapper.Map<IList<ArtifactsRelationDTO>>(result.Value);

--- a/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
@@ -22,7 +22,7 @@ namespace FRF.Web.Controllers
         {
             var response = await _budgetService.GetBudget(projectId);
 
-            if (!response.Success) return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+            if (!response.Success) return NotFound(response.Error);
 
             return Ok(response.Value);
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/BudgetController.cs
@@ -22,7 +22,7 @@ namespace FRF.Web.Controllers
         {
             var response = await _budgetService.GetBudget(projectId);
 
-            if (!response.Success) return NotFound();
+            if (!response.Success) return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
 
             return Ok(response.Value);
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/CategoriesController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/CategoriesController.cs
@@ -39,7 +39,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound();
+                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
             }
 
             var categoryDto = _mapper.Map<CategoryDTO>(response.Value);
@@ -65,7 +65,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound();
+                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
             }
 
             _mapper.Map(categoryDto, response.Value);
@@ -83,7 +83,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound();
+                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
             }
 
             await _categoriesService.DeleteAsync(id);

--- a/FiveRockingFingers/FRF.Web/Controllers/CategoriesController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/CategoriesController.cs
@@ -39,7 +39,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+                return NotFound(response.Error);
             }
 
             var categoryDto = _mapper.Map<CategoryDTO>(response.Value);
@@ -65,7 +65,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+                return NotFound(response.Error);
             }
 
             _mapper.Map(categoryDto, response.Value);
@@ -83,7 +83,7 @@ namespace FRF.Web.Controllers
 
             if (!response.Success)
             {
-                return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+                return NotFound(response.Error);
             }
 
             await _categoriesService.DeleteAsync(id);

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -52,14 +52,14 @@ namespace FiveRockingFingers.Controllers
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
             if (!currentUserId.Success)
-                return BadRequest($"Error {currentUserId.Error.Code}: {currentUserId.Error.Message}");
+                return BadRequest(currentUserId.Error);
 
             projectDto.Users.Add(new UserProfileUpsertDTO() {UserId = currentUserId.Value});
             var project = _mapper.Map<Project>(projectDto);
 
             var projectSaved = await _projectService.SaveAsync(project);
             if (!projectSaved.Success)
-                return BadRequest($"Error {projectSaved.Error.Code}: {projectSaved.Error.Message}");
+                return BadRequest(projectSaved.Error);
 
             var projectCreated = _mapper.Map<ProjectDTO>(projectSaved.Value);
             return Ok(projectCreated);
@@ -69,11 +69,11 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> UpdateAsync(int id, ProjectUpsertDTO projectDto)
         {
             var response = await _projectService.GetAsync(id);
-            if (!response.Success) return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
+            if (!response.Success) return NotFound(response.Error);
 
             _mapper.Map(projectDto, response.Value);
             var updated = await _projectService.UpdateAsync(response.Value);
-            if (!updated.Success) return BadRequest($"Error {updated.Error.Code}: {updated.Error.Message}");
+            if (!updated.Success) return BadRequest(updated.Error);
 
             var updatedProject = _mapper.Map<ProjectDTO>(updated.Value);
             return Ok(updatedProject);
@@ -83,10 +83,10 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> DeleteAsync(int id)
         {
             var project = await _projectService.GetAsync(id);
-            if (!project.Success) return NotFound($"Error {project.Error.Code}: {project.Error.Message}");
+            if (!project.Success) return NotFound(project.Error);
 
             var isDeleted = await _projectService.DeleteAsync(id);
-            if (!isDeleted.Success) return NotFound($"Error {isDeleted.Error.Code}: {isDeleted.Error.Message}");
+            if (!isDeleted.Success) return NotFound(isDeleted.Error);
 
             return NoContent();
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectsController.cs
@@ -51,14 +51,15 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> SaveAsync(ProjectUpsertDTO projectDto)
         {
             var currentUserId = await _userService.GetCurrentUserIdAsync();
+            if (!currentUserId.Success)
+                return BadRequest($"Error {currentUserId.Error.Code}: {currentUserId.Error.Message}");
 
             projectDto.Users.Add(new UserProfileUpsertDTO() {UserId = currentUserId.Value});
-
             var project = _mapper.Map<Project>(projectDto);
-            if (project == null) return BadRequest();
 
             var projectSaved = await _projectService.SaveAsync(project);
-            if (!projectSaved.Success) return BadRequest();
+            if (!projectSaved.Success)
+                return BadRequest($"Error {projectSaved.Error.Code}: {projectSaved.Error.Message}");
 
             var projectCreated = _mapper.Map<ProjectDTO>(projectSaved.Value);
             return Ok(projectCreated);
@@ -68,14 +69,11 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> UpdateAsync(int id, ProjectUpsertDTO projectDto)
         {
             var response = await _projectService.GetAsync(id);
-            if (!response.Success) return NotFound();
-
-            //To improve
-            if (!projectDto.Users.Any()) return BadRequest();
+            if (!response.Success) return NotFound($"Error {response.Error.Code}: {response.Error.Message}");
 
             _mapper.Map(projectDto, response.Value);
             var updated = await _projectService.UpdateAsync(response.Value);
-            if (!updated.Success) return BadRequest();
+            if (!updated.Success) return BadRequest($"Error {updated.Error.Code}: {updated.Error.Message}");
 
             var updatedProject = _mapper.Map<ProjectDTO>(updated.Value);
             return Ok(updatedProject);
@@ -85,10 +83,10 @@ namespace FiveRockingFingers.Controllers
         public async Task<IActionResult> DeleteAsync(int id)
         {
             var project = await _projectService.GetAsync(id);
-            if (!project.Success) return NotFound();
+            if (!project.Success) return NotFound($"Error {project.Error.Code}: {project.Error.Message}");
 
             var isDeleted = await _projectService.DeleteAsync(id);
-            if (!isDeleted.Success) return NotFound();
+            if (!isDeleted.Success) return NotFound($"Error {isDeleted.Error.Code}: {isDeleted.Error.Message}");
 
             return NoContent();
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
@@ -30,8 +30,8 @@ namespace FRF.Web.Controllers
         {
             var userSignIn = _mapper.Map<UserSignIn>(signInDto);
             var response = await _signInService.SignInAsync(userSignIn);
-            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized($"Error {response.Error.Code}: {response.Error.Message}");
-            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,($"Error {response.Error.Code}: {response.Error.Message}"));
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized(response.Error);
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,(response.Error));
 
             return Ok(response.Value);
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignInController.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Claims;
-using AutoMapper;
+﻿using AutoMapper;
 using FRF.Core.Models;
 using FRF.Core.Response;
 using FRF.Core.Services;
@@ -7,7 +6,6 @@ using FRF.Web.Dtos.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
-using FRF.Web.Dtos.Projects;
 
 namespace FRF.Web.Controllers
 {
@@ -32,8 +30,8 @@ namespace FRF.Web.Controllers
         {
             var userSignIn = _mapper.Map<UserSignIn>(signInDto);
             var response = await _signInService.SignInAsync(userSignIn);
-            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized();
-            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return Unauthorized($"Error {response.Error.Code}: {response.Error.Message}");
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,($"Error {response.Error.Code}: {response.Error.Message}"));
 
             return Ok(response.Value);
         }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
@@ -29,8 +29,8 @@ namespace FRF.Web.Controllers
         {
             var userSignUp = _mapper.Map<User>(signUpDto);
             var response = await _signUpService.SignUpAsync(userSignUp);
-            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return BadRequest($"Error {response.Error.Code}: {response.Error.Message}");
-            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,($"Error {response.Error.Code}: {response.Error.Message}"));
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return BadRequest(response.Error);
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,(response.Error));
             return Ok(response.Value);
         }
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/SignUpController.cs
@@ -29,8 +29,8 @@ namespace FRF.Web.Controllers
         {
             var userSignUp = _mapper.Map<User>(signUpDto);
             var response = await _signUpService.SignUpAsync(userSignUp);
-            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return BadRequest();
-            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500);
+            if (!response.Success && response.Error.Code == ErrorCodes.InvalidCredentials) return BadRequest($"Error {response.Error.Code}: {response.Error.Message}");
+            if (!response.Success && response.Error.Code == ErrorCodes.AuthenticationServerCurrentlyUnavailable) return StatusCode(500,($"Error {response.Error.Code}: {response.Error.Message}"));
             return Ok(response.Value);
         }
     }

--- a/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
@@ -29,7 +29,7 @@ namespace FRF.Web.Controllers
         {
             var email = HttpContext.User.FindFirst(ClaimTypes.Email).Value;
             var userPublicProfile = await _userService.GetUserPublicProfileAsync(email);
-            if (!userPublicProfile.Success) return BadRequest();
+            if (!userPublicProfile.Success) return BadRequest($"Error {userPublicProfile.Error.Code}: {userPublicProfile.Error.Message}");
 
             var mappedProfile = _mapper.Map<UserProfileDTO>(userPublicProfile.Value);
             return Ok(mappedProfile);
@@ -55,7 +55,7 @@ namespace FRF.Web.Controllers
             if (string.IsNullOrWhiteSpace(email)) return BadRequest();
             
             var userProfile = await _userService.GetUserPublicProfileAsync(email); 
-            if (!userProfile.Success) return NotFound();
+            if (!userProfile.Success) return NotFound($"Error {userProfile.Error.Code}: {userProfile.Error.Message}");
 
             var userPublicProfile = _mapper.Map<UserProfileDTO>(userProfile.Value);
             

--- a/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/UserController.cs
@@ -29,7 +29,7 @@ namespace FRF.Web.Controllers
         {
             var email = HttpContext.User.FindFirst(ClaimTypes.Email).Value;
             var userPublicProfile = await _userService.GetUserPublicProfileAsync(email);
-            if (!userPublicProfile.Success) return BadRequest($"Error {userPublicProfile.Error.Code}: {userPublicProfile.Error.Message}");
+            if (!userPublicProfile.Success) return BadRequest(userPublicProfile.Error);
 
             var mappedProfile = _mapper.Map<UserProfileDTO>(userPublicProfile.Value);
             return Ok(mappedProfile);
@@ -55,7 +55,7 @@ namespace FRF.Web.Controllers
             if (string.IsNullOrWhiteSpace(email)) return BadRequest();
             
             var userProfile = await _userService.GetUserPublicProfileAsync(email); 
-            if (!userProfile.Success) return NotFound($"Error {userProfile.Error.Code}: {userProfile.Error.Message}");
+            if (!userProfile.Success) return NotFound(userProfile.Error);
 
             var userPublicProfile = _mapper.Map<UserProfileDTO>(userProfile.Value);
             

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -1205,7 +1205,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
+            Assert.Equal(ErrorCodes.RelationNotValidRepeated, response.Error.Code);
             Assert.Null(response.Value);
         }
 
@@ -1239,7 +1239,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
+            Assert.Equal(ErrorCodes.RelationNotValidRepeated, response.Error.Code);
             Assert.Null(response.Value);
         }
 
@@ -1271,7 +1271,7 @@ namespace FRF.Core.Tests.Services
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
             Assert.NotNull(response.Error);
-            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
+            Assert.Equal(ErrorCodes.RelationNotValidDifferentBaseArtifact, response.Error.Code);
             Assert.Null(response.Value);
         }
 
@@ -1621,7 +1621,7 @@ namespace FRF.Core.Tests.Services
             // Assert
             Assert.False(response.Success);
             Assert.IsType<ServiceResponse<IList<CoreModels.ArtifactsRelation>>>(response);
-            Assert.Equal(ErrorCodes.RelationNotValid, response.Error.Code);
+            Assert.Equal(ErrorCodes.RelationNotValidRepeated, response.Error.Code);
         }
 
         [Fact]

--- a/test/FRF.Web.Tests/Controllers/ArtifactTypesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactTypesControllerTests.cs
@@ -134,7 +134,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetAllByProviderAsync(providerName);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
 
             _artifactTypesService.Verify(mock => mock.GetAllByProviderAsync(It.IsAny<string>()), Times.Once);
         }

--- a/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ArtifactsControllerTests.cs
@@ -343,7 +343,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetAsync(artifactId);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
         }
 
@@ -549,7 +549,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.UpdateAsync(artifactId, artifactUpdate);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
         }
 
@@ -629,7 +629,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteAsync(artifactId);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.Get(artifactId), Times.Once);
             _artifactsService.Verify(mock => mock.Delete(artifactId), Times.Never);
         }
@@ -667,13 +667,13 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactsService
                 .Setup(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()))
-                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "Error Message")));
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated, "Error Message")));
 
             // Act
             var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos[0].Artifact1Id, artifactsRelationDtos);
 
             // Assert
-            var response = Assert.IsType<BadRequestResult>(result);
+            var response = Assert.IsType<BadRequestObjectResult>(result);
             Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
             _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()), Times.Once);
         }
@@ -701,13 +701,13 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactsService
                 .Setup(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()))
-                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "Error Message")));
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated, "Error Message")));
 
             // Act
             var result = await _classUnderTest.SetRelationAsync(artifactsRelationDtos[0].Artifact1Id, artifactsRelationDtos);
 
             // Assert
-            var response = Assert.IsType<BadRequestResult>(result);
+            var response = Assert.IsType<BadRequestObjectResult>(result);
             Assert.IsNotType<List<ArtifactsRelationDTO>>(response);
             _artifactsService.Verify(mock => mock.SetRelationAsync(It.IsAny<int>(), It.IsAny<List<ArtifactsRelation>>()), Times.Once);
         }
@@ -817,7 +817,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetAllRelationsByProjectIdAsync(projectId);
 
             // Assert
-            Assert.IsType<BadRequestResult>(result);
+            Assert.IsType<BadRequestObjectResult>(result);
             _artifactsService.Verify(mock => mock.GetAllRelationsByProjectIdAsync(It.IsAny<int>()), Times.Once);
         }
 
@@ -859,7 +859,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteRelationAsync(artifactRelationId);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.DeleteRelationAsync(It.IsAny<Guid>()), Times.Once);
         }
 
@@ -912,7 +912,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteRelationsAsync(artifactRelationIdsList);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.DeleteRelationsAsync(It.IsAny<IList<Guid>>()), Times.Once);
         }
 
@@ -1001,7 +1001,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.UpdateRelationsAsync(0, artifactsRelationsListDto);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _artifactsService.Verify(mock => mock.UpdateRelationAsync(It.IsAny<int>(), It.IsAny<IList<ArtifactsRelation>>()), Times.Once);
         }
 
@@ -1042,13 +1042,13 @@ namespace FRF.Web.Tests.Controllers
 
             _artifactsService
                 .Setup(mock => mock.UpdateRelationAsync(It.IsAny<int>(), It.IsAny<IList<ArtifactsRelation>>()))
-                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValid, "[Mock] message")));
+                .ReturnsAsync(new ServiceResponse<IList<ArtifactsRelation>>(new Error(ErrorCodes.RelationNotValidRepeated, "[Mock] message")));
 
             // Act
             var result = await _classUnderTest.UpdateRelationsAsync(artifact1Id, artifactsRelationsListDto);
 
             // Assert
-            Assert.IsType<BadRequestResult>(result);
+            Assert.IsType<BadRequestObjectResult>(result);
             _artifactsService.Verify(mock => mock.UpdateRelationAsync(It.IsAny<int>(), It.IsAny<IList<ArtifactsRelation>>()), Times.Once);
         }
 

--- a/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/BudgetControllerTests.cs
@@ -54,7 +54,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetBudget(projectId);
 
             //Assert
-            var notFoundResult = Assert.IsType<NotFoundResult>(result);
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
             _budgetService.Verify(mock => mock.GetBudget(It.IsAny<int>()), Times.Once);
         }
     }

--- a/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/CategoriesControllerTests.cs
@@ -116,7 +116,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetAsync(categoryId);
 
             // Assert
-            var notFoundResult = Assert.IsType<NotFoundResult>(result);
+            var NotFoundObjectResult = Assert.IsType<NotFoundObjectResult>(result);
             _categoriesService.Verify(mock => mock.GetAsync(categoryId), Times.Once);
         }
 
@@ -222,7 +222,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.UpdateAsync(1, updatedCategory);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
 
             _categoriesService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
             _categoriesService.Verify(mock => mock.UpdateAsync(It.IsAny<Category>()), Times.Never);
@@ -259,7 +259,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteAsync(1);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
             _categoriesService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
             _categoriesService.Verify(mock => mock.DeleteAsync(It.IsAny<int>()), Times.Never);
         }

--- a/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectsControllerTests.cs
@@ -232,32 +232,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.UpdateAsync(0, projectUpsertDTO);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
-
-            _projectsService.Verify(mock => mock.UpdateAsync(It.IsAny<Project>()), Times.Never);
-            _projectsService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Update_WhenGivenEmptyUserList_BadRequest()
-        {
-            // Arrange
-            var rnd = new Random();
-            var projectId = rnd.Next(1, 99999);
-            var project = CreateProject(projectId);
-            var projectUpsertDTO = CreateProjectUpsertDto(project);
-
-            projectUpsertDTO.Users.Clear();
-
-            _projectsService
-                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
-                .ReturnsAsync(new ServiceResponse<Project>(project));
-
-            // Act
-            var result = await _classUnderTest.UpdateAsync(project.Id, projectUpsertDTO);
-
-            // Assert
-            Assert.IsType<BadRequestResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
 
             _projectsService.Verify(mock => mock.UpdateAsync(It.IsAny<Project>()), Times.Never);
             _projectsService.Verify(mock => mock.GetAsync(It.IsAny<int>()), Times.Once);
@@ -334,7 +309,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteAsync(projectId);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
 
             _projectsService.Verify(mock => mock.DeleteAsync(It.IsAny<int>()), Times.Never);
         }
@@ -359,7 +334,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.DeleteAsync(projectId);
 
             // Assert
-            Assert.IsType<NotFoundResult>(result);
+            Assert.IsType<NotFoundObjectResult>(result);
 
             _projectsService.Verify(mock => mock.GetAsync(It.Is<int>(p => p.Equals(projectId))), Times.Once);
             _projectsService.Verify(mock => mock.DeleteAsync(It.Is<int>(p => p.Equals(projectId))), Times.Once);

--- a/test/FRF.Web.Tests/Controllers/SignInControllerTest.cs
+++ b/test/FRF.Web.Tests/Controllers/SignInControllerTest.cs
@@ -72,7 +72,7 @@ namespace FRF.Web.Tests.Controllers
             var response = await _classUnderTest.SignIn(signInDto);
 
             // Assert
-            Assert.IsType<UnauthorizedResult>(response);
+            Assert.IsType<UnauthorizedObjectResult>(response);
             _signInService.Verify(mock => mock.SignInAsync(It.IsAny<UserSignIn>()), Times.Once);
             _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Never);
         }
@@ -92,7 +92,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.SignIn(signInDto);
 
             // Assert
-            var internalServerError = Assert.IsType<StatusCodeResult>(result);
+            var internalServerError = Assert.IsType<ObjectResult>(result);
             Assert.Equal(500, internalServerError.StatusCode);
             _signInService.Verify(mock => mock.SignInAsync(It.IsAny<UserSignIn>()), Times.Once);
             _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Never);

--- a/test/FRF.Web.Tests/Controllers/UserControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/UserControllerTests.cs
@@ -104,7 +104,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.GetUserPublicProfileAsync();
 
             // Assert
-            var badRequestResult = Assert.IsType<BadRequestResult>(result);
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
             _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
         }
 
@@ -170,7 +170,7 @@ namespace FRF.Web.Tests.Controllers
             var result = await _classUnderTest.SearchUserAsync(userProfile.Email);
 
             // Assert
-            var notFoundResult = Assert.IsType<NotFoundResult>(result);
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
             _userService.Verify(mock => mock.GetUserPublicProfileAsync(It.IsAny<string>()), Times.Once);
         }
     }


### PR DESCRIPTION
### Algunos ejemplos antes de la modificación:
![viejoErrorUpdate](https://user-images.githubusercontent.com/71275081/114052912-d99c9000-9864-11eb-8e73-2b3e2516b760.PNG)
![viejoError](https://user-images.githubusercontent.com/71275081/114052917-da352680-9864-11eb-9f50-0c8ece134d61.PNG)
### Ahora:
![nuevoError2](https://user-images.githubusercontent.com/71275081/114398810-96993000-9b76-11eb-8074-7afe2f88f747.PNG)
![nuevoError](https://user-images.githubusercontent.com/71275081/114398812-9731c680-9b76-11eb-95aa-c2afb909c599.PNG)


- Se modificó ErrorCodes RelationNotValid para evitar generalizar error cuando las relaciones son de diferente tipo, están repetidas  o tienen diferente artefacto base.
- Se agregó data annotation para validar que la lista de usuarios al actualizar un proyecto contenga al menos un usuario.
- Se modificaron respuestas de ArtifactTypesController, BudgetController, CategoriesController, SignInController, SignUpController y UserController para que implementen ErrorCode y error message de ServiceResponse.
- Se agregaron y acomodaron Unit Test.