### PR TITLE
[FIVE-405] (Backend) Actualizar proyectos para contar con una fecha estimada de inicio

### DIFF
--- a/FiveRockingFingers/FRF.Core/Models/Project.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Project.cs
@@ -14,6 +14,7 @@ namespace FRF.Core.Models
         public int? Budget { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? ModifiedDate { get; set; }
+        public DateTime? StartDate { get; set; }
         public IList<ProjectCategory> ProjectCategories { get; set; }
         public ICollection<UsersProfile> UsersByProject { get; set; }
     }

--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -8,7 +8,8 @@
         public const int CategoryNotExists = 3;
         public const int ProjectNotExists = 4;
         public const int ProviderNotExists = 5;
-        public const int ArtifactFromAnotherProject= 6;
+        public const int ArtifactFromAnotherProject = 6;
+        public const int InvalidStartDateForProject = 7;
 
         // Relation errors
         public const int RelationAlreadyExisted = 10;

--- a/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
@@ -70,6 +70,11 @@ namespace FRF.Core.Services
             mappedProject.CreatedDate = DateTime.Now;
             mappedProject.ModifiedDate = null;
 
+            if(!IsStartDateValid(mappedProject.CreatedDate, mappedProject.StartDate))
+                return new ServiceResponse<Project>(
+                        new Error(ErrorCodes.InvalidStartDateForProject, "The project start date must be a future date")
+                        );
+
             // Separate all the non duplicated User Id in a list of UsersProfile
             var noDuplicatedUsersId = project.UsersByProject
                 .Select(ubp =>
@@ -135,6 +140,11 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<Project>> UpdateAsync(Project project)
         {
+            if (!IsStartDateValid(project.CreatedDate, project.StartDate))
+                return new ServiceResponse<Project>(
+                        new Error(ErrorCodes.InvalidStartDateForProject, "The project start date must be a future date")
+                        );
+
             var categoryList = new List<EntityModels.Category>();
             foreach (var category in project.ProjectCategories)
             {
@@ -211,6 +221,14 @@ namespace FRF.Core.Services
 
             var mappedProject = _mapper.Map<Project>(projectToDelete);
             return new ServiceResponse<Project>(mappedProject);
+        }
+
+        private bool IsStartDateValid(DateTime createdDate, DateTime? startDate)
+        {
+            if (startDate == null)
+                return true;
+
+            return createdDate < startDate;
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectsService.cs
@@ -193,6 +193,7 @@ namespace FRF.Core.Services
             result.Client = project.Client;
             result.Budget = project.Budget;
             result.ModifiedDate = DateTime.Now;
+            result.StartDate = project.StartDate;
             result.ProjectCategories = mappedProjectCategory;
             result.UsersByProject = mappedUBP;
 
@@ -228,7 +229,7 @@ namespace FRF.Core.Services
             if (startDate == null)
                 return true;
 
-            return createdDate < startDate;
+            return createdDate.Date <= startDate?.Date;
         }
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Project.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Project.cs
@@ -15,6 +15,7 @@ namespace FRF.DataAccess.EntityModels
         public int? Budget { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime? ModifiedDate{ get; set; }
+        public DateTime? StartDate { get; set; }
         #nullable disable
         public IList<ProjectCategory> ProjectCategories { get; set; }
         public ICollection<UsersByProject> UsersByProject { get; set; }

--- a/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectDTO.cs
@@ -16,6 +16,7 @@ namespace FRF.Web.Dtos
         public string? Client { get; set; }
         public int? Budget { get; set; }
         public DateTime CreatedDate { get; set; }
+        public DateTime? StartDate { get; set; }
         public IList<ProjectCategoryDTO> ProjectCategories { get; set; }
         public IList<UserProfileDTO> Users { get; set; }
     }

--- a/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
@@ -15,8 +15,8 @@ namespace FRF.Web.Dtos.Projects
         [Required]
         [Range(1, 1000000000000, ErrorMessage = "Budget have to be greater than {1}")]
         public int? Budget { get; set; }
+        public DateTime? StartDate { get; set; }
         public IList<ProjectCategoryDTO> ProjectCategories { get; set; }
-        [Required, MinLength(1)]
         public IList<UserProfileUpsertDTO> Users { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -1,6 +1,7 @@
 ﻿import {
     Button, Card, CardActions, CardContent,
-    Chip, FormControl, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Typography
+    Checkbox,
+    Chip, FormControl, FormControlLabel, FormGroup, Grid, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Typography
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
@@ -48,6 +49,7 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
     const { register, handleSubmit, errors } = useForm();
     const [isValid] = React.useState<boolean>(true);
     const [tempCategories, setTempCategories] = React.useState([...props.categories]);
+    const [startDateEnabled, setStartDateEnabled] = React.useState(props.project.startDate ? true : false);
     const [state, setState] = React.useState({
         name: props.project.name,
         client: props.project.client,
@@ -57,6 +59,7 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
         id: props.project.id,
         projectCategories: props.project.projectCategories,
         users: props.project.users,
+        startDate: props.project.startDate,
         selectedCategories: props.project.projectCategories.map(pc => pc.category)
     });
 
@@ -121,7 +124,8 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
     const handleConfirm = async () => {
         var projectCategories = await props.fillProjectCategories(state.selectedCategories);
         const { name, client, owner, budget, id, createdDate, users } = state;
-        const project = { name, client, owner, budget, id, createdDate, projectCategories, users }
+        var startDate = startDateEnabled && state.startDate ? new Date(state.startDate) : null;
+        const project = { name, client, owner, budget, id, createdDate, startDate, projectCategories, users }
         const response = await ProjectService.update(id, project as Project);
         if (response.status === 200) {
             props.openSnackbar({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
@@ -231,6 +235,42 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
                                 />
                             )}
                         />
+                        <Grid>
+                            <Grid container spacing={3}>
+                                <Grid item xs={8}>
+                                    <TextField
+                                        id="startDate"
+                                        type="date"
+                                        name="startDate"
+                                        inputRef={register({ validate: { isValid: value => !startDateEnabled || value >= new Date().toISOString().slice(0, 10) } })}
+                                        error={errors.startDate ? true : false}
+                                        defaultValue={props.project.startDate ? new Date(props.project.startDate).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}
+                                        onChange={handleChange}
+                                        className={classes.inputF}
+                                        InputLabelProps={{
+                                            shrink: true,
+                                        }}
+                                        helperText={errors.startDate ? "La fecha no puede ser anterior a hoy" : null}
+                                        fullWidth
+                                        disabled={!startDateEnabled}
+                                    />
+                                </Grid>
+                                <Grid item xs={4}>
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                checked={startDateEnabled}
+                                                onChange={() => setStartDateEnabled(!startDateEnabled)}
+                                                name="checkedB"
+                                                color="primary"
+                                            />
+                                        }
+                                        label="Fecha de inicio"
+                                        style={{ height: '100%' }}
+                                    />
+                                </Grid>
+                            </Grid>
+                        </Grid>
                     </Typography>
                     <Typography className={classes.title} color="textSecondary" gutterBottom>
                         Usuarios

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -1,6 +1,6 @@
 ﻿import {
     Button, Chip, Dialog, DialogActions, DialogContent, DialogContentText,
-    DialogTitle, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps
+    DialogTitle, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Grid, FormControlLabel, Checkbox
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
@@ -39,6 +39,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
     const email = React.useRef<TextFieldProps>(null);
     const [fieldEmail, setFieldEmail] = React.useState<string | null>("")
     const [selectedCategories, setSelectedCategories] = React.useState([] as Category[]);
+    const [startDateEnabled, setStartDateEnabled] = React.useState(true);
     const classes = useStyles();
     const { user }  = useUser();
 
@@ -49,6 +50,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
         client: "",
         owner: "",
         budget: -1,
+        startDate: new Date().toISOString().slice(0, 10),
         users: [] as UserProfile[],
     });
 
@@ -58,6 +60,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
             client: "",
             owner: "",
             budget: -1,
+            startDate: new Date().toISOString().slice(0, 10),
             users: []
         });
     }
@@ -108,7 +111,8 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
     const handleConfirm = async () => {
         var projectCategories = await props.fillProjectCategories(selectedCategories);
         const { name, client, owner, budget, users } = state;
-        const project = { name, client, owner, budget, projectCategories, users }
+        var startDate = startDateEnabled ? new Date(state.startDate) : null;
+        const project = { name, client, owner, budget, startDate, projectCategories, users }
         const response = await ProjectService.save(project as Project);
         if (response.status === 200) {
             props.openSnackbar({ message: "El proyecto ha sido creado con éxito", severity: "success" });
@@ -188,6 +192,42 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
                         fullWidth
                     />
                     <ManageCategories categories={props.categories} selectedCategories={selectedCategories} setSelectedCategories={setSelectedCategories} />
+                    <Grid>
+                        <Grid container spacing={3}>
+                            <Grid item xs={8}>
+                                <TextField
+                                    id="startDate"
+                                    type="date"
+                                    name="startDate"
+                                    inputRef={register({ validate: { isValid: value => !startDateEnabled || value >= new Date().toISOString().slice(0, 10) } })}
+                                    error={errors.startDate ? true : false}
+                                    defaultValue={new Date().toISOString().slice(0, 10)}
+                                    onChange={handleChange}
+                                    className={classes.inputF}
+                                    InputLabelProps={{
+                                        shrink: true,
+                                    }}
+                                    helperText={errors.startDate ? "La fecha no puede ser anterior a hoy" : null}
+                                    fullWidth
+                                    disabled={!startDateEnabled}
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={startDateEnabled}
+                                            onChange={() => setStartDateEnabled(!startDateEnabled)}
+                                            name="checkedB"
+                                            color="primary"
+                                        />
+                                    }
+                                    label="Fecha de inicio"
+                                    style={{ height: '100%' }}
+                                />
+                            </Grid>
+                        </Grid>
+                    </Grid>
                     <FormGroup>
                         <Paper component="ul" className={classes.addUser} >
                             {state.users.map((user,index) => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Project.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Project.ts
@@ -9,6 +9,7 @@ export default interface Project {
     budget: number;
     createdDate: Date;
     modifiedDate: Date;
+    startDate: Date | null;
     projectCategories: ProjectCategory[];
     users: UserProfile[];
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ProjectService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ProjectService.ts
@@ -15,6 +15,7 @@ export default class ProjectService {
                     client: project.client,
                     budget: project.budget,
                     projectCategories: project.projectCategories,
+                    startDate: project.startDate,
                     users: project.users.map((parameter) => ({ userId: parameter.userId }))
                 });
         } catch (error) {
@@ -33,6 +34,7 @@ export default class ProjectService {
                     createdDate: project.createdDate,
                     budget: project.budget,
                     projectCategories: project.projectCategories,
+                    startDate: project.startDate,
                     users: project.users.map((parameter) => ({ userId: parameter.userId }))
                 });
         } catch (error) {

--- a/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ArtifactsServiceTests.cs
@@ -685,7 +685,7 @@ namespace FRF.Core.Tests.Services
                 Project = _mapper.Map<CoreModels.Project>(project),
                 ArtifactTypeId = artifactType.Id,
                 ArtifactType = _mapper.Map<CoreModels.ArtifactType>(artifactType),
-                Settings = new XElement("Settings", new XElement(setting1Name, updatedSetting1Value))
+                Settings = new XElement("Settings", new XElement(setting1Name, updatedSetting1Value, new XAttribute("type", SettingTypes.Decimal)))
             };
 
             _settingsValidator.Setup(mock => mock.ValidateSettings(It.IsAny<CoreModels.Artifact>()))

--- a/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
@@ -340,6 +340,7 @@ namespace FRF.Core.Tests.Services
             projectToUpdate.Client = "[Mock] Updated Project Client";
             projectToUpdate.Budget = 50000;
             projectToUpdate.CreatedDate = project.CreatedDate;
+            projectToUpdate.StartDate = project.StartDate?.AddDays(2);
             projectToUpdate.UsersByProject = new List<UsersProfile>
             {
                 userByProject
@@ -362,6 +363,7 @@ namespace FRF.Core.Tests.Services
             Assert.Equal(projectToUpdate.Client, resultValue.Client);
             Assert.Equal(projectToUpdate.Budget, resultValue.Budget);
             Assert.Equal(projectToUpdate.CreatedDate, resultValue.CreatedDate);
+            Assert.Equal(projectToUpdate.StartDate, resultValue.StartDate);
             Assert.NotNull(resultValue.ModifiedDate);
             Assert.Equal(projectToUpdate.UsersByProject.ToList()[0].UserId, resultValue.UsersByProject.ToList()[0].UserId);
         }

--- a/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ProjectsServiceTests.cs
@@ -44,6 +44,7 @@ namespace FRF.Core.Tests.Services
             project.Client = "[MOCK] Project client";
             project.Budget = 1000;
             project.CreatedDate = DateTime.Now;
+            project.StartDate = DateTime.Now.AddDays(1);
             project.ProjectCategories = new List<DataAccess.EntityModels.ProjectCategory>();
             _dataAccess.Projects.Add(project);
             _dataAccess.SaveChanges();
@@ -268,6 +269,48 @@ namespace FRF.Core.Tests.Services
         }
 
         [Fact]
+        public async Task SaveAsync_ReturnsErrorInvalidStartDate()
+        {
+            // Arange
+            var userByProject = new UsersProfile()
+            {
+                UserId = new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba")
+            };
+
+            var project = CreateProject();
+            CreateUserByProject(project);
+
+            var category = CreateCategory();
+
+            var projectToSave = new CoreModels.Project();
+            projectToSave.Name = "[Mock] Project name 1";
+            projectToSave.Owner = "[Mock] Project Owner";
+            projectToSave.Client = "[Mock] Project Client";
+            projectToSave.CreatedDate = DateTime.Now;
+            projectToSave.StartDate = DateTime.Now.AddDays(-1);
+            projectToSave.UsersByProject = new List<UsersProfile>
+            {
+                userByProject
+            };
+
+            var projectCategories = new CoreModels.ProjectCategory();
+            projectCategories.Category = _mapper.Map<CoreModels.Category>(category);
+
+            projectToSave.ProjectCategories = new List<CoreModels.ProjectCategory>
+            {
+                projectCategories
+            };
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectToSave);
+
+            // Assert
+            Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.InvalidStartDateForProject, result.Error.Code);
+        }
+
+        [Fact]
         public async Task UpdateAsync_ReturnsProject()
         {
             // Arange
@@ -402,6 +445,55 @@ namespace FRF.Core.Tests.Services
             Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
             Assert.False(result.Success);
             Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsErrorInvalidStartDate()
+        {
+            // Arange
+            var project = CreateProject();
+            project.StartDate = DateTime.Now.AddDays(-1);
+            CreateUserByProject(project);
+            var category = CreateCategory();
+
+            var projectCategory = new CoreModels.ProjectCategory()
+            {
+                Category = new CoreModels.Category()
+                {
+                    Id = category.Id,
+                    Name = category.Name,
+                    Description = category.Description
+                }
+            };
+
+            var userByProject = new UsersProfile()
+            {
+                UserId = new Guid("c3c0b740-1c8f-49a0-a5d7-2354cb9b6eba")
+            };
+
+            var projectToUpdate = new CoreModels.Project();
+            projectToUpdate.Id = project.Id;
+            projectToUpdate.Name = "[Mock] Project name 1";
+            projectToUpdate.Owner = "[Mock] Project Owner";
+            projectToUpdate.Client = "[Mock] Project Client";
+            projectToUpdate.CreatedDate = project.CreatedDate;
+            projectToUpdate.StartDate = project.StartDate;
+            projectToUpdate.UsersByProject = new List<UsersProfile>
+            {
+                userByProject
+            };
+            projectToUpdate.ProjectCategories = new List<CoreModels.ProjectCategory>()
+            {
+                projectCategory
+            };
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(projectToUpdate);
+
+            // Assert
+            Assert.IsType<ServiceResponse<CoreModels.Project>>(result);
+            Assert.False(result.Success);
+            Assert.Equal(ErrorCodes.InvalidStartDateForProject, result.Error.Code);
         }
 
         [Fact]


### PR DESCRIPTION
Se debe modificar los modelos de proyectos para incluir una fecha de inicio para el proyecto. Además se deben modificar los métodos SaveAsync y UpdateAsync del servicio de proyectos para verificar que la fecha de inicio del proyecto no sea anterior a la fecha de creación.

Cambios realizados

- Se agregó el campo StartDate en el Model y en el EntityModels de Projects

- Se agregó el código de error InvalidStartDateForProject

- Se agregó la validación de que el fecha de inicio del proyecto sea posterior a la fecha de creación del proyecto en los métodos SaveAsync y UpdateAsync del servicio de proyectos

- Se agregaron tests a la clase ProjectsServiceTests para verificar las validaciones anteriormente mencionadas

- Se arregló un error un test de la clase ArtifactsServiceTests