### PR TITLE
[FIVE-405] (Frontend) Actualizar proyectos para contar con una fecha estimada de inicio

### DIFF
--- a/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectDTO.cs
@@ -16,6 +16,7 @@ namespace FRF.Web.Dtos
         public string? Client { get; set; }
         public int? Budget { get; set; }
         public DateTime CreatedDate { get; set; }
+        public DateTime? StartDate { get; set; }
         public IList<ProjectCategoryDTO> ProjectCategories { get; set; }
         public IList<UserProfileDTO> Users { get; set; }
     }

--- a/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/Projects/ProjectUpsertDTO.cs
@@ -15,8 +15,8 @@ namespace FRF.Web.Dtos.Projects
         [Required]
         [Range(1, 1000000000000, ErrorMessage = "Budget have to be greater than {1}")]
         public int? Budget { get; set; }
+        public DateTime? StartDate { get; set; }
         public IList<ProjectCategoryDTO> ProjectCategories { get; set; }
-        [Required, MinLength(1)]
         public IList<UserProfileUpsertDTO> Users { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/EditProject.tsx
@@ -1,6 +1,7 @@
 ﻿import {
     Button, Card, CardActions, CardContent,
-    Chip, FormControl, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Typography
+    Checkbox,
+    Chip, FormControl, FormControlLabel, FormGroup, Grid, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Typography
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
@@ -48,6 +49,7 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
     const { register, handleSubmit, errors } = useForm();
     const [isValid] = React.useState<boolean>(true);
     const [tempCategories, setTempCategories] = React.useState([...props.categories]);
+    const [startDateEnabled, setStartDateEnabled] = React.useState(props.project.startDate ? true : false);
     const [state, setState] = React.useState({
         name: props.project.name,
         client: props.project.client,
@@ -57,6 +59,7 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
         id: props.project.id,
         projectCategories: props.project.projectCategories,
         users: props.project.users,
+        startDate: props.project.startDate,
         selectedCategories: props.project.projectCategories.map(pc => pc.category)
     });
 
@@ -121,7 +124,8 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
     const handleConfirm = async () => {
         var projectCategories = await props.fillProjectCategories(state.selectedCategories);
         const { name, client, owner, budget, id, createdDate, users } = state;
-        const project = { name, client, owner, budget, id, createdDate, projectCategories, users }
+        var startDate = startDateEnabled && state.startDate ? new Date(state.startDate) : null;
+        const project = { name, client, owner, budget, id, createdDate, startDate, projectCategories, users }
         const response = await ProjectService.update(id, project as Project);
         if (response.status === 200) {
             props.openSnackbar({ message: "El proyecto ha sido modificado con éxito", severity: "success" });
@@ -231,6 +235,42 @@ const EditProject = (props: { project: Project, cancelEdit: any, categories: Cat
                                 />
                             )}
                         />
+                        <Grid>
+                            <Grid container spacing={3}>
+                                <Grid item xs={8}>
+                                    <TextField
+                                        id="startDate"
+                                        type="date"
+                                        name="startDate"
+                                        inputRef={register({ validate: { isValid: value => !startDateEnabled || value >= new Date().toISOString().slice(0, 10) } })}
+                                        error={errors.startDate ? true : false}
+                                        defaultValue={props.project.startDate ? new Date(props.project.startDate).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}
+                                        onChange={handleChange}
+                                        className={classes.inputF}
+                                        InputLabelProps={{
+                                            shrink: true,
+                                        }}
+                                        helperText={errors.startDate ? "La fecha no puede ser anterior a hoy" : null}
+                                        fullWidth
+                                        disabled={!startDateEnabled}
+                                    />
+                                </Grid>
+                                <Grid item xs={4}>
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                checked={startDateEnabled}
+                                                onChange={() => setStartDateEnabled(!startDateEnabled)}
+                                                name="checkedB"
+                                                color="primary"
+                                            />
+                                        }
+                                        label="Fecha de inicio"
+                                        style={{ height: '100%' }}
+                                    />
+                                </Grid>
+                            </Grid>
+                        </Grid>
                     </Typography>
                     <Typography className={classes.title} color="textSecondary" gutterBottom>
                         Usuarios

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/components/ManageProjectsComponents/NewProjectDialog.tsx
@@ -1,6 +1,6 @@
 ﻿import {
     Button, Chip, Dialog, DialogActions, DialogContent, DialogContentText,
-    DialogTitle, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps
+    DialogTitle, FormGroup, IconButton, InputAdornment, Paper, TextField, TextFieldProps, Grid, FormControlLabel, Checkbox
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
@@ -39,6 +39,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
     const email = React.useRef<TextFieldProps>(null);
     const [fieldEmail, setFieldEmail] = React.useState<string | null>("")
     const [selectedCategories, setSelectedCategories] = React.useState([] as Category[]);
+    const [startDateEnabled, setStartDateEnabled] = React.useState(true);
     const classes = useStyles();
     const { user }  = useUser();
 
@@ -49,6 +50,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
         client: "",
         owner: "",
         budget: -1,
+        startDate: new Date().toISOString().slice(0, 10),
         users: [] as UserProfile[],
     });
 
@@ -58,6 +60,7 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
             client: "",
             owner: "",
             budget: -1,
+            startDate: new Date().toISOString().slice(0, 10),
             users: []
         });
     }
@@ -108,7 +111,8 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
     const handleConfirm = async () => {
         var projectCategories = await props.fillProjectCategories(selectedCategories);
         const { name, client, owner, budget, users } = state;
-        const project = { name, client, owner, budget, projectCategories, users }
+        var startDate = startDateEnabled ? new Date(state.startDate) : null;
+        const project = { name, client, owner, budget, startDate, projectCategories, users }
         const response = await ProjectService.save(project as Project);
         if (response.status === 200) {
             props.openSnackbar({ message: "El proyecto ha sido creado con éxito", severity: "success" });
@@ -188,6 +192,42 @@ const NewProjectDialog = (props: { create: boolean, categories: Category[], fini
                         fullWidth
                     />
                     <ManageCategories categories={props.categories} selectedCategories={selectedCategories} setSelectedCategories={setSelectedCategories} />
+                    <Grid>
+                        <Grid container spacing={3}>
+                            <Grid item xs={8}>
+                                <TextField
+                                    id="startDate"
+                                    type="date"
+                                    name="startDate"
+                                    inputRef={register({ validate: { isValid: value => !startDateEnabled || value >= new Date().toISOString().slice(0, 10) } })}
+                                    error={errors.startDate ? true : false}
+                                    defaultValue={new Date().toISOString().slice(0, 10)}
+                                    onChange={handleChange}
+                                    className={classes.inputF}
+                                    InputLabelProps={{
+                                        shrink: true,
+                                    }}
+                                    helperText={errors.startDate ? "La fecha no puede ser anterior a hoy" : null}
+                                    fullWidth
+                                    disabled={!startDateEnabled}
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={startDateEnabled}
+                                            onChange={() => setStartDateEnabled(!startDateEnabled)}
+                                            name="checkedB"
+                                            color="primary"
+                                        />
+                                    }
+                                    label="Fecha de inicio"
+                                    style={{ height: '100%' }}
+                                />
+                            </Grid>
+                        </Grid>
+                    </Grid>
                     <FormGroup>
                         <Paper component="ul" className={classes.addUser} >
                             {state.users.map((user,index) => {

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Project.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/interfaces/Project.ts
@@ -9,6 +9,7 @@ export default interface Project {
     budget: number;
     createdDate: Date;
     modifiedDate: Date;
+    startDate: Date | null;
     projectCategories: ProjectCategory[];
     users: UserProfile[];
 }

--- a/FiveRockingFingers/FRF.Web/ClientApp/src/services/ProjectService.ts
+++ b/FiveRockingFingers/FRF.Web/ClientApp/src/services/ProjectService.ts
@@ -15,6 +15,7 @@ export default class ProjectService {
                     client: project.client,
                     budget: project.budget,
                     projectCategories: project.projectCategories,
+                    startDate: project.startDate,
                     users: project.users.map((parameter) => ({ userId: parameter.userId }))
                 });
         } catch (error) {
@@ -33,6 +34,7 @@ export default class ProjectService {
                     createdDate: project.createdDate,
                     budget: project.budget,
                     projectCategories: project.projectCategories,
+                    startDate: project.startDate,
                     users: project.users.map((parameter) => ({ userId: parameter.userId }))
                 });
         } catch (error) {


### PR DESCRIPTION
## Tarea a realizar
Se debe modificar el FrontEnd para solicitar una fecha de inicio estimada tanto en la creación como la modificación (nuevamente, puede ser nula).

## Cambios realizados
- Se modifican los DTO y la interfaz de proyectos para contar con la fecha de inicio.
- Se modifican los formularios de creación y modificación de proyectos para dar la posibilidad de establecerles una fecha de inicio.

En la imagen se puede ver el cambio en el formulario de creación (en el de modificación en similar), donde es necesario establecer una fecha de inicio, salvo que el usuario deshabilite el tilde del lado derecho. Esta fecha (en caso de estar habilitado el tilde) se valida con la fecha de hoy, para no crear un proyecto con una fecha de inicio pasada. En caso de estar deshabilitada, no se realiza dicha validación

![image](https://user-images.githubusercontent.com/71275374/114929229-e93e4a80-9e09-11eb-8ddc-832810732b63.png)

En caso de deshabilitar el tilde derecho, se deshabilita el campo de fecha, y el proyecto se crea con fecha de inicio nula.
![image](https://user-images.githubusercontent.com/71275374/114929617-6bc70a00-9e0a-11eb-8a21-b5838609ad30.png)
