### PR TITLE
[FIVE-416] Crear tabla project-modules

### DIFF
--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -18,7 +18,8 @@ namespace FRF.Core
             CreateMap<DataAccess.EntityModels.Category, Models.Category>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())
-                .ForMember(dest => dest.ProjectCategories, act => act.Ignore());
+                .ForMember(dest => dest.ProjectCategories, act => act.Ignore())
+                .ForMember(dest => dest.CategoryModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ProjectCategory, Models.ProjectCategory>()
                 .ReverseMap();
             CreateMap<DataAccess.EntityModels.Artifact, Models.Artifact>()
@@ -61,12 +62,16 @@ namespace FRF.Core
             CreateMap<DataAccess.EntityModels.Module, Models.Module>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())
-                .ForMember(dest => dest.ProjectModules, act => act.Ignore());
+                .ForMember(dest => dest.ProjectModules, act => act.Ignore())
+                .ForMember(dest => dest.Id, act => act.Ignore())
+                .ForMember(dest => dest.CategoryModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ProjectModule, Models.ProjectModule>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())
                 .ForMember(dest => dest.Project, act => act.Ignore())
                 .ForMember(dest => dest.Module, act => act.Ignore());
+            CreateMap<DataAccess.EntityModels.CategoryModule, Models.CategoryModule>()
+                .ReverseMap();
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -60,6 +60,11 @@ namespace FRF.Core
             CreateMap<DataAccess.EntityModels.Module, Models.Module>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore());
+            CreateMap<DataAccess.EntityModels.ProjectModule, Models.ProjectModule>()
+                .ReverseMap()
+                .ForMember(dest => dest.Id, act => act.Ignore())
+                .ForMember(dest => dest.Project, act => act.Ignore())
+                .ForMember(dest => dest.Module, act => act.Ignore());
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -60,7 +60,8 @@ namespace FRF.Core
                 .ForMember(dest => dest.Resource, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.Module, Models.Module>()
                 .ReverseMap()
-                .ForMember(dest => dest.Id, act => act.Ignore());
+                .ForMember(dest => dest.Id, act => act.Ignore())
+                .ForMember(dest => dest.ProjectModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ProjectModule, Models.ProjectModule>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())

--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -13,7 +13,8 @@ namespace FRF.Core
                 .ForMember(dest => dest.Id, act => act.Ignore())
                 .ForMember(dest => dest.UsersByProject, act => act.Ignore())
                 .ForMember(dest => dest.ProjectCategories, act => act.Ignore())
-                .ForMember(dest => dest.ProjectResource, act => act.Ignore());
+                .ForMember(dest => dest.ProjectResource, act => act.Ignore())
+                .ForMember(dest => dest.ProjectModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.Category, Models.Category>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())

--- a/FiveRockingFingers/FRF.Core/Models/Category.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Category.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace FRF.Core.Models
 {
@@ -12,5 +10,6 @@ namespace FRF.Core.Models
         public string? Description { get; set; }
 #nullable disable
         public IList<ProjectCategory> ProjectCategories { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/CategoryModule.cs
+++ b/FiveRockingFingers/FRF.Core/Models/CategoryModule.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Core.Models
+{
+    public class CategoryModule
+    {
+        public Category Category { get; set; }
+        public Module Module { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Models/Module.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Module.cs
@@ -8,6 +8,7 @@ namespace FRF.Core.Models
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
         public IList<ProjectModule> ProjectModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Module.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Module.cs
@@ -1,4 +1,6 @@
-﻿namespace FRF.Core.Models
+﻿using System.Collections.Generic;
+
+namespace FRF.Core.Models
 {
     public class Module
     {
@@ -6,5 +8,6 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<ProjectModule> ProjectModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Project.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Project.cs
@@ -16,5 +16,6 @@ namespace FRF.Core.Models
         public IList<ProjectCategory> ProjectCategories { get; set; }
         public ICollection<UsersProfile> UsersByProject { get; set; }
         public IList<ProjectResource> ProjectResource { get; set; }
+        public IList<ProjectModule> ProjectModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/ProjectModule.cs
+++ b/FiveRockingFingers/FRF.Core/Models/ProjectModule.cs
@@ -1,0 +1,13 @@
+﻿namespace FRF.Core.Models
+{
+    public class ProjectModule
+    {
+        public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public Project Project { get; set; }
+        public int ModuleId { get; set; }
+        public Module Module { get; set; }
+        public string Alias { get; set; }
+        public int Cost { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
+++ b/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
@@ -20,6 +20,7 @@ namespace FRF.DataAccess
         public DbSet<ProjectResource> ProjectResources { get; set; }
         public DbSet<Module> Modules { get; set; }
         public DbSet<ProjectModule> ProjectModules { get; set; }
+        public DbSet<CategoryModule> CategoriesModules { get; set; }
 
         public DataAccessContext(DbContextOptions<DataAccessContext> options, IConfiguration configuration) : base(options)
         {
@@ -37,6 +38,7 @@ namespace FRF.DataAccess
             builder.Entity<ProjectResource>().HasKey(pr => new { pr.Id});
             builder.Entity<Module>().HasKey(m => new { m.Id});
             builder.Entity<ProjectModule>().HasKey(pm => new { pm.Id});
+            builder.Entity<CategoryModule>().HasKey(cm => new { cm.CategoryId, cm.ModuleId});
         }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
+++ b/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
@@ -19,6 +19,7 @@ namespace FRF.DataAccess
         public DbSet<Resource> Resources { get; set; }
         public DbSet<ProjectResource> ProjectResources { get; set; }
         public DbSet<Module> Modules { get; set; }
+        public DbSet<ProjectModule> ProjectModules { get; set; }
 
         public DataAccessContext(DbContextOptions<DataAccessContext> options, IConfiguration configuration) : base(options)
         {
@@ -35,6 +36,7 @@ namespace FRF.DataAccess
             builder.Entity<Resource>().HasKey(re => new {re.Id});
             builder.Entity<ProjectResource>().HasKey(pr => new { pr.Id});
             builder.Entity<Module>().HasKey(m => new { m.Id});
+            builder.Entity<ProjectModule>().HasKey(pm => new { pm.Id});
         }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_CategoriesModules.sql
+++ b/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_CategoriesModules.sql
@@ -1,0 +1,14 @@
+CREATE TABLE [dbo].[CategoriesModules](
+	[ModuleId] [int] NOT NULL,
+	[CategoryId] [int] NOT NULL
+) ON [PRIMARY]
+
+ALTER TABLE [dbo].[CategoriesModules]  WITH CHECK ADD  CONSTRAINT [FK_CategoriesModules_Categories] FOREIGN KEY([CategoryId])
+REFERENCES [dbo].[Categories] ([Id])
+
+ALTER TABLE [dbo].[CategoriesModules] CHECK CONSTRAINT [FK_CategoriesModules_Categories]
+
+ALTER TABLE [dbo].[CategoriesModules]  WITH CHECK ADD  CONSTRAINT [FK_CategoriesModules_Modules] FOREIGN KEY([ModuleId])
+REFERENCES [dbo].[Modules] ([Id])
+
+ALTER TABLE [dbo].[CategoriesModules] CHECK CONSTRAINT [FK_CategoriesModules_Modules]

--- a/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_ProjectModules.sql
+++ b/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_ProjectModules.sql
@@ -1,0 +1,21 @@
+CREATE TABLE [dbo].[ProjectModules](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[ProjectId] [int] NOT NULL,
+	[ModuleId] [int] NOT NULL,
+	[Alias] [nvarchar](50) NOT NULL,
+	[Cost] [int] NOT NULL,
+ CONSTRAINT [PK_ProjectModules] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+
+ALTER TABLE [dbo].[ProjectModules]  WITH CHECK ADD  CONSTRAINT [FK_ProjectModules_Modules] FOREIGN KEY([ModuleId])
+REFERENCES [dbo].[Modules] ([Id])
+
+ALTER TABLE [dbo].[ProjectModules] CHECK CONSTRAINT [FK_ProjectModules_Modules]
+
+ALTER TABLE [dbo].[ProjectModules]  WITH CHECK ADD  CONSTRAINT [FK_ProjectModules_Projects] FOREIGN KEY([ProjectId])
+REFERENCES [dbo].[Projects] ([Id])
+
+ALTER TABLE [dbo].[ProjectModules] CHECK CONSTRAINT [FK_ProjectModules_Projects]

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Category.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Category.cs
@@ -15,5 +15,6 @@ namespace FRF.DataAccess.EntityModels
         public string? Description { get; set; }
         #nullable disable
         public IList<ProjectCategory> ProjectCategories { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/CategoryModule.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/CategoryModule.cs
@@ -1,0 +1,10 @@
+﻿namespace FRF.DataAccess.EntityModels
+{
+    public class CategoryModule
+    {
+        public int CategoryId { get; set; }
+        public Category Category { get; set; }
+        public int ModuleId { get; set; }
+        public Module Module { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
@@ -8,6 +8,7 @@ namespace FRF.DataAccess.EntityModels
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
         public IList<ProjectModule> ProjectModules { get; set; } 
 
     }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
@@ -1,4 +1,6 @@
-﻿namespace FRF.DataAccess.EntityModels
+﻿using System.Collections.Generic;
+
+namespace FRF.DataAccess.EntityModels
 {
     public class Module
     {
@@ -6,5 +8,7 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<ProjectModule> ProjectModules { get; set; } 
+
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Project.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Project.cs
@@ -20,5 +20,6 @@ namespace FRF.DataAccess.EntityModels
         public IList<ProjectCategory> ProjectCategories { get; set; }
         public ICollection<UsersByProject> UsersByProject { get; set; }
         public IList<ProjectResource> ProjectResource { get; set; } 
+        public IList<ProjectModule> ProjectModules { get; set; } 
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/ProjectModule.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/ProjectModule.cs
@@ -1,0 +1,13 @@
+﻿namespace FRF.DataAccess.EntityModels
+{
+    public class ProjectModule
+    {
+        public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public Project Project { get; set; }
+        public int ModuleId { get; set; }
+        public Module Module { get; set; }
+        public string Alias { get; set; }
+        public int Cost { get; set; }
+    }
+}


### PR DESCRIPTION
### Descripción:
Se debe crear la tabla ProjectModules en base de datos con los siguientes atributos.

- Id (int)
- ProjectId (int)
- ModuleId (int)
- Alias (nvarchar)
- Cost (int) (considerando que son puntos de historia)

Además de esto, se debe crear el EntityModel correspondiente a esta tabla.
### Realizado:
- Se creó script de creación de tabla ProjectModules
- Se creó EntityModel y Model ProjectModule.
- Se configuró DataAccessContext para que EF relaciones la nueva tabla ProjectModules con la clase ProjectModule.
- Se configuró AutoMapperProfile para realizar mapeo entre EntityModel y ProjectModel.
- Se agregó referencia a ProjectModule en clase Project
- Se agregó navigator de ProjectModules en clase Module.