### PR TITLE
[FIVE-417] Crear tabla categories-modules

### DIFF
--- a/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Core/AutoMapperProfile.cs
@@ -18,7 +18,8 @@ namespace FRF.Core
             CreateMap<DataAccess.EntityModels.Category, Models.Category>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())
-                .ForMember(dest => dest.ProjectCategories, act => act.Ignore());
+                .ForMember(dest => dest.ProjectCategories, act => act.Ignore())
+                .ForMember(dest => dest.CategoryModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ProjectCategory, Models.ProjectCategory>()
                 .ReverseMap();
             CreateMap<DataAccess.EntityModels.Artifact, Models.Artifact>()
@@ -60,12 +61,15 @@ namespace FRF.Core
                 .ForMember(dest => dest.Resource, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.Module, Models.Module>()
                 .ReverseMap()
-                .ForMember(dest => dest.Id, act => act.Ignore());
+                .ForMember(dest => dest.Id, act => act.Ignore())
+                .ForMember(dest => dest.CategoryModules, act => act.Ignore());
             CreateMap<DataAccess.EntityModels.ProjectModule, Models.ProjectModule>()
                 .ReverseMap()
                 .ForMember(dest => dest.Id, act => act.Ignore())
                 .ForMember(dest => dest.Project, act => act.Ignore())
                 .ForMember(dest => dest.Module, act => act.Ignore());
+            CreateMap<DataAccess.EntityModels.CategoryModule, Models.CategoryModule>()
+                .ReverseMap();
         }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/Category.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Category.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace FRF.Core.Models
 {
@@ -12,5 +10,6 @@ namespace FRF.Core.Models
         public string? Description { get; set; }
 #nullable disable
         public IList<ProjectCategory> ProjectCategories { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.Core/Models/CategoryModule.cs
+++ b/FiveRockingFingers/FRF.Core/Models/CategoryModule.cs
@@ -1,0 +1,8 @@
+﻿namespace FRF.Core.Models
+{
+    public class CategoryModule
+    {
+        public Category Category { get; set; }
+        public Module Module { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Models/Module.cs
+++ b/FiveRockingFingers/FRF.Core/Models/Module.cs
@@ -1,4 +1,6 @@
-﻿namespace FRF.Core.Models
+﻿using System.Collections.Generic;
+
+namespace FRF.Core.Models
 {
     public class Module
     {
@@ -6,5 +8,6 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
+++ b/FiveRockingFingers/FRF.DataAccess/DataAccessContext.cs
@@ -20,6 +20,7 @@ namespace FRF.DataAccess
         public DbSet<ProjectResource> ProjectResources { get; set; }
         public DbSet<Module> Modules { get; set; }
         public DbSet<ProjectModule> ProjectModules { get; set; }
+        public DbSet<CategoryModule> CategoriesModules { get; set; }
 
         public DataAccessContext(DbContextOptions<DataAccessContext> options, IConfiguration configuration) : base(options)
         {
@@ -37,6 +38,7 @@ namespace FRF.DataAccess
             builder.Entity<ProjectResource>().HasKey(pr => new { pr.Id});
             builder.Entity<Module>().HasKey(m => new { m.Id});
             builder.Entity<ProjectModule>().HasKey(pm => new { pm.Id});
+            builder.Entity<CategoryModule>().HasKey(cm => new { cm.CategoryId, cm.ModuleId});
         }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_CategoriesModules.sql
+++ b/FiveRockingFingers/FRF.DataAccess/DbScripts/Script_Create_CategoriesModules.sql
@@ -1,0 +1,14 @@
+CREATE TABLE [dbo].[CategoriesModules](
+	[ModuleId] [int] NOT NULL,
+	[CategoryId] [int] NOT NULL
+) ON [PRIMARY]
+
+ALTER TABLE [dbo].[CategoriesModules]  WITH CHECK ADD  CONSTRAINT [FK_CategoriesModules_Categories] FOREIGN KEY([CategoryId])
+REFERENCES [dbo].[Categories] ([Id])
+
+ALTER TABLE [dbo].[CategoriesModules] CHECK CONSTRAINT [FK_CategoriesModules_Categories]
+
+ALTER TABLE [dbo].[CategoriesModules]  WITH CHECK ADD  CONSTRAINT [FK_CategoriesModules_Modules] FOREIGN KEY([ModuleId])
+REFERENCES [dbo].[Modules] ([Id])
+
+ALTER TABLE [dbo].[CategoriesModules] CHECK CONSTRAINT [FK_CategoriesModules_Modules]

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Category.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Category.cs
@@ -15,5 +15,6 @@ namespace FRF.DataAccess.EntityModels
         public string? Description { get; set; }
         #nullable disable
         public IList<ProjectCategory> ProjectCategories { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/CategoryModule.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/CategoryModule.cs
@@ -1,0 +1,10 @@
+﻿namespace FRF.DataAccess.EntityModels
+{
+    public class CategoryModule
+    {
+        public int CategoryId { get; set; }
+        public Category Category { get; set; }
+        public int ModuleId { get; set; }
+        public Module Module { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
+++ b/FiveRockingFingers/FRF.DataAccess/EntityModels/Module.cs
@@ -1,4 +1,6 @@
-﻿namespace FRF.DataAccess.EntityModels
+﻿using System.Collections.Generic;
+
+namespace FRF.DataAccess.EntityModels
 {
     public class Module
     {
@@ -6,5 +8,6 @@
         public string Name { get; set; }
         public string Description { get; set; }
         public int SuggestedCost { get; set; }
+        public IList<CategoryModule> CategoryModules { get; set; }
     }
 }


### PR DESCRIPTION
### Descripción:
Se debe crear la tabla CategoriesModules en base de datos con los siguientes atributos.

- ModuleId (int)
- CategoryId (int)

Se deben modificar los EntityModels de Module y Category para que los Modules incluyan las categories y las categories incluyan a los modules.
### Realizado:
- Se creó script de creación de tabla CategoriesModules
- Se creó EntityModel y Model CategoryModule.
- Se configuró DataAccessContext para que EF relaciones la nueva tabla CategoriesModules con la clase CategoryModule.
- Se configuró AutoMapperProfile para realizar mapeo entre EntityModel y CategoryModel.
