### PR TITLE
[FIVE-419] (DAL) Crear Servicio y Controller de ProjectModules

### DIFF
--- a/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
+++ b/FiveRockingFingers/FRF.Core/Response/ErrorCodes.cs
@@ -33,5 +33,9 @@
 
         //Resources errors
         public const int ResourceNameRepeated = 50;
+
+        public const int ProjectModuleNotExists = 100;
+        public const int ModuleNotExists = 101;
+        public const int ModuleCostInvalid = 102;
     }
 }

--- a/FiveRockingFingers/FRF.Core/Services/IProjectModulesService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/IProjectModulesService.cs
@@ -1,0 +1,18 @@
+﻿using FRF.Core.Models;
+using FRF.Core.Response;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FRF.Core.Services
+{
+    public interface IProjectModulesService
+    {
+        public Task<ServiceResponse<ProjectModule>> GetAsync(int id);
+        public Task<ServiceResponse<List<ProjectModule>>> GetByProjectIdAsync(int projectId);
+        public Task<ServiceResponse<ProjectModule>> SaveAsync(ProjectModule projectModule);
+        public Task<ServiceResponse<ProjectModule>> UpdateAsync(ProjectModule projectModule);
+        public Task<ServiceResponse<ProjectModule>> DeleteAsync(int id);
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FRF.Core.Services
+{
+    public class ProjectModulesService : IProjectModulesService
+    {
+        private readonly DataAccessContext _dataContext;
+        private readonly IMapper _mapper;
+
+        public ProjectModulesService(DataAccessContext dataContext, IMapper mapper)
+        {
+            _dataContext = dataContext;
+            _mapper = mapper;
+        }
+
+        public async Task<ServiceResponse<ProjectModule>> GetAsync(int id)
+        {
+            var projectModule = await _dataContext.ProjectModules.SingleOrDefaultAsync(pm => pm.Id == id);
+
+            if (projectModule == null)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project resource with Id = {id}"));
+
+            var mappedProjectModule = _mapper.Map<ProjectModule>(projectModule);
+            return new ServiceResponse<ProjectModule>(mappedProjectModule);
+        }
+
+        public async Task<ServiceResponse<List<ProjectModule>>> GetByProjectIdAsync(int projectId)
+        {
+            if (!await _dataContext.Projects.AnyAsync(p => p.Id == projectId))
+                return new ServiceResponse<List<ProjectModule>>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {projectId}"));
+
+            var projectModules = await _dataContext.ProjectModules
+                .Where(pm => pm.ProjectId == projectId)
+                .ToListAsync();
+
+            var mappedProjectModules = _mapper.Map<List<ProjectModule>>(projectModules);
+
+            return new ServiceResponse<List<ProjectModule>>(mappedProjectModules);
+        }
+
+        public async Task<ServiceResponse<ProjectModule>> SaveAsync(ProjectModule projectModule)
+        {
+            var project = await _dataContext.Projects.SingleOrDefaultAsync(p => p.Id == projectModule.ProjectId);
+
+            if (project == null)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {projectModule.ProjectId}"));
+
+            if (!await _dataContext.Modules.AnyAsync(m => m.Id == projectModule.ModuleId))
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleNotExists, $"There is no module with Id = {projectModule.ModuleId}"));
+
+            if (projectModule.Cost < 0)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleCostInvalid, $"The cost of the module must be grater or equal to zero"));
+
+            // Maps the category into an EntityModel, deleting the Id if there was one.
+            var mappedProjectModule = _mapper.Map<DataAccess.EntityModels.ProjectModule>(projectModule);
+
+            // Adds the category to the database, generating a unique Id for it
+            await _dataContext.ProjectModules.AddAsync(mappedProjectModule);
+
+            // Saves changes
+            await _dataContext.SaveChangesAsync();
+
+            return new ServiceResponse<ProjectModule>(_mapper.Map<ProjectModule>(mappedProjectModule));
+        }
+
+        public async Task<ServiceResponse<ProjectModule>> UpdateAsync(ProjectModule projectModule)
+        {
+            var projectModuleResponse = await GetAsync(projectModule.Id);
+
+            if (!projectModuleResponse.Success)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project module with Id = {projectModule.ProjectId}"));
+
+            var project = await _dataContext.Projects.SingleOrDefaultAsync(p => p.Id == projectModule.ProjectId);
+
+            if (project == null)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {projectModule.ProjectId}"));
+
+            if (!await _dataContext.Modules.AnyAsync(m => m.Id == projectModule.ModuleId))
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleNotExists, $"There is no module with Id = {projectModule.ModuleId}"));
+
+            if (projectModule.Cost < 0)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleCostInvalid, $"The cost of the module must be grater or equal to zero"));
+
+            var result = await _dataContext.ProjectModules.SingleAsync(pm => pm.Id == projectModule.Id);
+            result.ModuleId = projectModule.ModuleId;
+            result.Alias = projectModule.Alias;
+            result.Cost = projectModule.Cost;
+
+            await _dataContext.SaveChangesAsync();
+
+            var mappedProjectModule = _mapper.Map<ProjectModule>(result);
+            return new ServiceResponse<ProjectModule>(mappedProjectModule);
+        }
+
+        public async Task<ServiceResponse<ProjectModule>> DeleteAsync(int id)
+        {
+            var projectModuleToDelete = await _dataContext.ProjectModules.SingleOrDefaultAsync(pm => pm.Id == id);
+
+            if (projectModuleToDelete == null)
+                return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project module with Id = {id}"));
+
+            _dataContext.ProjectModules.Remove(projectModuleToDelete);
+            await _dataContext.SaveChangesAsync();
+
+            var mappedProjectModule = _mapper.Map<ProjectModule>(projectModuleToDelete);
+            return new ServiceResponse<ProjectModule>(mappedProjectModule);
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
@@ -24,7 +24,7 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<ProjectModule>> GetAsync(int id)
         {
-            var projectModule = await _dataContext.ProjectModules.SingleOrDefaultAsync(pm => pm.Id == id);
+            var projectModule = await _dataContext.ProjectModules.FirstOrDefaultAsync(pm => pm.Id == id);
 
             if (projectModule == null)
                 return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project resource with Id = {id}"));
@@ -49,7 +49,7 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<ProjectModule>> SaveAsync(ProjectModule projectModule)
         {
-            var project = await _dataContext.Projects.SingleOrDefaultAsync(p => p.Id == projectModule.ProjectId);
+            var project = await _dataContext.Projects.FirstOrDefaultAsync(p => p.Id == projectModule.ProjectId);
 
             if (project == null)
                 return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {projectModule.ProjectId}"));

--- a/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
+++ b/FiveRockingFingers/FRF.Core/Services/ProjectModulesService.cs
@@ -79,7 +79,7 @@ namespace FRF.Core.Services
             if (!projectModuleResponse.Success)
                 return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project module with Id = {projectModule.ProjectId}"));
 
-            var project = await _dataContext.Projects.SingleOrDefaultAsync(p => p.Id == projectModule.ProjectId);
+            var project = await _dataContext.Projects.FirstOrDefaultAsync(p => p.Id == projectModule.ProjectId);
 
             if (project == null)
                 return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, $"There is no project with Id = {projectModule.ProjectId}"));
@@ -103,7 +103,7 @@ namespace FRF.Core.Services
 
         public async Task<ServiceResponse<ProjectModule>> DeleteAsync(int id)
         {
-            var projectModuleToDelete = await _dataContext.ProjectModules.SingleOrDefaultAsync(pm => pm.Id == id);
+            var projectModuleToDelete = await _dataContext.ProjectModules.FirstOrDefaultAsync(pm => pm.Id == id);
 
             if (projectModuleToDelete == null)
                 return new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, $"There is no project module with Id = {id}"));

--- a/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/AutoMapperProfile.cs
@@ -61,6 +61,7 @@ namespace FRF.Web.Dtos
             CreateMap<CategoryModule, CategoryModuleDTO>().ReverseMap();
             CreateMap<CategoryModuleUpsertDTO, CategoryModule>();
             CreateMap<CategoryUpsertDTO, Category>();
+            CreateMap<ProjectModuleUpsertDTO, ProjectModule>();
         }
     }
 }

--- a/FiveRockingFingers/FRF.Web.Dtos/ProjectModules/ProjectModuleUpsertDTO.cs
+++ b/FiveRockingFingers/FRF.Web.Dtos/ProjectModules/ProjectModuleUpsertDTO.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FRF.Web.Dtos.ProjectModules
+{
+    public class ProjectModuleUpsertDTO
+    {
+        public int ProjectId { get; set; }
+        public int ModuleId { get; set; }
+        public string Alias { get; set; }
+        public int Cost { get; set; }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Controllers/ProjectModulesController.cs
+++ b/FiveRockingFingers/FRF.Web/Controllers/ProjectModulesController.cs
@@ -1,0 +1,101 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.Core.Services;
+using FRF.Web.Dtos.ProjectModules;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FRF.Web.Controllers
+{
+    [ApiController]
+    [Route("api/project-modules")]
+    [Authorize]
+    public class ProjectModulesController : ControllerBase
+    {
+        private readonly IMapper _mapper;
+        private readonly IProjectModulesService _projectModulesService;
+
+        public ProjectModulesController(IProjectModulesService projectModulesService, IMapper mapper)
+        {
+            _projectModulesService = projectModulesService;
+            _mapper = mapper;
+        }
+
+        [HttpGet("~/api/projects/{projectId}/project-modules")]
+        public async Task<IActionResult> GetByProjectIdAsync(int projectId)
+        {
+            var projectModules = await _projectModulesService.GetByProjectIdAsync(projectId);
+
+            if (!projectModules.Success) return NotFound(projectModules.Error);
+
+            var projectModulesDto = _mapper.Map<IEnumerable<ProjectModuleDTO>>(projectModules.Value);
+
+            return Ok(projectModulesDto);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetAsync(int id)
+        {
+            var response = await _projectModulesService.GetAsync(id);
+
+            if (!response.Success) return NotFound(response.Error);
+
+            var projectModuleDto = _mapper.Map<ProjectModuleDTO>(response.Value);
+
+            return Ok(projectModuleDto);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> SaveAsync(ProjectModuleUpsertDTO projectModuleDto)
+        {
+            var projectModule = _mapper.Map<FRF.Core.Models.ProjectModule>(projectModuleDto);
+
+            var response = await _projectModulesService.SaveAsync(projectModule);
+
+            if (!response.Success && (response.Error.Code == ErrorCodes.ProjectNotExists || response.Error.Code == ErrorCodes.ModuleNotExists))
+                return NotFound(response.Error);
+
+            if (!response.Success && (response.Error.Code == ErrorCodes.ModuleCostInvalid))
+                return BadRequest(response.Error);
+
+            var projectModuleCreated = _mapper.Map<ProjectModuleDTO>(response.Value);
+
+            return Ok(projectModuleCreated);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateAsync(int id, ProjectModuleUpsertDTO projectModuleDto)
+        {
+
+            var projectModule = _mapper.Map<ProjectModule>(projectModuleDto);
+            projectModule.Id = id;
+
+            var response = await _projectModulesService.UpdateAsync(projectModule);
+
+            if (!response.Success && (response.Error.Code == ErrorCodes.ProjectNotExists || response.Error.Code == ErrorCodes.ModuleNotExists))
+                return NotFound(response.Error);
+
+            if (!response.Success && (response.Error.Code == ErrorCodes.ModuleCostInvalid))
+                return BadRequest(response.Error);
+
+            var updatedProjectModule = _mapper.Map<ProjectModuleDTO>(response.Value);
+
+            return Ok(updatedProjectModule);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteAsync(int id)
+        {
+            var response = await _projectModulesService.DeleteAsync(id);
+
+            if (!response.Success) return NotFound(response.Error);
+
+            return NoContent();
+        }
+    }
+}

--- a/FiveRockingFingers/FRF.Web/Startup.cs
+++ b/FiveRockingFingers/FRF.Web/Startup.cs
@@ -92,6 +92,7 @@ namespace FRF.Web
 			services.AddTransient<IBudgetService, BudgetService>();
 			services.AddTransient<ISettingsValidator, SettingsValidator>();
             services.AddTransient<IResourcesService, ResourcesService>();
+			services.AddTransient<IProjectModulesService, ProjectModulesService>();
 
 
 

--- a/test/FRF.Core.Tests/Services/ProjectModulesServiceTests.cs
+++ b/test/FRF.Core.Tests/Services/ProjectModulesServiceTests.cs
@@ -1,0 +1,401 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Core.Tests.Services
+{
+    public class ProjectModulesServiceTests
+    {
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly IMapper _mapper = MapperBuilder.Build();
+        private readonly DataAccessContextForTest _dataAccess;
+        private readonly ProjectModulesService _classUnderTest;
+
+        public ProjectModulesServiceTests()
+        {
+            _configuration = new Mock<IConfiguration>();
+
+            _dataAccess = new DataAccessContextForTest(Guid.NewGuid(), _configuration.Object);
+
+            _dataAccess.Database.EnsureDeleted();
+            _dataAccess.Database.EnsureCreated();
+
+            _classUnderTest = new ProjectModulesService(_dataAccess, _mapper);
+        }
+
+        private DataAccess.EntityModels.ProjectModule CreateProjectModule(int projectId, int moduleId)
+        {
+            var projectModule = new DataAccess.EntityModels.ProjectModule()
+            {
+                Alias = "[Mock] Alias",
+                Cost = 10,
+                ProjectId = projectId,
+                ModuleId = moduleId
+            };
+            _dataAccess.ProjectModules.Add(projectModule);
+            _dataAccess.SaveChanges();
+
+            return projectModule;
+        }
+
+        private DataAccess.EntityModels.Module CreateModule()
+        {
+            var module = new DataAccess.EntityModels.Module()
+            {
+                Name = "[Mock] Name",
+                Description = "[Mock] Description",
+                SuggestedCost = 10
+            };
+            _dataAccess.Modules.Add(module);
+            _dataAccess.SaveChanges();
+
+            return module;
+        }
+
+        private DataAccess.EntityModels.Project CreateProject()
+        {
+            var project = new DataAccess.EntityModels.Project()
+            {
+                Name = "[Mock] Project name",
+                Budget = 100,
+                ProjectCategories = new List<DataAccess.EntityModels.ProjectCategory>(),
+                StartDate = DateTime.Now
+            };
+
+            _dataAccess.Projects.Add(project);
+            _dataAccess.SaveChanges();
+
+            return project;
+        }
+
+        [Fact]
+        public async Task GetByProjectIdAsync_ReturnsList()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, module.Id);
+
+            // Act
+            var result = await _classUnderTest.GetByProjectIdAsync(project.Id);
+
+            // Assert
+            Assert.IsType<ServiceResponse<List<ProjectModule>>>(result);
+            Assert.True(result.Success);
+            var resultValue = Assert.Single(result.Value);
+
+            CompareProjectModules(_mapper.Map<ProjectModule>(projectModule), resultValue);
+        }
+
+        [Fact]
+        public async Task GetByProjectIdAsync_ReturnsEmptyList()
+        {
+            // Arrange
+            var project = CreateProject();
+
+            // Act
+            var result = await _classUnderTest.GetByProjectIdAsync(project.Id);
+
+            // Assert
+            Assert.IsType<ServiceResponse<List<ProjectModule>>>(result);
+            Assert.True(result.Success);
+            Assert.Empty(result.Value);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsProjectModule()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, module.Id);
+
+            // Act
+            var result = await _classUnderTest.GetAsync(projectModule.Id);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.True(result.Success);
+            var resultValue = result.Value;
+
+            CompareProjectModules(_mapper.Map<ProjectModule>(projectModule), resultValue);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsNull()
+        {
+            // Arrange
+            var projectResourceId = 0;
+
+            // Act
+            var result = await _classUnderTest.GetAsync(projectResourceId);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ProjectModuleNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsProjectModule()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModuleToSave = new ProjectModule()
+            {
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.True(result.Success);
+            var resultValue = result.Value;
+
+            CompareProjectModules(projectModuleToSave, resultValue);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsExceptionNoProject()
+        {
+            // Arrange
+            var module = CreateModule();
+            var projectId = 0;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModuleToSave = new ProjectModule()
+            {
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = projectId,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsExceptionNoModule()
+        {
+            // Arrange
+            var moduleId = 0;
+            var project = CreateProject();
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectResourceToSave = new ProjectModule()
+            {
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = moduleId
+            };
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectResourceToSave);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ModuleNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsExceptionInvalidCost()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = -1;
+
+            var projectModuleToSave = new ProjectModule()
+            {
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ModuleCostInvalid, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsProjectResource()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, module.Id);
+            var projectModuleAlias = "[Mock] Updated Alias";
+            var projectModuleCost = 1000;
+
+            var updatedProjectModule = new ProjectModule()
+            {
+                Id = projectModule.Id,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(updatedProjectModule);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.True(result.Success);
+            var resultValue = result.Value;
+
+            CompareProjectModules(updatedProjectModule, resultValue);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsExceptionNoProject()
+        {
+            // Arrange
+            var module = CreateModule();
+            var projectId = 0;
+            var projectModule = CreateProjectModule(projectId, module.Id);
+            var projectModuleAlias = "[Mock] Updated Alias";
+            var projectModuleCost = 1000;
+
+            var updatedProjectModule = new ProjectModule()
+            {
+                Id = projectModule.Id,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = projectId,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(updatedProjectModule);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ProjectNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsExceptionNoModule()
+        {
+            // Arrange
+            var moduleId = 0;
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, moduleId);
+            var projectModuleAlias = "[Mock] Updated Alias";
+            var projectModuleCost = 1000;
+
+            var updatedProjectModule = new ProjectModule()
+            {
+                Id = projectModule.Id,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = moduleId
+            };
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(updatedProjectModule);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ModuleNotExists, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsExceptionInvalidCost()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, module.Id);
+            var projectModuleAlias = "[Mock] Updated Alias";
+            var projectModuleCost = -1;
+
+            var updatedProjectModule = new ProjectModule()
+            {
+                Id = projectModule.Id,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost,
+                ProjectId = project.Id,
+                ModuleId = module.Id
+            };
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(updatedProjectModule);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.False(result.Success);
+            Assert.NotNull(result.Error);
+            Assert.Equal(ErrorCodes.ModuleCostInvalid, result.Error.Code);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ReturnsProjectModule()
+        {
+            // Arrange
+            var module = CreateModule();
+            var project = CreateProject();
+            var projectModule = CreateProjectModule(project.Id, module.Id);
+
+            // Act
+            var result = await _classUnderTest.DeleteAsync(projectModule.Id);
+
+            // Assert
+            Assert.IsType<ServiceResponse<ProjectModule>>(result);
+            Assert.True(result.Success);
+            var resultValue = result.Value;
+
+            CompareProjectModules(_mapper.Map<ProjectModule>(projectModule), resultValue);
+        }
+
+        private void CompareProjectModules(ProjectModule projectModuleExpected, ProjectModule projectModuleActual)
+        {
+            Assert.Equal(projectModuleExpected.Alias, projectModuleActual.Alias);
+            Assert.Equal(projectModuleExpected.Cost, projectModuleActual.Cost);
+            Assert.Equal(projectModuleExpected.ProjectId, projectModuleActual.ProjectId);
+            Assert.Equal(projectModuleExpected.ModuleId, projectModuleActual.ModuleId);
+        }
+    }
+}

--- a/test/FRF.Web.Tests/Controllers/ProjectModulesControllerTests.cs
+++ b/test/FRF.Web.Tests/Controllers/ProjectModulesControllerTests.cs
@@ -1,0 +1,421 @@
+﻿using AutoMapper;
+using FRF.Core.Models;
+using FRF.Core.Response;
+using FRF.Core.Services;
+using FRF.Web.Controllers;
+using FRF.Web.Dtos.ProjectModules;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FRF.Web.Tests.Controllers
+{
+    public class ProjectModulesControllerTests
+    {
+        private readonly IMapper _mapper = MapperBuilder.Build();
+        private readonly Mock<IProjectModulesService> _projectModulesService;
+        private readonly ProjectModulesController _classUnderTest;
+
+        public ProjectModulesControllerTests()
+        {
+            _projectModulesService = new Mock<IProjectModulesService>();
+
+            _classUnderTest = new ProjectModulesController(_projectModulesService.Object, _mapper);
+        }
+
+        [Fact]
+        public async Task GetByProjectIdAsync_ReturnsOk()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+            var moduleId = 1;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModules = new List<ProjectModule>()
+            {
+                new ProjectModule()
+                {
+                    Id = projectModuleId,
+                    ProjectId = projectId,
+                    ModuleId = moduleId,
+                    Alias = projectModuleAlias,
+                    Cost = projectModuleCost
+                }
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.GetByProjectIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<List<ProjectModule>>(projectModules));
+
+            // Act
+            var result = await _classUnderTest.GetByProjectIdAsync(projectId);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<List<ProjectModuleDTO>>(okResult.Value);
+
+            Assert.Equal(projectModules.Count, resultValue.Count);
+
+            CompareProjectModules(_mapper.Map<ProjectModuleDTO>(projectModules[0]), resultValue[0]);
+        }
+
+        [Fact]
+        public async Task GetByProjectIdAsync_ReturnsNotFound()
+        {
+            // Arrange
+            var projectId = 0;
+            var error = new Error(ErrorCodes.ProjectNotExists, "[Mock] Message");
+
+            _projectModulesService
+               .Setup(mock => mock.GetByProjectIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<List<ProjectModule>>(error));
+
+            // Act
+            var result = await _classUnderTest.GetByProjectIdAsync(projectId);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(notFoundResult.Value);
+            Assert.Equal(ErrorCodes.ProjectNotExists, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.GetByProjectIdAsync(projectId), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsOk()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+            var moduleId = 1;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModule = new ProjectModule()
+            {
+                Id = projectModuleId,
+                ProjectId = projectId,
+                ModuleId = moduleId,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost
+            };
+
+            _projectModulesService
+               .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(projectModule));
+
+            // Act
+            var result = await _classUnderTest.GetAsync(projectModuleId);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<ProjectModuleDTO>(okResult.Value);
+
+            CompareProjectModules(_mapper.Map<ProjectModuleDTO>(projectModule), resultValue);
+            _projectModulesService.Verify(mock => mock.GetAsync(projectModuleId), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_ReturnsNotFound()
+        {
+            // Arrange
+            var projectModuleId = 1;
+
+            _projectModulesService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, "[Mock] Message")));
+
+            // Act
+            var result = await _classUnderTest.GetAsync(projectModuleId);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(notFoundResult.Value);
+            Assert.Equal(ErrorCodes.ProjectModuleNotExists, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.GetAsync(projectModuleId), Times.Once);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsOk()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+            var moduleId = 1;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModuleToSave = new ProjectModuleUpsertDTO()
+            {
+                ProjectId = projectId,
+                ModuleId = moduleId,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost
+            };
+
+            _projectModulesService
+               .Setup(mock => mock.SaveAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new ProjectModule()
+                {
+                    Id = projectModuleId,
+                    ProjectId = projectId,
+                    ModuleId = moduleId,
+                    Alias = projectModuleAlias,
+                    Cost = projectModuleCost
+                }));
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<ProjectModuleDTO>(okResult.Value);
+
+            Assert.Equal(projectModuleId, resultValue.Id);
+            Assert.Equal(projectModuleToSave.Alias, resultValue.Alias);
+            Assert.Equal(projectModuleToSave.Cost, resultValue.Cost);
+            Assert.Equal(projectModuleToSave.ProjectId, resultValue.ProjectId);
+            Assert.Equal(projectModuleToSave.ModuleId, resultValue.ModuleId);
+            _projectModulesService.Verify(mock => mock.SaveAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsNotFound_ProjectNotExists()
+        {
+            // Arrange
+            var projectId = 1;
+            var moduleId = 1;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModuleToSave = new ProjectModuleUpsertDTO()
+            {
+                ProjectId = projectId,
+                ModuleId = moduleId,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.SaveAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, "[Mock] Message")));
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(notFoundResult.Value);
+            Assert.Equal(ErrorCodes.ProjectNotExists, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.SaveAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SaveAsync_ReturnsBadRequest_InvalidCostForProjectModule()
+        {
+            // Arrange
+            var projectId = 1;
+            var moduleId = 1;
+            var projectModuleAlias = "[Mock] Alias";
+            var projectModuleCost = 10;
+
+            var projectModuleToSave = new ProjectModuleUpsertDTO()
+            {
+                ProjectId = projectId,
+                ModuleId = moduleId,
+                Alias = projectModuleAlias,
+                Cost = projectModuleCost
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.SaveAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleCostInvalid, "[Mock] Message")));
+
+            // Act
+            var result = await _classUnderTest.SaveAsync(projectModuleToSave);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(badRequestResult.Value);
+            Assert.Equal(ErrorCodes.ModuleCostInvalid, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.SaveAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsOk()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+
+            var moduleIdNew = 1;
+            var projectModuleAliasNew = "[Mock] New Alias";
+            var projectModuleCostNew = 10;
+
+            var moduleIdOld = 2;
+            var projectModuleAliasOld = "[Mock] Old Alias";
+            var projectModuleCostOld = 20;
+
+            var updatedProjectModule = new ProjectModuleUpsertDTO()
+            {
+                ProjectId = projectId,
+                ModuleId = moduleIdNew,
+                Alias = projectModuleAliasNew,
+                Cost = projectModuleCostNew
+            };
+
+            var oldProjectModule = new ProjectModule()
+            {
+                Id = projectModuleId,
+                ProjectId = projectId,
+                ModuleId = moduleIdOld,
+                Alias = projectModuleAliasOld,
+                Cost = projectModuleCostOld
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(oldProjectModule));
+
+            _projectModulesService
+                .Setup(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new ProjectModule()
+                {
+                    Id = projectModuleId,
+                    Alias = updatedProjectModule.Alias,
+                    Cost = updatedProjectModule.Cost,
+                    ProjectId = updatedProjectModule.ProjectId,
+                    ModuleId = updatedProjectModule.ModuleId
+                }));
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(oldProjectModule.Id, updatedProjectModule);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultValue = Assert.IsType<ProjectModuleDTO>(okResult.Value);
+
+            Assert.Equal(updatedProjectModule.Alias, resultValue.Alias);
+            Assert.Equal(updatedProjectModule.Cost, resultValue.Cost);
+            Assert.Equal(updatedProjectModule.ProjectId, resultValue.ProjectId);
+            Assert.Equal(updatedProjectModule.ModuleId, resultValue.ModuleId);
+
+            _projectModulesService.Verify(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsNotFound_ProjectNotExists()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+            var moduleId = 1;
+            var alias = "[Mock] Alias";
+            var cost = 10;
+
+            var updatedProjectModule = new ProjectModuleUpsertDTO()
+            {
+                Cost = cost,
+                Alias = alias,
+                ProjectId = projectId,
+                ModuleId = moduleId
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectNotExists, "[Mock] Message")));
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(projectModuleId, updatedProjectModule);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(notFoundResult.Value);
+            Assert.Equal(ErrorCodes.ProjectNotExists, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_ReturnsBadRequest_InvalidBeginDateForProjectModule()
+        {
+            // Arrange
+            var projectModuleId = 1;
+            var projectId = 1;
+            var moduleId = 1;
+            var alias = "[Mock] Alias";
+            var cost = -1;
+
+            var updatedProjectModule = new ProjectModuleUpsertDTO()
+            {
+                Cost = cost,
+                Alias = alias,
+                ProjectId = projectId,
+                ModuleId = moduleId
+            };
+
+            _projectModulesService
+                .Setup(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ModuleCostInvalid, "[Mock] Message")));
+
+            // Act
+            var result = await _classUnderTest.UpdateAsync(projectModuleId, updatedProjectModule);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(badRequestResult.Value);
+            Assert.Equal(ErrorCodes.ModuleCostInvalid, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.UpdateAsync(It.IsAny<ProjectModule>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ReturnsNoContent()
+        {
+            // Arrange
+            var idToDelete = 1;
+
+            _projectModulesService
+                .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new ProjectModule()));
+
+            // Act
+            var result = await _classUnderTest.DeleteAsync(idToDelete);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _projectModulesService.Verify(mock => mock.DeleteAsync(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ReturnsNotFound()
+        {
+            // Arrange
+            var idToDelete = 1;
+
+            _projectModulesService
+                .Setup(mock => mock.DeleteAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ServiceResponse<ProjectModule>(new Error(ErrorCodes.ProjectModuleNotExists, "Error message")));
+
+            // Act
+            var result = await _classUnderTest.DeleteAsync(idToDelete);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            var resultValue = Assert.IsType<Error>(notFoundResult.Value);
+            Assert.Equal(ErrorCodes.ProjectModuleNotExists, resultValue.Code);
+            _projectModulesService.Verify(mock => mock.DeleteAsync(It.IsAny<int>()), Times.Once);
+        }
+
+        private void CompareProjectModules(ProjectModuleDTO projectModuleExpected, ProjectModuleDTO projectModuleActual)
+        {
+            Assert.Equal(projectModuleExpected.Alias, projectModuleActual.Alias);
+            Assert.Equal(projectModuleExpected.Cost, projectModuleActual.Cost);
+            Assert.Equal(projectModuleExpected.ProjectId, projectModuleActual.ProjectId);
+            Assert.Equal(projectModuleExpected.ModuleId, projectModuleActual.ModuleId);
+        }
+    }
+}


### PR DESCRIPTION
Se deben crear el servicio de ProjectModules con los siguientes métodos:

- GetByProjectIdAsync
- GetAsync
- SaveAsync
- UpdateAsync
- DeleteAsync

**Cambios realizados**

- Se agregaron los códigos de error ProjectModuleNotExists, ModuleNotExists y ModuleCostInvalid
- Se creó la interfaz IProjectModulesService con los métodos GetAsync, GetByProjectIdAsync, SaveAsync, UpdateAsync y DeleteAsync
- Se creó el servicio ProjectModulesService que implementa la interfaz anterior
- Se creó la clase ProjectModulesServiceTests con los tests relacionados con el servicio anteriormente mencionado